### PR TITLE
Schema update to support multi-organism data

### DIFF
--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -151,7 +151,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [Sars_cov_2.ASM985889v3.101.gtf.gz] |
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf.gz] |
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz
@@ -162,7 +162,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 [cellranger 2020-A (July 7, 2020) release]: https://support.10xgenomics.com/single-cell-gene-expression/software/release-notes/build
 
 [ENSEMBL (COVID-19)]:https://covid-19.ensembl.org/index.html
-[Sars_cov_2.ASM985889v3.101.gtf.gz]:ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
+[Sars\_cov\_2.ASM985889v3.101.gtf.gz]:ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
 
 ## `obs` (Cell Metadata)
 

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -679,7 +679,7 @@ When a dataset is uploaded, the cellxgene Data Portal MUST automatically add the
 <table><tbody>
     <tr>
       <th>Key</th>
-      <td>feature_name</td>
+      <td>feature_reference</td>
     </tr>
     <tr>
       <th>Annotator</th>

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -37,7 +37,7 @@ This document is organized by:
 
 * **AnnData** - The canonical data format for the cellxgene Data Portal is HDF5-backed [AnnData](https://anndata.readthedocs.io/en/latest) as written by version 0.7 of the anndata library.  Part of the rationale for selecting this format is to allow cellxgene to access both the data and metadata within a single file. The schema requirements and definitions for the AnnData `X`, `obs`, `var`, `obsm`, and `uns` attributes are described below.
 
-* **Organisms**. Genes MUST be either from Human or Mouse. Multi-organism data is accepted as long as Human or Mouse orthologs are used.
+* **Organisms**. Data MUST be from an organism defined in the NCBI organismal classification. For data that is neither Human, Mouse, nor SARS-COV-2 for Human cells, orthologous genes from the pinned Human and Mouse gene annotations are REQUIRED.
 
 * **Reserved Names**. The names of the metadata keys specified by the cellxgene schema are reserved and MUST be unique. For example, duplicate `"feature_biotype"` keys in AnnData `var` are not allowed.
 
@@ -143,15 +143,16 @@ The following ontology dependencies are *pinned* for this version of the schema.
 
 ### Required Gene Annotations
 
-cellxgene requires ENSEMBL gene identifiers to ensure that all datasets it stores measure the same features and can therefore be integrated.
+cellxgene requires ENSEMBL identifiers for genes and ERCC identifiers for spike-ins to ensure that all datasets it stores measure the same features and can therefore be integrated.
 
 The following gene annotation dependencies are *pinned* for this version of the schema. For multi-organism experiments, cells from any organism are allowed as long as orthologs from the following organism annotations are used.
 
-| Organism | Required version | Download |
+| Source | Required version | Download |
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
 | [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEMBL assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf] |
+| [ThermoFisher ERCC spike-Ins] | ThermoFisher ERCC RNA Spike-In Control Mixes (Cat # 4456740, 4456739) | [cms_095047.txt] |
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz
@@ -163,6 +164,9 @@ The following gene annotation dependencies are *pinned* for this version of the 
 
 [ENSEMBL (COVID-19)]: https://covid-19.ensembl.org/index.html
 [Sars\_cov\_2.ASM985889v3.101.gtf]: https://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
+
+[ThermoFisher ERCC spike-Ins]: https://www.thermofisher.com/order/catalog/product/4456740#/4456740
+[cms_095047.txt]: https://assets.thermofisher.com/TFS-Assets/LSG/manuals/cms_095047.txt
 
 
 ## `obs` (Cell Metadata)
@@ -629,7 +633,7 @@ Curators MUST annotate the following columns in the `var` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td>This MUST be <code>"gene"</code>.  
+        <td>This MUST be <code>"gene"</code> or <code>"spike-in"</code>.  
         </td>
     </tr>
 </tbody></table>
@@ -648,7 +652,7 @@ Curators MUST annotate the following columns in the `var` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td><code>str</code>. This MUST be an ENSEMBL term from the gene annotation corresponding to the organism for the gene.  
+        <td><code>str</code>. This MUST be an ENSEMBL term from the gene annotation corresponding to the organism for the gene, or an ERCC spike-in identifier.
         </td>
     </tr>
 </tbody></table>
@@ -856,6 +860,7 @@ schema v2.0.0 substantially *remodeled* schema v1.1.0:
 * var
   * Replaced HGNC **symbols** as `var.index` with ENSEMBL **identifiers** 
   * Added feature biotype, ENSEMBL id, ENSEMBL name, and feature reference.
+  * Added spike-ins IDs in var.
 
 * uns
   * Added `batch_condition`

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -145,7 +145,7 @@ The following ontology dependencies are *pinned* for this version of the schema.
 
 cellxgene requires ENSEMBL gene identifiers to ensure that all datasets it stores measure the same features and can therefore be integrated.
 
-The following gene annotation dependencies are *pinned* for this version of the schema. For multi-species experiments, cells from any organism are allowed as long as orthologs from the following species annotations are used.
+The following gene annotation dependencies are *pinned* for this version of the schema. For multi-species experiments, cells from any organism are allowed as long as orthologs from the following organism annotations are used.
 
 | Organism | Required version | Download |
 |:--|:--|:--|

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -151,7 +151,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf.gz] |
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf] |
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz
@@ -161,8 +161,8 @@ The following gene annotation dependencies are *pinned* for this version of the 
 
 [cellranger 2020-A (July 7, 2020) release]: https://support.10xgenomics.com/single-cell-gene-expression/software/release-notes/build
 
