### PR TITLE
Fix performance issue of raw layer validation

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -935,7 +935,10 @@ class Validator:
             # Get array without zeros
             non_zeroes_index = x.nonzero()
 
-            x_non_zeroes = x[non_zeroes_index]
+            if max_values_to_check > len(non_zeroes_index[0]):
+                max_values_to_check = len(non_zeroes_index[0])
+
+            x_non_zeroes = x[non_zeroes_index[0][:max_values_to_check], non_zeroes_index[1][:max_values_to_check]]
 
             # If all values are zeros then is raw, otherwise if a single value is not an int then return is not raw
             if x_non_zeroes.size < 1:
@@ -946,10 +949,6 @@ class Validator:
 
                     if isnan(i):
                         continue
-
-                    max_values_to_check -= 1
-                    if max_values_to_check < 1:
-                        break
 
                     if i % 1 != 0:
                         self._raw_layer_exists = False


### PR DESCRIPTION
This is a performance fix for when the validator does an integer check on the expression matrix. With large datasets the validator would take hours/days running without finishing the check. This is because a copy of all non-zero values from the expression matrix was made.

The issue has been fixed and only a copy of the first 5000 values is made (an arbitrarily chosen number).