### PR TITLE
RFC: Add mandatory batch field to schema

### DIFF
--- a/docs/corpora_schema.md
+++ b/docs/corpora_schema.md
@@ -4,7 +4,7 @@ Contact: acarr@chanzuckerberg.com
 
 Document Status: _Approved_
 
-Version: 1.1.0
+Version: 1.2.0
 
 Date Last Modified: 2020-12-11
 
@@ -141,6 +141,7 @@ organism|String
 organism\_ontology\_term\_id|NCBITaxon term
 layer\_descriptions|A dictionary whose keys MUST be the layer names whose values are free text description of how the layer was created (e.g. "counts per million")
 version|A dictionary with a key `corpora_schema_version` and its value MUST be the schema encoding version. See [here](https://github.com/chanzuckerberg/single-cell-curation/tree/main/docs/encodings/) for documentation that describes the encoding.
+batch_condition|A string or list of string keys of cell metadata fields (which MUST exist, but need not be defined by this schema) that together define the "batches" that a normalization or integration algorithm should be aware of. For example if "patient" "seqBatch" exist and describe the cells, then `"patient"` or `["patient", "seqBatch"]` would be valid batch_condition values.
 
 
 ### Presentation Metadata

--- a/docs/corpora_schema.md
+++ b/docs/corpora_schema.md
@@ -90,7 +90,7 @@ Users will still be able to access more specific cell type annotations that have
 A dataset comprising cells of the human embryo provides a more extreme example.
 In this case, the most  precise accurate term may be the root of the cell ontology `cell`, or its child term `cell in vitro`.
 The Cell Ontology is expanding over time, and we hope to migrate datasets to more defined terms as they are defined.
-In the mean time, having these less precise terms maximizes the findability (and therefore reusability) of datasets.
+In the mean time, using Cell Ontology terms maximizes the findability (and therefore reusability) of datasets.
 
 #### Cell Metadata
 
@@ -139,9 +139,9 @@ There following fields annotate the whole dataset and MUST be provided.
 :--|:--
 organism|String
 organism\_ontology\_term\_id|NCBITaxon term
-layer\_descriptions|A dictionary whose keys MUST be the layer names whose values are free text description of how the layer was created (e.g. "counts per million")
-version|A dictionary with a key `corpora_schema_version` and its value MUST be the schema encoding version. See [here](https://github.com/chanzuckerberg/single-cell-curation/tree/main/docs/encodings/) for documentation that describes the encoding.
-batch_condition|A string or list of string keys of cell metadata fields (which MUST exist, but need not be defined by this schema) that together define the "batches" that a normalization or integration algorithm should be aware of. For example if "patient" "seqBatch" exist and describe the cells, then `"patient"` or `["patient", "seqBatch"]` would be valid batch_condition values.
+layer\_descriptions|Dictionary\[String\]|Keys MUST be the layer names whose values are free text description of how the layer was created (e.g. "counts per million")
+version|Dictionary| MUST contain key `corpora_schema_version` and its value MUST be the schema encoding version. See [here](https://github.com/chanzuckerberg/single-cell-curation/tree/main/docs/encodings/) for documentation that describes the encoding.
+batch_condition|String \| List\[String\]| values MUST match cell metadata keys. Together, these keys define the "batches" that a normalization or integration algorithm should be aware of. For example if "patient" "seqBatch" are keys of vectors of cell metadata `"patient"`, `"seqBatch"`, or `["patient", "seqBatch"]` would be valid batch_condition values.
 
 
 ### Presentation Metadata

--- a/docs/encodings/anndata_encoding.md
+++ b/docs/encodings/anndata_encoding.md
@@ -48,6 +48,7 @@ layer\_descriptions|`dict` with string keys and values|One key must be "X" which
 organism|`str`|
 organism\_ontology\_term\_id|`str`|
 batch\_condition|`str` OR `list[str]`. `str` values must refer to keys in `obs`.
+
 ​
 The cellxgene schema defines the following optional keys and values in `uns`. If the key is present, then the value must not be empty.
 ​

--- a/docs/encodings/anndata_encoding.md
+++ b/docs/encodings/anndata_encoding.md
@@ -47,6 +47,7 @@ title|`str`|
 layer\_descriptions|`dict` with string keys and values|One key must be "X" which describes the transformations (if any) performed to produce the X matrix cellxgene displays.
 organism|`str`|
 organism\_ontology\_term\_id|`str`|
+batch\_condition|`str` OR `list[str]`. `str` values must refer to keys in `obs`.
 ​
 The cellxgene schema defines the following optional keys and values in `uns`. If the key is present, then the value must not be empty.
 ​


### PR DESCRIPTION
This PR describes a proposed schema change and encoding implementation of adding "batch" information to the schema. 

In brief, it is designed to enable a user to specify an arbitrary set of cell metadata fields that jointly describe the batch of each cell. These fields may or may not be part of the cellxgene schema. 

It addresses #2 .