### PR TITLE
Expand list of assays for which raw validation is bypassed

### DIFF
--- a/cellxgene_schema_cli/CHANGELOG.md
+++ b/cellxgene_schema_cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the python package `cellxgene-schema` are documented in t
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2021-10-06
+
+### Changed
+
+- Adds the assay ontology term EFO:0008939 (snmC-seq) to the list of assays for which validation of raw data is bypassed.
+
 ## [2.0.1] - 2021-10-06
 
 ### Changed

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/2_0_0.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/2_0_0.yaml
@@ -11,6 +11,7 @@ raw:
                         - EFO:0007045 # ATAC-seq
                         - EFO:0008804 # Methyl-seq
                         - EFO:0000751 # methylation profiling
+                        - EFO:0008939 # snmC-seq
 components:
     obsm:
         type: embedding_dict

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="2.0.1",
+    version="2.0.2.rc1",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",


### PR DESCRIPTION
Adds EFO:0008939 to list of assays for which raw validation is bypassed in `cellxgene-schema validate`. Changelog was modified accordingly and version updated to v2.0.2