### PR TITLE
Warn when Seurat conversion will fail

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -27,6 +27,7 @@ class Validator:
     """Handles validation of AnnData"""
 
     schema_definitions_dir = env.SCHEMA_DEFINITIONS_DIR
+    _seurat_array_max_length = 2 ** 31 - 1  # 32-bit signed int for indexing arrays in R imposes this limit
 
     def __init__(self):
 
@@ -39,6 +40,7 @@ class Validator:
         self.h5ad_path = ""
         self.invalid_feature_ids = []
         self._raw_layer_exists = None
+        self.is_seurat_convertible: bool = True
 
         # Values will be instances of ontology.GeneChecker,
         # keys will be one of ontology.SupportedOrganisms
@@ -811,6 +813,55 @@ class Validator:
                         f"to use this type of matrix for the given sparsity."
                     )
 
+    def _validate_seurat_convertibility(self):
+        """
+        Use length of component matrices to determine if the anndata object will be unable to be converted to Seurat by
+        virtue of the R language's array size limit (4-byte signed int length). Add warning for each matrix which is
+        too large.
+
+        rtype: None
+        """
+
+        to_validate = [self.adata.X]
+        to_validate_name = ["X"]
+
+        # check if there's raw data
+        if self.adata.raw:
+            to_validate.append(self.adata.raw.X)
+            to_validate_name.append("raw")
+
+        failing_matrix_names: List[str] = []
+        # Check length of component arrays
+        for x, x_name in zip(to_validate, to_validate_name):
+
+            if (
+                    isinstance(x, sparse.csc_matrix)
+                    or isinstance(x, sparse.csr_matrix)
+                    or isinstance(x, sparse.coo_matrix)
+            ):
+                effective_r_array_size = x.count_nonzero()
+
+            elif isinstance(x, ndarray):
+                effective_r_array_size = max(x.shape)
+
+            else:
+                self.warnings.append(
+                    f"{x_name} matrix is of type {type(x)}, sparsity calculation hasn't been "
+                    f"implemented"
+                )
+                continue
+
+            if effective_r_array_size > self._seurat_array_max_length:
+                failing_matrix_names.append(x_name)
+
+        if failing_matrix_names:
+            printable_matrix_names = "\n".join(failing_matrix_names)
+            self.warnings.append(
+                f"The following matrices will fail conversion to Seurat due to exceeding the R array size limit: "
+                f"{printable_matrix_names}"
+            )
+            self.is_seurat_convertible = False
+
     def _validate_embedding_dict(self):
 
         """
@@ -1164,6 +1215,10 @@ class Validator:
         logger.debug("Validating sparsity...")
         self._validate_sparsity()
 
+        # Checks Seurat convertibility
+        logger.debug("Validating Seurat convertibility...")
+        self._validate_seurat_convertibility()
+
         # Checks each component
         for component, component_def in self.schema_def["components"].items():
             logger.debug(f"Validating component: {component}")
@@ -1240,7 +1295,7 @@ class Validator:
 
 
 def validate(h5ad_path: Union[str, bytes, os.PathLike], add_labels_file: str = None, verbose: bool = False) -> (
-        bool, list):
+        bool, list, bool):
     from .write_labels import AnnDataLabelAppender
     """
     Entry point for validation.