-[ENSEMBL (COVID-19)]:https://covid-19.ensembl.org/index.html
-[Sars\_cov\_2.ASM985889v3.101.gtf.gz]: https://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
+[ENSEMBL (COVID-19)]: https://covid-19.ensembl.org/index.html
+[Sars\_cov\_2.ASM985889v3.101.gtf]: https://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
 
 
 ## `obs` (Cell Metadata)
@@ -306,7 +306,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               <td>A term from the set of <a href="http://www.ontobee.org/search?ontology=MMUSDV&keywords=month-old&submit=Search+terms"> month-old stages</a><br>(e.g. <a href="http://purl.obolibrary.org/obo/MmusDv_0000062">MmusDv:0000062)</a></td>
             </tr>
           </tbody></table>
-          <br> Otherwise, for all other organisms this MUST be the most accurate child of <code>EFO:0000399.
+          <br> Otherwise, for all other organisms this MUST be the most accurate child of <code>EFO:0000399</code>.
         </td>
     </tr>
 </tbody></table>

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -151,7 +151,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/f
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -151,7 +151,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf.gz] |
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | <a href="ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz">Sars\_cov\_2.ASM985889v3.101.gtf.gz</a>|
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz
@@ -162,7 +162,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 [cellranger 2020-A (July 7, 2020) release]: https://support.10xgenomics.com/single-cell-gene-expression/software/release-notes/build
 
 [ENSEMBL (COVID-19)]:https://covid-19.ensembl.org/index.html
-[Sars\_cov\_2.ASM985889v3.101.gtf.gz]: ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
+
 
 ## `obs` (Cell Metadata)
 

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -145,13 +145,13 @@ The following ontology dependencies are *pinned* for this version of the schema.
 
 cellxgene requires ENSEMBL gene identifiers to ensure that all datasets it stores measure the same features and can therefore be integrated.
 
