### PR TITLE
Add warning during raw data validation for when raw.X has non-integer values

### DIFF
--- a/cellxgene_schema_cli/CHANGELOG.md
+++ b/cellxgene_schema_cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the python package `cellxgene-schema` are documented in t
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2021-11-01    
+    
+### Added    
+    
+- A check during raw data validation in `validate.Validator`. When both `adata.X` and `adata.raw.X` are present, but `adata.raw.X` contains non-integer values a warning is added.         
+
 ## [2.0.3] - 2021-10-08
 ### Changed
 - Replace print with logging in `Validator` and `AnnDataLabelAppender`.

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1030,6 +1030,15 @@ class Validator:
 
             normalization = self.adata.uns["X_normalization"]
 
+            # If both "raw.X" and "X" exist but neither are raw
+            if (
+                not self._is_raw()
+                and self._get_raw_x_loc() == "raw.X"
+            ):
+                self.warnings.append(
+                    "Raw data may be missing: data in 'raw.X' contains non-integer values."
+                )
+
             # If raw data is missing: no "raw.X", and "X_normalization" is not "none"
             if (
                 not self._is_raw()

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="2.0.3",
+    version="2.0.4",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -180,6 +180,13 @@ adata.raw = adata
 adata.X = non_raw_X
 adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
 
+# Anndata with "X" and "raw.X" but neither has actual raw values
+adata_no_raw_values = anndata.AnnData(
+    X=sparse.csr_matrix(non_raw_X), obs=good_obs, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_no_raw_values.raw = adata_no_raw_values
+adata_no_raw_values.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
 # Anndata with no obs nor var
 adata_minimal = anndata.AnnData(X=sparse.csr_matrix(X), uns=good_uns, obsm=good_obsm)
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -99,6 +99,21 @@ class TestExpressionMatrix(unittest.TestCase):
             ],
         )
 
+    def test_raw_values(self):
+
+        """
+        When both `adata.X` and `adata.raw.X` are present, but `adata.raw.X` contains non-integer values a warning is added.
+        """
+
+        self.validator.adata = examples.adata_no_raw_values.copy()
+        self.validator.validate_adata()
+        self.assertEqual(
+            self.validator.warnings,
+            [
+                "WARNING: Raw data may be missing: data in 'raw.X' contains non-integer values."
+            ],
+        )
+
     def test_raw_existence(self):
 
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -102,7 +102,8 @@ class TestExpressionMatrix(unittest.TestCase):
     def test_raw_values(self):
 
         """
-        When both `adata.X` and `adata.raw.X` are present, but `adata.raw.X` contains non-integer values a warning is added.
+        When both `adata.X` and `adata.raw.X` are present, but `adata.raw.X` contains non-integer values a warning
+        is added.
         """
 
         self.validator.adata = examples.adata_no_raw_values.copy()


### PR DESCRIPTION
The validator was missing one check when validating the raw data:

- When both `adata.X` and `adata.raw.X` are present but `adata.raw.X` contains non-integer values, then a warning should be shown suggesting that data in `adata.raw.X` may not be raw.

A warning is preferred as opposed to an error as @jychien states:

> For the Pott gut demo dataset, they actually used STARsolo for their pipeline. I am not as familiar with data from STARsolo, and it looks like it handles multi-gene reads in a way different from cellranger, and possibly could result in non-integers depending on the parameter used (documentation). I think a warning would be good, in case we need to be more flexible and don't want to have to change the validator for different pipelines or assays. But I think we've come across enough matrices where raw is not really raw that a warning would be helpful.