### PR TITLE
Initial draft of a release process for the cellxgene-schema PyPI package

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -30,7 +30,7 @@ Steps must be run from the project directory and in a virtual env with all the d
 
 1. Run `make release-candidate-to-test-pypi` to release the newly created release candidate to Test PyPI. Test the release by installing `cellxgene-schema` using `pip install -i https://test.pypi.org/simple/ cellxgene-schema=={release_candidate_version}` in a fresh virtual environment.
 
-1. If you detect errors in the release, fix them in `main` and then rebase the release branch. Then run `make recreate-release-candidate` to bump up the release candidate version (i.e. 2.1.0rc0 will get bumped up to 2.1.0rc1). Run `make release-candidate-to-test-pypi` again to release this candidate to Test PyPI for testing.
+1. If you detect errors in the release, fix them in `main` and then rebase the release branch. Then run `make recreate-release-candidate` to bump up the release candidate version (i.e. 2.1.0-rc.0 will get bumped up to 2.1.0-rc.1). Run `make release-candidate-to-test-pypi` again to release this candidate to Test PyPI for testing.
 
 1. If everything looks good, release the final candidate to Test PyPI by running `make release-final-to-test-pypi`. This will remove the `rc` tag from the version and upload the distribution to Test PyPI in one go. Test one last time to make sure everything is OK.
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -20,9 +20,7 @@ Steps must be run from the project directory and in a virtual env with all the d
 
 1. Decide on whether the changes going into the next release warrant a patch, minor, or major version bump using [semantic versioning](https://semver.org/) and determine the version number based on the current latest version (i.e. if the current version is 2.0.4 and you'd like to do a minor version bump, then the next version will be 2.1.0).
 
-1. Create a release branch from the `main` branch of the `single-cell-curation` repo (e.g. `git checkout -b release-version-x.y.z`).
-
-1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be `2.1.4-rc.0`. The `rc` suffix will be removed in a later step.
+1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be `2.1.4-rc.0`. The `rc` suffix will be removed in a later step. This step will also automatically create and checkout a new release Git branch.
 
 1. Update the [CHANGELOG](https://github.com/chanzuckerberg/single-cell-curation/blob/main/cellxgene_schema_cli/CHANGELOG.md) with the latest changes going into the new release. 
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -52,6 +52,7 @@ High level checklist to ensure that you completed the release successfully.
 - [ ] Did you create and merge in a PR to bump the version in `setup.py`?
 - [ ] Did you create a Github release for the new version?
 - [ ] Did you test the new release to make sure it works?
+- [ ] For any internal uses of `cellxgene-schema` have you upgraded the version number or let the appropriate stakeholders know that a new version exists?
 
 ## Additional Resources
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -40,10 +40,10 @@ Steps must be run from the project directory and in a virtual env with all the d
 
 1. Test the installation in a fresh virtual environment by running `pip install --no-cache-dir cellxgene-schema`. If you find errors, go back to step 1.
 
-1. Create Github release using the version number and release notes ([instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)):
-    1. Draft new release. The release description should be the same as the CHANGELOG from Step 4. The release title should be "Release {version_num}".
+1. Create a Github release ([instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)):
+    1. Draft a new release. The release description should be the same as the CHANGELOG from Step 4. The release title should be "Release {version_num}".
     1. Select `main` as release branch (ensure you merged the release PR).
-    1. Create new tag with same name as the release (`vx.y.z`).
+    1. Create a new tag with same name as the release (`vx.y.z`).
 
 ## Gut-check checklist
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -57,4 +57,4 @@ High level checklist to ensure that you completed the release successfully.
 ## Additional Resources
 
 - [How to create a Python virtual environment](https://docs.python.org/3/library/venv.html#creating-virtual-environments)
-- If you need access to the Test PyPI or PyPI projects, please ping the [#single-cell-eng](https://czi-sci.slack.com/archives/C023Q1APASK) Slack channel. 
+- If you need access to the Test PyPI or PyPI projects, please ping the [#single-cell-eng](https://czi-sci.slack.com/archives/C023Q1APASK) Slack channel. Once you have access, **please setup 2FA**!

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,0 +1,59 @@
+# cellxgene-schema Release Process
+
+_This document defines the release process of the pip installable `cellxgene-schema` tool to PyPI._
+
+The goal of the release process is to publish an installable package to PyPi, with a matching tagged release on github.
+
+## Overview
+
+The release process should result in the following side effects:
+
+* Version number bump, using semantic versioning
+* Tagged Github release
+* Publication to PyPi
+
+Note all release tags pushed to GitHub MUST follow semantic versioning.
+
+## How to release the next version of `cellxgene-schema`
+
+Steps must be run from the project directory and in a virtual env with all the dependencies defined in `requirements.txt` installed.
+
+1. Decide on whether the changes going into the next release warrant a patch, minor, or major version bump using [semantic versioning](https://semver.org/) and determine the version number based on the current latest version (i.e. if the current version is 2.0.3 and you'd like to do a minor version bump, then the next version will be 2.1.0).
+
+1. Create a release branch from latest main (e.g. `git checkout -b release-version-x.y.z`).
+
+1. In `setup.py` change the version number to be the version number determined in step 1.
+
+1. Update the [CHANGELOG](https://github.com/chanzuckerberg/single-cell-curation/blob/main/cellxgene_schema_cli/CHANGELOG.md) with the latest changes going into the new release. 
+
+1. Commit the changes, push the new branch to origin, and open a PR to be reviewed. Do not merge in the PR yet.
+
+1. Release the new version to Test PyPI. This can be done by running `make test-release`. Test the release by installing `cellxgene-schema` using pip `pip install -i https://test.pypi.org/simple/ cellxgene-schema` in a fresh virtual environment.
+
+1. If you find errors with the release candidate, fix them in `main`, delete the current release branch, and start over from step 1 with the next version number. Please also update the CHANGELOG with a note that the version number has been burned. This is necessary because once a version goes out on Test PyPI (or PyPI), that version number cannot be used again (i.e. there are no updates supported). For example, if you were trying to release a minor bump, say 2.1.0, and you found an error, then the next version will be 2.2.0 and 2.1.0 will be a "burn".
+
+1. If everything looks good, get the PR that you opened reviewed and **merged**. 
+
+1. Release the version to (prod) PyPI by running `make release`.
+
+1. Test the installation in a fresh virtual environment by running `pip install --no-cache-dir cellxgene-schema`. If you find errors, go back to step 1.
+
+1. Create Github release using the version number and release notes ([instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)):
+    1. Draft new release. The release description should be the same as the CHANGELOG from Step 4. The release title should be "Release {version_num}".
+    1. Select `main` as release branch (ensure you merged the release PR).
+    1. Create new tag with same name as the release (`vx.y.z`).
+
+## Gut-check checklist
+
+High level checklist to ensure that you completed the release successfully.
+
+- [ ] Do both the Test PyPI and PyPI latest versions match and are they the version you intended to release?
+- [ ] Did you update the CHANGELOG with notes about what went into the new release?
+- [ ] Did you create and merge in a PR to bump the version in `setup.py`?
+- [ ] Did you create a Github release for the new version?
+- [ ] Did you test the new release to make sure it works?
+
+## Additional Resources
+
+- [How to create a Python virtual environment](https://docs.python.org/3/library/venv.html#creating-virtual-environments)
+- If you need access to the Test PyPI or PyPI projects, please ping the [#single-cell-eng](https://czi-sci.slack.com/archives/C023Q1APASK) Slack channel. 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -18,23 +18,25 @@ Note all release tags pushed to GitHub MUST follow semantic versioning.
 
 Steps must be run from the project directory and in a virtual env with all the dependencies defined in `requirements.txt` installed.
 
-1. Decide on whether the changes going into the next release warrant a patch, minor, or major version bump using [semantic versioning](https://semver.org/) and determine the version number based on the current latest version (i.e. if the current version is 2.0.3 and you'd like to do a minor version bump, then the next version will be 2.1.0).
+1. Decide on whether the changes going into the next release warrant a patch, minor, or major version bump using [semantic versioning](https://semver.org/) and determine the version number based on the current latest version (i.e. if the current version is 2.0.4 and you'd like to do a minor version bump, then the next version will be 2.1.0).
 
-1. Create a release branch from latest main (e.g. `git checkout -b release-version-x.y.z`).
+1. Create a release branch from the `main` branch of the `single-cell-curation` repo (e.g. `git checkout -b release-version-x.y.z`).
 
-1. In `setup.py` change the version number to be the version number determined in step 1.
+1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be 2.1.0rc0. The `rc` suffix will be removed in a later step.
 
 1. Update the [CHANGELOG](https://github.com/chanzuckerberg/single-cell-curation/blob/main/cellxgene_schema_cli/CHANGELOG.md) with the latest changes going into the new release. 
 
 1. Commit the changes, push the new branch to origin, and open a PR to be reviewed. Do not merge in the PR yet.
 
-1. Release the new version to Test PyPI. This can be done by running `make test-release`. Test the release by installing `cellxgene-schema` using pip `pip install -i https://test.pypi.org/simple/ cellxgene-schema` in a fresh virtual environment.
+1. Run `make release-candidate-to-test-pypi` to release the newly created release candidate to Test PyPI. Test the release by installing `cellxgene-schema` using `pip install -i https://test.pypi.org/simple/ cellxgene-schema=={release_candidate_version}` in a fresh virtual environment.
 
-1. If you find errors with the release candidate, fix them in `main`, delete the current release branch, and start over from step 1 with the next version number. Please also update the CHANGELOG with a note that the version number has been burned. This is necessary because once a version goes out on Test PyPI (or PyPI), that version number cannot be used again (i.e. there are no updates supported). For example, if you were trying to release a minor bump, say 2.1.0, and you found an error, then the next version will be 2.2.0 and 2.1.0 will be a "burn".
+1. If you detect errors in the release, fix them in `main` and then rebase the release branch. Then run `make recreate-release-candidate` to bump up the release candidate version (i.e. 2.1.0rc0 will get bumped up to 2.1.0rc1). Run `make release-candidate-to-test-pypi` again to release this candidate to Test PyPI for testing.
 
-1. If everything looks good, get the PR that you opened reviewed and **merged**. 
+1. If everything looks good, release the final candidate to Test PyPI by running `make release-final-to-test-pypi`. This will remove the `rc` tag from the version and upload the distribution to Test PyPI in one go. Test one last time to make sure everything is OK.
 
-1. Release the version to (prod) PyPI by running `make release`.
+1. Ensure that all commits are pushed to your branch (especially make sure that all the version changes are pushed) and get the PR reviewed and **merged**.
+
+1. Release to (prod) PyPI by running `make release-final`.
 
 1. Test the installation in a fresh virtual environment by running `pip install --no-cache-dir cellxgene-schema`. If you find errors, go back to step 1.
 
@@ -49,7 +51,7 @@ High level checklist to ensure that you completed the release successfully.
 
 - [ ] Do both the Test PyPI and PyPI latest versions match and are they the version you intended to release?
 - [ ] Did you update the CHANGELOG with notes about what went into the new release?
-- [ ] Did you create and merge in a PR to bump the version in `setup.py`?
+- [ ] Did you create and merge in a PR with the version in `setup.py` changed to the latest?
 - [ ] Did you create a Github release for the new version?
 - [ ] Did you test the new release to make sure it works?
 - [ ] For any internal uses of `cellxgene-schema` have you upgraded the version number or let the appropriate stakeholders know that a new version exists?

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -22,7 +22,7 @@ Steps must be run from the project directory and in a virtual env with all the d
 
 1. Create a release branch from the `main` branch of the `single-cell-curation` repo (e.g. `git checkout -b release-version-x.y.z`).
 
-1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be 2.1.0rc0. The `rc` suffix will be removed in a later step.
+1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be `2.1.4-rc.0`. The `rc` suffix will be removed in a later step.
 
 1. Update the [CHANGELOG](https://github.com/chanzuckerberg/single-cell-curation/blob/main/cellxgene_schema_cli/CHANGELOG.md) with the latest changes going into the new release. 
 


### PR DESCRIPTION
~~This is a first draft of a release process to release new versions of the `cellxgene-schema` PyPI package. The process is very similar to the release process of [cellxgene Desktop](https://github.com/chanzuckerberg/cellxgene/blob/main/dev_docs/release_process.md) but with one notable exception. I have simplified the release process to exclude `rc` versions for now. Until burning of version numbers becomes a problem, I figured we can stick to just releasing to Test PyPI first and if we burn a version number there, we should note it and just use the next.~~

This is a draft of the release process to release new versions of the `cellxgene-schema` PyPI package that is pretty much identical to the release process of [cellxgene Desktop](https://github.com/chanzuckerberg/cellxgene/blob/main/dev_docs/release_process.md). 

[This sibling PR](https://github.com/chanzuckerberg/single-cell-curation/pull/169) introduces the commands cited in this documentation that enables creating release candidates, bumping up the versions of the release candidate, creating the final distributions and uploading all this distributions to Test PyPI and PyPI. Reviewers should check to ensure that the content between these two PRs aren't in conflict.

Note: I have _not_ tested this process myself so please double check my work. Or if it's convenient, please trial it on a new release and make changes accordingly. 