-The following gene annotation dependencies are *pinned* for this version of the schema.
+The following gene annotation dependencies are *pinned* for this version of the schema. **Cells from any organism are allowed as long as orthologs from these annotations are used.**
 
 | Organism | Required version | Download |
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-|||
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [Sars_cov_2.ASM985889v3.101.gtf.gz] |
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz
@@ -160,6 +160,9 @@ The following gene annotation dependencies are *pinned* for this version of the 
 [gencode.vM23.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_mouse/release_M23/gencode.vM23.primary_assembly.annotation.gtf.gz
 
 [cellranger 2020-A (July 7, 2020) release]: https://support.10xgenomics.com/single-cell-gene-expression/software/release-notes/build
+
+[ENSEMBL (COVID-19)]:https://covid-19.ensembl.org/index.html
+[Sars_cov_2.ASM985889v3.101.gtf.gz]:ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
 
 ## `obs` (Cell Metadata)
 
@@ -256,7 +259,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td>categorical with <code>str</code> categories. If unavailable, this MUST be <code>"unknown"</code>.<br><br>If <code>organism_ontolology_term_id</code> is <code>"NCBITaxon:9606"</code> for <i>Homo sapiens</i>, this MUST be the most<br>accurate HsapDv term with the following STRONGLY RECOMMENDED:
+        <td>categorical with <code>str</code> categories. If unavailable, this MUST be <code>"unknown"</code>.<br><br>If <code>organism_ontolology_term_id</code> <b>is not</b> <code>"NCBITaxon:9606"</code> (<i>Homo sapiens</i>) <br> <b>nor</b> <code>"NCBITaxon:10090"</code> (<i>Mus musculus</i>), this MUST be the most accurate child of <code>EFO:0000399</code>. <br><br>If <code>organism_ontolology_term_id</code> is <code>"NCBITaxon:9606"</code> for <i>Homo sapiens</i>, this MUST be the most<br>accurate HsapDv term with the following STRONGLY RECOMMENDED:
           <br><br>
           <table>
           <thead>
@@ -377,7 +380,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td>categorical with <code>str</code> categories. This MUST be either <code>"NCBITaxon:9606"</code> for <i>Homo sapiens</i> or <code>"NCBITaxon:10090"</code> for <i>Mus musculus</i>.
+        <td>categorical with <code>str</code> categories. This MUST be an NCBITaxon term.
         </td>
     </tr>
 </tbody></table>
@@ -651,7 +654,7 @@ Curators MUST annotate the following columns in the `var` dataframe:
 
 When a dataset is uploaded, the cellxgene Data Portal MUST automatically add the matching human-readable name for the corresponding gene identifier to the `var` dataframe. Curators MUST NOT annotate the following column:
 
-### feature_ name
+### feature_reference
 
 <table><tbody>
     <tr>
@@ -669,6 +672,26 @@ When a dataset is uploaded, the cellxgene Data Portal MUST automatically add the
     </tr>
 </tbody></table>
 <br>
+
+### feature_reference
+
+<table><tbody>
+    <tr>
+      <th>Key</th>
+      <td>feature_name</td>
+    </tr>
+    <tr>
+      <th>Annotator</th>
+      <td>Data Portal</td>
+    </tr>
+    <tr>
+      <th>Value</th>
+        <td><code>str</code>. This MUST indicate the reference organism of genes, it MUST be <code>NCBITaxon:9606</code> for <i>Homo sapiens</i>, <code>NCBITaxon:10090</code> for <i>Mus musculus</i>, or <code>NCBITaxon:2697049</code> for  SARS-CoV-2.
+        </td>
+    </tr>
+</tbody></table>
+<br>
+
 
 ## `obsm` (Embeddings)
 

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -151,7 +151,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/] (ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/)
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/f
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -151,7 +151,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf] |
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEMBL assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf] |
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -37,7 +37,7 @@ This document is organized by:
 
 * **AnnData** - The canonical data format for the cellxgene Data Portal is HDF5-backed [AnnData](https://anndata.readthedocs.io/en/latest) as written by version 0.7 of the anndata library.  Part of the rationale for selecting this format is to allow cellxgene to access both the data and metadata within a single file. The schema requirements and definitions for the AnnData `X`, `obs`, `var`, `obsm`, and `uns` attributes are described below.
 
-* **Organisms**. Data MUST be either Human or Mouse data. No other organisms are accepted by the cellxgene Data Portal. 
+* **Organisms**. Genes MUST be either from Human or Mouse. Multi-organism data is accepted as long as Human or Mouse orthologs are used.
 
 * **Reserved Names**. The names of the metadata keys specified by the cellxgene schema are reserved and MUST be unique. For example, duplicate `"feature_biotype"` keys in AnnData `var` are not allowed.
 
@@ -344,7 +344,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td>categorical with <code>str</code> categories. If <code>organism_ontolology_term_id</code> is <code>"NCBITaxon:9606"</code> for <i>Homo sapiens</i>, this MUST be either a HANCESTRO term or <code>"unknown"</code> if unavailable. <br><br> If <code>organism_ontolology_term_id</code> is <code>"NCBITaxon:10090"</code> for <i>Mus musculus</i>, this MUST be <code>"na"</code>.
+        <td>categorical with <code>str</code> categories. If <code>organism_ontolology_term_id</code> is <code>"NCBITaxon:9606"</code> for <i>Homo sapiens</i>, this MUST be either a HANCESTRO term or <code>"unknown"</code> if unavailable. <br><br>Otherwise this MUST be <code>"na"</code>.
         </td>
     </tr>
 </tbody></table>

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -654,7 +654,7 @@ Curators MUST annotate the following columns in the `var` dataframe:
 </tbody></table>
 <br>
 
-When a dataset is uploaded, the cellxgene Data Portal MUST automatically add the matching human-readable name for the corresponding gene identifier to the `var` dataframe. Curators MUST NOT annotate the following column:
+When a dataset is uploaded, the cellxgene Data Portal MUST infer the organism reference for the corresponding identifier. The Data Portal MUST automatically add both the matching human-readable name and the organism NCBITaxon term to the `var` dataframe. Curators MUST NOT annotate the following columns:
 
 ### feature_name
 
@@ -684,7 +684,7 @@ When a dataset is uploaded, the cellxgene Data Portal MUST automatically add the
     </tr>
     <tr>
       <th>Annotator</th>
-      <td>Curator</td>
+      <td>Data Portal</td>
     </tr>
     <tr>
       <th>Value</th>
@@ -833,7 +833,9 @@ schema v2.0.0 substantially *remodeled* schema v1.1.0:
 * General Requirements
   * AnnData is now the canonical data format. The schema outline and descriptions are AnnData-centric.
 
-  * Only Human and Mouse data are accepted by the cellxgene Data Portal. 
+  * Only Human and Mouse gene IDs are accepted by the cellxgene Data Portal.
+
+  * Multi-organism data is accepted as long as orthologous genes from Human or Mouse are used. 
 
   * Policies for reserved names and redundant metadata are documented.
 
@@ -853,7 +855,7 @@ schema v2.0.0 substantially *remodeled* schema v1.1.0:
 
 * var
   * Replaced HGNC **symbols** as `var.index` with ENSEMBL **identifiers** 
-  * Added feature biotype, ENSEMBL id, and ENSEMBL name
+  * Added feature biotype, ENSEMBL id, ENSEMBL name, and feature reference.
 
 * uns
   * Added `batch_condition`

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -162,7 +162,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 [cellranger 2020-A (July 7, 2020) release]: https://support.10xgenomics.com/single-cell-gene-expression/software/release-notes/build
 
 [ENSEMBL (COVID-19)]:https://covid-19.ensembl.org/index.html
-[Sars\_cov\_2.ASM985889v3.101.gtf.gz]:ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
+[Sars\_cov\_2.ASM985889v3.101.gtf.gz]: ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
 
 ## `obs` (Cell Metadata)
 

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -145,7 +145,7 @@ The following ontology dependencies are *pinned* for this version of the schema.
 
 cellxgene requires ENSEMBL gene identifiers to ensure that all datasets it stores measure the same features and can therefore be integrated.
 
-The following gene annotation dependencies are *pinned* for this version of the schema. **Cells from any organism are allowed as long as orthologs from these annotations are used.**
+The following gene annotation dependencies are *pinned* for this version of the schema. For multi-species experiments, cells from any organism are allowed as long as orthologs from the following species annotations are used.
 
 | Organism | Required version | Download |
 |:--|:--|:--|

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -145,7 +145,7 @@ The following ontology dependencies are *pinned* for this version of the schema.
 
 cellxgene requires ENSEMBL gene identifiers to ensure that all datasets it stores measure the same features and can therefore be integrated.
 
-The following gene annotation dependencies are *pinned* for this version of the schema. For multi-species experiments, cells from any organism are allowed as long as orthologs from the following organism annotations are used.
+The following gene annotation dependencies are *pinned* for this version of the schema. For multi-organism experiments, cells from any organism are allowed as long as orthologs from the following organism annotations are used.
 
 | Organism | Required version | Download |
 |:--|:--|:--|

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -693,7 +693,7 @@ When a dataset is uploaded, the cellxgene Data Portal MUST infer the organism re
     </tr>
     <tr>
       <th>Value</th>
-        <td><code>str</code>. This MUST indicate the reference organism of genes and MUST be <code>NCBITaxon:9606</code> for <i>Homo sapiens</i>, <code>NCBITaxon:10090</code> for <i>Mus musculus</i>, or <code>NCBITaxon:2697049</code> for  SARS-CoV-2.
+        <td><code>str</code>. This MUST indicate the reference organism of features and MUST be <code>NCBITaxon:9606</code> for <i>Homo sapiens</i>, <code>NCBITaxon:10090</code> for <i>Mus musculus</i>, <code>NCBITaxon:2697049</code> for  SARS-CoV-2, or <code>NCBITaxon:32630</code> for  ERCC Spike-Ins
         </td>
     </tr>
 </tbody></table>

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -151,7 +151,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf.gz] |
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz
@@ -162,6 +162,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 [cellranger 2020-A (July 7, 2020) release]: https://support.10xgenomics.com/single-cell-gene-expression/software/release-notes/build
 
 [ENSEMBL (COVID-19)]:https://covid-19.ensembl.org/index.html