@@ -1248,7 +1303,8 @@ def validate(h5ad_path: Union[str, bytes, os.PathLike], add_labels_file: str = N
     :param Union[str, bytes, os.PathLike] h5ad_path: Path to h5ad file to validate
     :param str add_labels_file: Path to new h5ad file with ontology/gene labels added
 
-    :return (True, []) if successful validation, (False, [list_of_errors] otherwise
+    :return (True, [], <bool>) if successful validation, (False, [list_of_errors], <bool>) otherwise; last bool is for
+    seurat convertibility
     :rtype tuple
     """
 
@@ -1274,4 +1330,4 @@ def validate(h5ad_path: Union[str, bytes, os.PathLike], add_labels_file: str = N
 
         return validator.is_valid and writer.was_writing_successful, validator.errors + writer.errors
 
-    return True, validator.errors
+    return True, validator.errors, validator.is_seurat_convertible

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1,4 +1,7 @@
+import anndata
+import numpy as np
 import unittest
+from scipy import sparse
 
 from cellxgene_schema.write_labels import AnnDataLabelAppender
 from cellxgene_schema.ontology import OntologyChecker
@@ -198,3 +201,59 @@ class TestAddLabelFunctions(unittest.TestCase):
         ids = ["CL:NO_TERM"]
         with self.assertRaises(ValueError):
             self.writer._get_mapping_dict_curie(ids, curie_constraints)
+
+
+class TestSeuratConvertibility(unittest.TestCase):
+
+    def test_determine_seurat_convertibility(self):
+        # Sparse matrix with too many nonzero values is not Seurat-convertible
+        sparse_matrix_too_large = sparse.csr_matrix(np.ones((4, 2)))
+        data_all_nonzero = anndata.AnnData(sparse_matrix_too_large)
+
+        validator: Validator = Validator()
+        validator._seurat_array_max_length = 2 ** 3 - 1  # Reduce size required to fail (for better test run time)
+        validator.adata = data_all_nonzero
+        validator._validate_seurat_convertibility()
+        self.assertFalse(validator.is_seurat_convertible)
+
+        # Reducing nonzero count by 1, to within limit, makes it Seurat-convertible
+        sparse_matrix_with_zero = sparse.csr_matrix(np.array([0, 1, 2, 3, 4, 5, 6, 7]))
+        data_with_zero = anndata.AnnData(sparse_matrix_with_zero)
+
+        validator: Validator = Validator()
+        validator._seurat_array_max_length = 2 ** 3 - 1
+        validator.adata = data_with_zero
+        validator._validate_seurat_convertibility()
+        self.assertTrue(validator.is_seurat_convertible)
+
+        # Dense matrices with a dimension that exceeds limit will fail -- zeros are irrelevant
+        dense_matrix_with_zero = np.array([[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7]])
+        data_with_zero_dense = anndata.AnnData(dense_matrix_with_zero)
+
+        validator: Validator = Validator()
+        validator._seurat_array_max_length = 2 ** 3 - 1
+        validator.adata = data_with_zero_dense
+        validator._validate_seurat_convertibility()
+        self.assertFalse(validator.is_seurat_convertible)
+
+        # Dense matrices will fail if number of rows exceeds Seurat array max length
+        dense_matrix_with_high_row_count = np.array([[0], [1], [2], [3], [4], [5], [6], [7]])
+        data_with_zero_dense_high_row_count = anndata.AnnData(dense_matrix_with_high_row_count)
+
+        validator: Validator = Validator()
+        validator._seurat_array_max_length = 2 ** 3 - 1
+        validator.adata = data_with_zero_dense_high_row_count
+        validator._validate_seurat_convertibility()
+        self.assertFalse(validator.is_seurat_convertible)
+
+    def test_add_warning_for_seurat_nonconvertible(self):
+
+        sparse_matrix_too_large = sparse.csr_matrix(np.ones((4, 2)))
+        data_all_nonzero = anndata.AnnData(sparse_matrix_too_large)
+
+        validator: Validator = Validator()
+        validator._seurat_array_max_length = 2 ** 3 - 1
+        validator.adata = data_all_nonzero
+        validator._validate_seurat_convertibility()
+        self.assertFalse(validator.is_seurat_convertible)
+        self.assertTrue(len(validator.warnings) == 1)

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -30,7 +30,7 @@ Steps must be run from the project directory and in a virtual env with all the d
 
 1. Run `make release-candidate-to-test-pypi` to release the newly created release candidate to Test PyPI. Test the release by installing `cellxgene-schema` using `pip install -i https://test.pypi.org/simple/ cellxgene-schema=={release_candidate_version}` in a fresh virtual environment.
 
-1. If you detect errors in the release, fix them in `main` and then rebase the release branch. Then run `make recreate-release-candidate` to bump up the release candidate version (i.e. 2.1.0rc0 will get bumped up to 2.1.0rc1). Run `make release-candidate-to-test-pypi` again to release this candidate to Test PyPI for testing.
+1. If you detect errors in the release, fix them in `main` and then rebase the release branch. Then run `make recreate-release-candidate` to bump up the release candidate version (i.e. 2.1.0-rc.0 will get bumped up to 2.1.0-rc.1). Run `make release-candidate-to-test-pypi` again to release this candidate to Test PyPI for testing.
 
 1. If everything looks good, release the final candidate to Test PyPI by running `make release-final-to-test-pypi`. This will remove the `rc` tag from the version and upload the distribution to Test PyPI in one go. Test one last time to make sure everything is OK.
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -20,9 +20,7 @@ Steps must be run from the project directory and in a virtual env with all the d
 
 1. Decide on whether the changes going into the next release warrant a patch, minor, or major version bump using [semantic versioning](https://semver.org/) and determine the version number based on the current latest version (i.e. if the current version is 2.0.4 and you'd like to do a minor version bump, then the next version will be 2.1.0).
 
-1. Create a release branch from the `main` branch of the `single-cell-curation` repo (e.g. `git checkout -b release-version-x.y.z`).
-
-1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be `2.1.4-rc.0`. The `rc` suffix will be removed in a later step.
+1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be `2.1.4-rc.0`. The `rc` suffix will be removed in a later step. This step will also automatically create and checkout a new release Git branch.
 
 1. Update the [CHANGELOG](https://github.com/chanzuckerberg/single-cell-curation/blob/main/cellxgene_schema_cli/CHANGELOG.md) with the latest changes going into the new release. 
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -52,6 +52,7 @@ High level checklist to ensure that you completed the release successfully.
 - [ ] Did you create and merge in a PR to bump the version in `setup.py`?
 - [ ] Did you create a Github release for the new version?
 - [ ] Did you test the new release to make sure it works?
+- [ ] For any internal uses of `cellxgene-schema` have you upgraded the version number or let the appropriate stakeholders know that a new version exists?
 
 ## Additional Resources
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -40,10 +40,10 @@ Steps must be run from the project directory and in a virtual env with all the d
 
 1. Test the installation in a fresh virtual environment by running `pip install --no-cache-dir cellxgene-schema`. If you find errors, go back to step 1.
 
-1. Create Github release using the version number and release notes ([instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)):
-    1. Draft new release. The release description should be the same as the CHANGELOG from Step 4. The release title should be "Release {version_num}".
+1. Create a Github release ([instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)):
+    1. Draft a new release. The release description should be the same as the CHANGELOG from Step 4. The release title should be "Release {version_num}".
     1. Select `main` as release branch (ensure you merged the release PR).
-    1. Create new tag with same name as the release (`vx.y.z`).
+    1. Create a new tag with same name as the release (`vx.y.z`).
 
 ## Gut-check checklist
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -57,4 +57,4 @@ High level checklist to ensure that you completed the release successfully.
 ## Additional Resources
 
 - [How to create a Python virtual environment](https://docs.python.org/3/library/venv.html#creating-virtual-environments)
-- If you need access to the Test PyPI or PyPI projects, please ping the [#single-cell-eng](https://czi-sci.slack.com/archives/C023Q1APASK) Slack channel. 
+- If you need access to the Test PyPI or PyPI projects, please ping the [#single-cell-eng](https://czi-sci.slack.com/archives/C023Q1APASK) Slack channel. Once you have access, **please setup 2FA**!

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,0 +1,59 @@
+# cellxgene-schema Release Process
+
+_This document defines the release process of the pip installable `cellxgene-schema` tool to PyPI._
+
+The goal of the release process is to publish an installable package to PyPi, with a matching tagged release on github.
+
+## Overview
+
+The release process should result in the following side effects:
+
+* Version number bump, using semantic versioning
+* Tagged Github release
+* Publication to PyPi
+
+Note all release tags pushed to GitHub MUST follow semantic versioning.
+
+## How to release the next version of `cellxgene-schema`
+
+Steps must be run from the project directory and in a virtual env with all the dependencies defined in `requirements.txt` installed.
+
+1. Decide on whether the changes going into the next release warrant a patch, minor, or major version bump using [semantic versioning](https://semver.org/) and determine the version number based on the current latest version (i.e. if the current version is 2.0.3 and you'd like to do a minor version bump, then the next version will be 2.1.0).
+
+1. Create a release branch from latest main (e.g. `git checkout -b release-version-x.y.z`).
+
+1. In `setup.py` change the version number to be the version number determined in step 1.
+
+1. Update the [CHANGELOG](https://github.com/chanzuckerberg/single-cell-curation/blob/main/cellxgene_schema_cli/CHANGELOG.md) with the latest changes going into the new release. 
+
+1. Commit the changes, push the new branch to origin, and open a PR to be reviewed. Do not merge in the PR yet.
+
+1. Release the new version to Test PyPI. This can be done by running `make test-release`. Test the release by installing `cellxgene-schema` using pip `pip install -i https://test.pypi.org/simple/ cellxgene-schema` in a fresh virtual environment.
+
+1. If you find errors with the release candidate, fix them in `main`, delete the current release branch, and start over from step 1 with the next version number. Please also update the CHANGELOG with a note that the version number has been burned. This is necessary because once a version goes out on Test PyPI (or PyPI), that version number cannot be used again (i.e. there are no updates supported). For example, if you were trying to release a minor bump, say 2.1.0, and you found an error, then the next version will be 2.2.0 and 2.1.0 will be a "burn".
+
+1. If everything looks good, get the PR that you opened reviewed and **merged**. 
+
+1. Release the version to (prod) PyPI by running `make release`.
+
+1. Test the installation in a fresh virtual environment by running `pip install --no-cache-dir cellxgene-schema`. If you find errors, go back to step 1.
+
+1. Create Github release using the version number and release notes ([instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)):
+    1. Draft new release. The release description should be the same as the CHANGELOG from Step 4. The release title should be "Release {version_num}".
+    1. Select `main` as release branch (ensure you merged the release PR).
+    1. Create new tag with same name as the release (`vx.y.z`).
+
+## Gut-check checklist
+
+High level checklist to ensure that you completed the release successfully.
+
+- [ ] Do both the Test PyPI and PyPI latest versions match and are they the version you intended to release?
+- [ ] Did you update the CHANGELOG with notes about what went into the new release?
+- [ ] Did you create and merge in a PR to bump the version in `setup.py`?
+- [ ] Did you create a Github release for the new version?
+- [ ] Did you test the new release to make sure it works?
+
+## Additional Resources
+
+- [How to create a Python virtual environment](https://docs.python.org/3/library/venv.html#creating-virtual-environments)
+- If you need access to the Test PyPI or PyPI projects, please ping the [#single-cell-eng](https://czi-sci.slack.com/archives/C023Q1APASK) Slack channel. 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -18,23 +18,25 @@ Note all release tags pushed to GitHub MUST follow semantic versioning.
 
 Steps must be run from the project directory and in a virtual env with all the dependencies defined in `requirements.txt` installed.
 
-1. Decide on whether the changes going into the next release warrant a patch, minor, or major version bump using [semantic versioning](https://semver.org/) and determine the version number based on the current latest version (i.e. if the current version is 2.0.3 and you'd like to do a minor version bump, then the next version will be 2.1.0).
+1. Decide on whether the changes going into the next release warrant a patch, minor, or major version bump using [semantic versioning](https://semver.org/) and determine the version number based on the current latest version (i.e. if the current version is 2.0.4 and you'd like to do a minor version bump, then the next version will be 2.1.0).
 
-1. Create a release branch from latest main (e.g. `git checkout -b release-version-x.y.z`).
+1. Create a release branch from the `main` branch of the `single-cell-curation` repo (e.g. `git checkout -b release-version-x.y.z`).
 
-1. In `setup.py` change the version number to be the version number determined in step 1.
+1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be 2.1.0rc0. The `rc` suffix will be removed in a later step.
 
 1. Update the [CHANGELOG](https://github.com/chanzuckerberg/single-cell-curation/blob/main/cellxgene_schema_cli/CHANGELOG.md) with the latest changes going into the new release. 
 
 1. Commit the changes, push the new branch to origin, and open a PR to be reviewed. Do not merge in the PR yet.
 
-1. Release the new version to Test PyPI. This can be done by running `make test-release`. Test the release by installing `cellxgene-schema` using pip `pip install -i https://test.pypi.org/simple/ cellxgene-schema` in a fresh virtual environment.
+1. Run `make release-candidate-to-test-pypi` to release the newly created release candidate to Test PyPI. Test the release by installing `cellxgene-schema` using `pip install -i https://test.pypi.org/simple/ cellxgene-schema=={release_candidate_version}` in a fresh virtual environment.
 
-1. If you find errors with the release candidate, fix them in `main`, delete the current release branch, and start over from step 1 with the next version number. Please also update the CHANGELOG with a note that the version number has been burned. This is necessary because once a version goes out on Test PyPI (or PyPI), that version number cannot be used again (i.e. there are no updates supported). For example, if you were trying to release a minor bump, say 2.1.0, and you found an error, then the next version will be 2.2.0 and 2.1.0 will be a "burn".
+1. If you detect errors in the release, fix them in `main` and then rebase the release branch. Then run `make recreate-release-candidate` to bump up the release candidate version (i.e. 2.1.0rc0 will get bumped up to 2.1.0rc1). Run `make release-candidate-to-test-pypi` again to release this candidate to Test PyPI for testing.
 
-1. If everything looks good, get the PR that you opened reviewed and **merged**. 
+1. If everything looks good, release the final candidate to Test PyPI by running `make release-final-to-test-pypi`. This will remove the `rc` tag from the version and upload the distribution to Test PyPI in one go. Test one last time to make sure everything is OK.
 
-1. Release the version to (prod) PyPI by running `make release`.
+1. Ensure that all commits are pushed to your branch (especially make sure that all the version changes are pushed) and get the PR reviewed and **merged**.
+
+1. Release to (prod) PyPI by running `make release-final`.
 
 1. Test the installation in a fresh virtual environment by running `pip install --no-cache-dir cellxgene-schema`. If you find errors, go back to step 1.
 
@@ -49,7 +51,7 @@ High level checklist to ensure that you completed the release successfully.
 
 - [ ] Do both the Test PyPI and PyPI latest versions match and are they the version you intended to release?
 - [ ] Did you update the CHANGELOG with notes about what went into the new release?
-- [ ] Did you create and merge in a PR to bump the version in `setup.py`?
+- [ ] Did you create and merge in a PR with the version in `setup.py` changed to the latest?
 - [ ] Did you create a Github release for the new version?
 - [ ] Did you test the new release to make sure it works?
 - [ ] For any internal uses of `cellxgene-schema` have you upgraded the version number or let the appropriate stakeholders know that a new version exists?

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -22,7 +22,7 @@ Steps must be run from the project directory and in a virtual env with all the d
 
 1. Create a release branch from the `main` branch of the `single-cell-curation` repo (e.g. `git checkout -b release-version-x.y.z`).
 
-1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be 2.1.0rc0. The `rc` suffix will be removed in a later step.
+1. Run `make create-release-candidate PART={major | minor | patch}`, where you set `PART` to be one of `major` or `minor` or `patch` based on Step 1. This step will automatically bump the version of the package to the appropriate next version in `setup.py` and commit the change to the branch. Note that this will create a release candidate version, so if the current version is 2.0.4 and you want to do a minor release, then the version will be `2.1.4-rc.0`. The `rc` suffix will be removed in a later step.
 
 1. Update the [CHANGELOG](https://github.com/chanzuckerberg/single-cell-curation/blob/main/cellxgene_schema_cli/CHANGELOG.md) with the latest changes going into the new release. 
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-curation/162

**Functional**
@metakuni 

**Readability**
@ebezzi

## Changes

This commit issues warnings for AnnData matrices X and raw.X when either
of them is unable to be converted to Seurat due to size limitations. It
also returns the Seurat convertibility status to calls to
validate.validate in order to make the convertibility available to the
Data Portal.