### PR TITLE
Add feature_is_filtered to var requirements

### DIFF
--- a/schema/2.0.0/corpora_schema.md
+++ b/schema/2.0.0/corpora_schema.md
@@ -662,9 +662,9 @@ Curators MUST annotate the following columns in the `var` and `raw.var` datafram
 </tbody></table>
 <br>
 
-Curators MUST annotate the following column only in the `var` dataframe:
+Curators MUST annotate the following column only in the `var` dataframe. This column MUST NOT be present in `raw.var`:
 
-### feature\_is_filtered
+### feature_is_filtered
 
 <table><tbody>
     <tr>


### PR DESCRIPTION
Adds a new field `feature_is_filtered` to `var`.

Changes:
- Features that have been filtered out in `X` from `raw.X` MUST have a value of `0` in `X`
- Those features need to have a value of `True` in `feature_is_filtered` of `var`

@ambrosejcarr @brianraymor should this field be optional?