+[Sars\_cov\_2.ASM985889v3.101.gtf.gz]: https://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
 
 
 ## `obs` (Cell Metadata)

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -260,7 +260,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td>categorical with <code>str</code> categories. If unavailable, this MUST be <code>"unknown"</code>.<br><br>If <code>organism_ontolology_term_id</code> <b>is not</b> <code>"NCBITaxon:9606"</code> (<i>Homo sapiens</i>) <br> <b>nor</b> <code>"NCBITaxon:10090"</code> (<i>Mus musculus</i>), this MUST be the most accurate child of <code>EFO:0000399</code>. <br><br>If <code>organism_ontolology_term_id</code> is <code>"NCBITaxon:9606"</code> for <i>Homo sapiens</i>, this MUST be the most<br>accurate HsapDv term with the following STRONGLY RECOMMENDED:
+        <td>categorical with <code>str</code> categories. If unavailable, this MUST be <code>"unknown"</code> <br><br>If <code>organism_ontolology_term_id</code> is <code>"NCBITaxon:9606"</code> for <i>Homo sapiens</i>, this MUST be the most<br>accurate HsapDv term with the following STRONGLY RECOMMENDED:
           <br><br>
           <table>
           <thead>
@@ -306,6 +306,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               <td>A term from the set of <a href="http://www.ontobee.org/search?ontology=MMUSDV&keywords=month-old&submit=Search+terms"> month-old stages</a><br>(e.g. <a href="http://purl.obolibrary.org/obo/MmusDv_0000062">MmusDv:0000062)</a></td>
             </tr>
           </tbody></table>
