### PR TITLE
Warn when Seurat conversion will fail

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -40,7 +40,7 @@ def schema_cli():
     is_flag=True
 )
 def schema_validate(h5ad_file, add_labels_file, verbose):
-    is_valid, _ = validate(h5ad_file, add_labels_file, verbose=verbose)
+    is_valid, _, _ = validate(h5ad_file, add_labels_file, verbose=verbose)
     if is_valid:
         sys.exit(0)
     else:

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/2_0_0.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/2_0_0.yaml
@@ -2,6 +2,8 @@ title: Corpora schema version 2.0.0
 type: anndata
 # If sparsity of any expression matrix is greater than this and not csr sparse matrix, then there will be warning.
 sparsity: 0.5
+# If the R array will exceed this number in size, then Seurat conversion will fail
+max_size_for_seurat: 2147483647  # 2^31 - 1 (max value for 4-byte signed int)
 # Perform the checks for "raw" requirements IF:
 raw:
     obs:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1317,7 +1317,8 @@ def validate(h5ad_path: Union[str, bytes, os.PathLike], add_labels_file: str = N
         writer.write_labels(add_labels_file)
         logger.info(f"H5AD label writing complete in {datetime.now() - label_start}, was_writing_successful: {writer.was_writing_successful}") # noqa E501
 
-        return validator.is_valid and writer.was_writing_successful, validator.errors + writer.errors, \
-               validator.is_seurat_convertible
+        return validator.is_valid and writer.was_writing_successful, \
+            validator.errors + writer.errors, \
+            validator.is_seurat_convertible
 
     return True, validator.errors, validator.is_seurat_convertible

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -825,7 +825,6 @@ class Validator:
         if self.adata.raw:
             to_validate.append(self.adata.raw.X)
             to_validate_name.append("raw")
-        inconvertible_matrix_names: List[(str, int, bool)] = []
         # Check length of component arrays
         for matrix, matrix_name in zip(to_validate, to_validate_name):
             if sparse.issparse(matrix):
@@ -1318,6 +1317,7 @@ def validate(h5ad_path: Union[str, bytes, os.PathLike], add_labels_file: str = N
         writer.write_labels(add_labels_file)
         logger.info(f"H5AD label writing complete in {datetime.now() - label_start}, was_writing_successful: {writer.was_writing_successful}") # noqa E501
 
-        return validator.is_valid and writer.was_writing_successful, validator.errors + writer.errors, validator.is_seurat_convertible
+        return validator.is_valid and writer.was_writing_successful, validator.errors + writer.errors, \
+               validator.is_seurat_convertible
 
     return True, validator.errors, validator.is_seurat_convertible

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -27,7 +27,6 @@ class Validator:
     """Handles validation of AnnData"""
 
     schema_definitions_dir = env.SCHEMA_DEFINITIONS_DIR
-    _seurat_array_max_length = 2 ** 31 - 1  # 32-bit signed int for indexing arrays in R imposes this limit
 
     def __init__(self):
 
@@ -839,16 +838,20 @@ class Validator:
                 continue
             if effective_r_array_size > self.schema_def["max_size_for_seurat"]:
                 if is_sparse:
-                    warning_message = f"This dataset cannot be converted to the .rds (Seurat v3) format. " \
-                                      f"{effective_r_array_size} nonzero elements in matrix {matrix_name} exceed the " \
-                                      f"limitations in the R dgCMatrix sparse matrix class (2^31 - 1 nonzero " \
-                                      f"elements)."
+                    self.warnings.append(
+                        f"This dataset cannot be converted to the .rds (Seurat v3) format. "
+                        f"{effective_r_array_size} nonzero elements in matrix {matrix_name} exceed the "
+                        f"limitations in the R dgCMatrix sparse matrix class (2^31 - 1 nonzero "
+                        f"elements)."
+                    )
                 else:
-                    warning_message = f"This dataset cannot be converted to the .rds (Seurat v3) format. " \
-                                      f"{effective_r_array_size} elements in at least one dimension of matrix " \
-                                      f"{matrix_name} exceed the limitations in the R dgCMatrix sparse matrix class " \
-                                      f"(2^31 - 1 nonzero elements)."
-                self.warnings.append(warning_message)
+                    self.warnings.append(
+                        f"This dataset cannot be converted to the .rds (Seurat v3) format. "
+                        f"{effective_r_array_size} elements in at least one dimension of matrix "
+                        f"{matrix_name} exceed the limitations in the R dgCMatrix sparse matrix class "
+                        f"(2^31 - 1 nonzero elements)."
+                    )
+
                 self.is_seurat_convertible = False
 
     def _validate_embedding_dict(self):

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="2.0.4",
+    version="2.0.5",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="2.0.5",
+    version="2.1.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -236,3 +236,11 @@ class TestSeuratConvertibility(unittest.TestCase):
         self.validator._validate_seurat_convertibility()
         self.assertTrue(len(self.validator.warnings) == 1)
         self.assertFalse(self.validator.is_seurat_convertible)
+
+        # Dense matrices with dimensions in bounds but total count over will succeed
+        dense_matrix = np.ones((good_obs.shape[0], good_var.shape[0]))
+        self.validation_helper(dense_matrix)
+        self.validator.schema_def["max_size_for_seurat"] = 2 ** 3 - 1
+        self.validator._validate_seurat_convertibility()
+        self.assertTrue(len(self.validator.warnings) == 0)
+        self.assertTrue(self.validator.is_seurat_convertible)


### PR DESCRIPTION
https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-curation/162

**Functional**
@pablo-gar 
@metakuni 

**Readability**
@ebezzi 

## Changes

This commit issues warnings for AnnData matrices X and raw.X when either
of them is unable to be converted to Seurat due to size limitations. It
also returns the Seurat convertibility status to calls to
validate.validate in order to make the convertibility available to the
Data Portal.