### PR TITLE
chore: improve cli responsiveness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *.idea*
 __pycache__
 *.DS_Store*
+dist
+cellxgene_schema_cli/build
+cellxgene_schema_cli/dist
+*.egg-info
 
 # enviroments
 venv/

--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -1,6 +1,5 @@
 import click
 import sys
-from .validate import validate
 
 
 @click.group(
@@ -10,10 +9,7 @@ from .validate import validate
     context_settings=dict(max_content_width=85, help_option_names=["-h", "--help"]),
 )
 def schema_cli():
-    try:
-        import anndata  # noqa: F401
-    except ImportError:
-        raise click.ClickException("[cellxgene] cellxgene-schema requires anndata")
+    pass
 
 
 @click.command(
@@ -40,6 +36,15 @@ def schema_cli():
     is_flag=True
 )
 def schema_validate(h5ad_file, add_labels_file, verbose):
+    # This can ve very slow so we defer loading until Click arg validation has passed
+    try:
+        import anndata  # noqa: F401
+    except ImportError:
+        raise click.ClickException("[cellxgene] cellxgene-schema requires anndata")
+
+    print("Loading validator modules")
+    from .validate import validate
+
     is_valid, _, _ = validate(h5ad_file, add_labels_file, verbose=verbose)
     if is_valid:
         sys.exit(0)

--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -36,7 +36,9 @@ def schema_cli():
     is_flag=True
 )
 def schema_validate(h5ad_file, add_labels_file, verbose):
-    # This can ve very slow so we defer loading until Click arg validation has passed
+    # Imports are very slow so we defer loading until Click arg validation has passed
+
+    print("Loading dependencies")
     try:
         import anndata  # noqa: F401
     except ImportError:


### PR DESCRIPTION
Ticket: #2470 https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/cellxgene/2470

Move imports to after Click-argument validation to improve cli responsiveness.
Time to see help menu reduced from ~5s to ~0.1s.

Before:
```
(venv) ➜  cellxgene_schema_cli git:(main) ✗ L$ time PYTHONPATH=. python -m cellxgene_schema.cli validate
Usage: python -m cellxgene_schema.cli validate [OPTIONS] H5AD_FILE
Try 'python -m cellxgene_schema.cli validate -h' for help.

Error: Missing argument 'H5AD_FILE'.
PYTHONPATH=. python -m cellxgene_schema.cli validate 
**5.38s user 0.71s system 116% cpu 5.221 total**
```

After:
```
(venv) ➜  cellxgene_schema_cli git:(main) ✗ L$ time PYTHONPATH=. python -m cellxgene_schema.cli validate
Usage: python -m cellxgene_schema.cli validate [OPTIONS] H5AD_FILE
Try 'python -m cellxgene_schema.cli validate -h' for help.

Error: Missing argument 'H5AD_FILE'.
PYTHONPATH=. python -m cellxgene_schema.cli validate 
**0.04s user 0.01s system 90% cpu 0.064 total**
```

Also added some messages to indicate progress on imports loading so user knows something is happening.
```
(venv) ➜  cellxgene_schema_cli git:(brodgers/2470_cli_slow) ✗ L$ time PYTHONPATH=. python -m cellxgene_schema.cli validate /Users/bmasscheleinrodgers/cxg/cellxgene/example-dataset/pbmc3k.h5ad
Loading dependencies
Loading validator modules
Starting validation...
/Users/bmasscheleinrodgers/cxg/single-cell-curation/venv/lib/python3.9/site-packages/anndata/compat/__init__.py:180: FutureWarning: Moving element from .uns['neighbors']['distances'] to .obsp['distances'].

This is where adjacency matrices should go now.
  warn(
/Users/bmasscheleinrodgers/cxg/single-cell-curation/venv/lib/python3.9/site-packages/anndata/compat/__init__.py:180: FutureWarning: Moving element from .uns['neighbors']['connectivities'] to .obsp['connectivities'].

This is where adjacency matrices should go now.
  warn(
ERROR: adata has no schema definition in 'adata.uns'. Validation cannot be performed.
Validation complete in 0:00:00.201663 with status is_valid=False
PYTHONPATH=. python -m cellxgene_schema.cli validate   5.16s user 0.88s system 110% cpu 5.492 total
```