+          <br> Otherwise, for all other organisms this MUST be the most accurate child of <code>EFO:0000399.
         </td>
     </tr>
 </tbody></table>
@@ -381,7 +382,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td>categorical with <code>str</code> categories. This MUST be an NCBITaxon term.
+        <td>categorical with <code>str</code> categories. This MUST be a NCBITaxon term.
         </td>
     </tr>
 </tbody></table>
@@ -683,11 +684,11 @@ When a dataset is uploaded, the cellxgene Data Portal MUST automatically add the
     </tr>
     <tr>
       <th>Annotator</th>
-      <td>Data Portal</td>
+      <td>Curator</td>
     </tr>
     <tr>
       <th>Value</th>
-        <td><code>str</code>. This MUST indicate the reference organism of genes, it MUST be <code>NCBITaxon:9606</code> for <i>Homo sapiens</i>, <code>NCBITaxon:10090</code> for <i>Mus musculus</i>, or <code>NCBITaxon:2697049</code> for  SARS-CoV-2.
+        <td><code>str</code>. This MUST indicate the reference organism of genes and MUST be <code>NCBITaxon:9606</code> for <i>Homo sapiens</i>, <code>NCBITaxon:10090</code> for <i>Mus musculus</i>, or <code>NCBITaxon:2697049</code> for  SARS-CoV-2.
         </td>
     </tr>
 </tbody></table>

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -37,7 +37,7 @@ This document is organized by:
 
 * **AnnData** - The canonical data format for the cellxgene Data Portal is HDF5-backed [AnnData](https://anndata.readthedocs.io/en/latest) as written by version 0.7 of the anndata library.  Part of the rationale for selecting this format is to allow cellxgene to access both the data and metadata within a single file. The schema requirements and definitions for the AnnData `X`, `obs`, `var`, `obsm`, and `uns` attributes are described below.
 
-* **Organisms**. Data MUST be from an organism defined in the NCBI organismal classification. For data that is neither Human, Mouse, nor SARS-COV-2 for Human cells, orthologous genes from the pinned Human and Mouse gene annotations are REQUIRED.
+* **Organisms**. Data MUST be from an organism defined in the NCBI organismal classification. For data that is neither Human, Mouse, nor SARS-COV-2, features MUST be translated into orthologous genes from the pinned Human and Mouse gene annotations.
 
 * **Reserved Names**. The names of the metadata keys specified by the cellxgene schema are reserved and MUST be unique. For example, duplicate `"feature_biotype"` keys in AnnData `var` are not allowed.
 
@@ -143,7 +143,7 @@ The following ontology dependencies are *pinned* for this version of the schema.
 
 ### Required Gene Annotations
 
-cellxgene requires ENSEMBL identifiers for genes and ERCC identifiers for spike-ins to ensure that all datasets it stores measure the same features and can therefore be integrated.
+cellxgene requires ENSEMBL identifiers for genes and External RNA Controls Consortium (ERCC) identifiers for [RNA Spike-In Control Mixes] to ensure  that all datasets it stores measure the same features and can therefore be integrated.
 
 The following gene annotation dependencies are *pinned* for this version of the schema. For multi-organism experiments, cells from any organism are allowed as long as orthologs from the following organism annotations are used.
 
@@ -152,7 +152,9 @@ The following gene annotation dependencies are *pinned* for this version of the 
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
 | [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEMBL assembly: ASM985889v3) | [Sars\_cov\_2.ASM985889v3.101.gtf] |
-| [ThermoFisher ERCC spike-Ins] | ThermoFisher ERCC RNA Spike-In Control Mixes (Cat # 4456740, 4456739) | [cms_095047.txt] |
+| [ThermoFisher ERCC Spike-Ins] | ThermoFisher ERCC RNA Spike-In Control Mixes (Cat # 4456740, 4456739) | [cms_095047.txt] |
+
+[RNA Spike-In Control Mixes]: https://www.thermofisher.com/document-connect/document-connect.html?url=https%3A%2F%2Fassets.thermofisher.com%2FTFS-Assets%2FLSG%2Fmanuals%2Fcms_086340.pdf&title=VXNlciBHdWlkZTogRVJDQyBSTkEgU3Bpa2UtSW4gQ29udHJvbCBNaXhlcyAoRW5nbGlzaCAp
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz
@@ -165,7 +167,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 [ENSEMBL (COVID-19)]: https://covid-19.ensembl.org/index.html
 [Sars\_cov\_2.ASM985889v3.101.gtf]: https://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz
 
-[ThermoFisher ERCC spike-Ins]: https://www.thermofisher.com/order/catalog/product/4456740#/4456740
+[ThermoFisher ERCC Spike-Ins]: https://www.thermofisher.com/order/catalog/product/4456740#/4456740
 [cms_095047.txt]: https://assets.thermofisher.com/TFS-Assets/LSG/manuals/cms_095047.txt
 
 
@@ -652,8 +654,7 @@ Curators MUST annotate the following columns in the `var` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td><code>str</code>. This MUST be an ENSEMBL term from the gene annotation corresponding to the organism for the gene, or an ERCC spike-in identifier.
-        </td>
+        <td><code>str</code>. If the <code>feature_biotype</code> is <code>"gene"</code> then this MUST be an ENSEMBL term. If the <code>feature_biotype</code> is <code>"spike-in"</code> then this MUST be an ERCC Spike-In identifier. </td>
     </tr>
 </tbody></table>
 <br>
@@ -673,7 +674,7 @@ When a dataset is uploaded, the cellxgene Data Portal MUST infer the organism re
     </tr>
     <tr>
       <th>Value</th>
-        <td><code>str</code>. This MUST be the human-readable ENSEMBL gene name assigned to the <code>feature_id</code>.  
+        <td><code>str</code>. If the <code>feature_biotype</code> is <code>"gene"</code> then this this MUST be the human-readable ENSEMBL gene name assigned to the <code>feature_id</code>. If the <code>feature_biotype</code> is <code>"spike-in"</code> then this MUST the ERCC Spike-In identifier appended with <code>" spike-in control"</code>.
         </td>
     </tr>
 </tbody></table>

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -151,7 +151,7 @@ The following gene annotation dependencies are *pinned* for this version of the 
 |:--|:--|:--|
 | [ENSEMBL (Human)] | Human reference GRCh38 (GENCODE v32/Ensembl 98)] matching [cellranger 2020-A (July 7, 2020) release] | [gencode.v32.primary_assembly.annotation.gtf] |
 | [ENSEMBL (Mouse)] | Mouse reference mm10 (GENCODE vM23/Ensembl 98) matching [cellranger 2020-A (July 7, 2020) release]| [gencode.vM23.primary_assembly.annotation.gtf] |
-| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | <a href="ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz">Sars\_cov\_2.ASM985889v3.101.gtf.gz</a>|
+| [ENSEMBL (COVID-19)] | SARS-CoV-2 reference (ENSEBML assembly: ASM985889v3) | [ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/] (ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/)
 
 [ENSEMBL (Human)]: http://www.ensembl.org/Homo_sapiens/Info/Index
 [gencode.v32.primary_assembly.annotation.gtf]: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_32/gencode.v32.primary_assembly.annotation.gtf.gz

--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -654,7 +654,7 @@ Curators MUST annotate the following columns in the `var` dataframe:
 
 When a dataset is uploaded, the cellxgene Data Portal MUST automatically add the matching human-readable name for the corresponding gene identifier to the `var` dataframe. Curators MUST NOT annotate the following column:
 
-### feature_reference
+### feature_name
 
 <table><tbody>
     <tr>


### PR DESCRIPTION
At the heart of the issue is that we need to accommodate the schema for multi-organism datasets that use orthologous genes with either human or mouse ENSEMBL IDs. If we want IDs for more organisms we can discuss it in the future as needed.

This PR:

1. Changes cell requirements of adata.obs["organism_ontology_term_id"]  and allows any organism for cells.
2. Adds a cell requirement to adata.obs["development_stage_ontology_id"]  to allow for development stages of non-human and non-mouse cells.
3. Adds a gene requirement by adding a column to adata.var to indicate the source of the gene ID.
4. Clarifies text to state that we are taking cells from any organism so long as they are using orthologs in human or mouse.

This PR addresses:

- Dependencies of adata.obs["organism_ontology_term_id"]  and adata.obs["ethnicity_ontology_term_id"]  -- anything that's not human MUST be "na"
- Dependencies of adata.obs["organism_ontology_term_id"]  and adata.obs["development_stage_ontology_term_id"]  -- for human MUST be HsapDv , for mouse MmusDv, anything else a child of EFO:0000399
- Regardless of what organism a cell is from we can still specify the "reference" for the gene IDs -- this solves the gene ortholog problem as well as allowing for COVID genes