### PR TITLE
Add ontology ancestor mapping notebook

### DIFF
--- a/notebooks/compute_ancestor_mapping.ipynb
+++ b/notebooks/compute_ancestor_mapping.ipynb
@@ -1,8 +1,24 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "89ea87d1-2459-4c09-b482-786db8cd3031",
+   "metadata": {},
+   "source": [
+    "# Ontology ancestors mapping\n",
+    "This notebook can be used to compute mappings between nodes in an ontology files and their ancestors.\n",
+    "It will:\n",
+    "1. Load the required ontology files (human, mouse, UBERON)\n",
+    "1. For `human` and `mouse`, start from each node available in the ontology\n",
+    "1. for `UBERON`, only start from a defined, hardcoded subset of leaf nodes which is relevant for our datasets\n",
+    "1. Recursively compute ancestors using the `is_a` relationship and `part_of` restriction (defined as `BFO_0000050`)\n",
+    "1. Create mappings from each node to its ancestors\n",
+    "1. Write a json file with these mappings (a dictionary of lists)"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 361,
+   "execution_count": null,
    "id": "309f0981-0d2b-4392-90e2-3c60bf4e23ae",
    "metadata": {},
    "outputs": [],
@@ -13,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 362,
+   "execution_count": null,
    "id": "d9d21563-dc35-4f1d-9c95-3d1730f419e1",
    "metadata": {},
    "outputs": [],
@@ -39,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 363,
+   "execution_count": null,
    "id": "d4129e18-6542-405a-b40c-c475fffc4d65",
    "metadata": {},
    "outputs": [],
@@ -59,12 +75,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 364,
+   "execution_count": null,
    "id": "c2792522-532c-4e0c-91a3-74b5221bda02",
    "metadata": {},
    "outputs": [],
    "source": [
-    "human_ontology = \"hsapdv.owl\"\n",
+    "human_ontology = \"http://purl.obolibrary.org/obo/hsapdv.owl\"\n",
     "\n",
     "onto = get_ontology(human_ontology)\n",
     "onto.load()\n",
@@ -74,12 +90,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 365,
+   "execution_count": null,
    "id": "ab070e7e-bb27-4397-b0c2-839746228dd0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mouse_ontology = \"mmusdv.owl\"\n",
+    "mouse_ontology = \"http://purl.obolibrary.org/obo/mmusdv.owl\"\n",
     "\n",
     "onto = get_ontology(mouse_ontology)\n",
     "onto.load()\n",
@@ -89,23 +105,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 366,
+   "execution_count": null,
    "id": "b82a6bb3-a40a-488f-a001-b2b849016fcb",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "get_ontology(\"http://purl.obolibrary.org/obo/uberon.owl#\")"
-      ]
-     },
-     "execution_count": 366,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "uberon_ontology = \"uberon.owl\"\n",
+    "uberon_ontology = \"http://purl.obolibrary.org/obo/uberon.owl\"\n",
     "\n",
     "onto = get_ontology(uberon_ontology)\n",
     "onto.load()"
@@ -113,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 367,
+   "execution_count": null,
    "id": "0831cff6-1c4a-494c-b466-02181e5fe3d4",
    "metadata": {},
    "outputs": [],
@@ -172,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 368,
+   "execution_count": null,
    "id": "d5538452-e69a-4d49-b385-4e737c2a8905",
    "metadata": {},
    "outputs": [],
@@ -184,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 369,
+   "execution_count": null,
    "id": "dad71f23-d601-4454-92dc-32940d477064",
    "metadata": {},
    "outputs": [],

--- a/ontology/compute_ancestor_mapping.ipynb
+++ b/ontology/compute_ancestor_mapping.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 361,
+   "id": "309f0981-0d2b-4392-90e2-3c60bf4e23ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from owlready2 import *\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 362,
+   "id": "d9d21563-dc35-4f1d-9c95-3d1730f419e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_ancestors(class_name):\n",
+    "\n",
+    "    z = onto.search_one(iri = f'http://purl.obolibrary.org/obo/{class_name}')\n",
+    "\n",
+    "    def recurse(x):\n",
+    "        for e in x.is_a:\n",
+    "            if hasattr(e, \"value\"):\n",
+    "                prop = e.property.name\n",
+    "                if prop != \"BFO_0000050\": continue\n",
+    "                val = e.value.name.replace(\"obo.\", \"\")\n",
+    "                z = onto.search_one(iri = f'http://purl.obolibrary.org/obo/{val}')\n",
+    "                yield (z, z.name, z.label, z.IAO_0000115)\n",
+    "                yield from recurse(z)\n",
+    "\n",
+    "\n",
+    "    yield (z, z.name, z.label, z.IAO_0000115)\n",
+    "    yield from recurse(z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 363,
+   "id": "d4129e18-6542-405a-b40c-c475fffc4d65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_mapping(classes, prefix = None):\n",
+    "    x = dict()\n",
+    "    for cls in classes:\n",
+    "        for a in get_ancestors(cls.name):\n",
+    "            if prefix and not a[1].startswith(prefix):\n",
+    "                continue\n",
+    "            if cls.name in x:\n",
+    "                x[cls.name].append(a[1])\n",
+    "            else:\n",
+    "                x[cls.name] = [a[1]]    \n",
+    "    return x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 364,
+   "id": "c2792522-532c-4e0c-91a3-74b5221bda02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "human_ontology = \"hsapdv.owl\"\n",
+    "\n",
+    "onto = get_ontology(human_ontology)\n",
+    "onto.load()\n",
+    "\n",
+    "m_human = create_mapping(onto.classes(), \"HsapDv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 365,
+   "id": "ab070e7e-bb27-4397-b0c2-839746228dd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mouse_ontology = \"mmusdv.owl\"\n",
+    "\n",
+    "onto = get_ontology(mouse_ontology)\n",
+    "onto.load()\n",
+    "\n",
+    "m_mouse = create_mapping(onto.classes(), \"MmusDv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 366,
+   "id": "b82a6bb3-a40a-488f-a001-b2b849016fcb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "get_ontology(\"http://purl.obolibrary.org/obo/uberon.owl#\")"
+      ]
+     },
+     "execution_count": 366,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "uberon_ontology = \"uberon.owl\"\n",
+    "\n",
+    "onto = get_ontology(uberon_ontology)\n",
+    "onto.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 367,
+   "id": "0831cff6-1c4a-494c-b466-02181e5fe3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uberon_classes = [\n",
+    "    \"UBERON_0007236\",\n",
+    "    \"UBERON_0000106\",\n",
+    "    \"UBERON_0014859\",\n",
+    "    \"UBERON_0008264\",\n",
+    "    \"UBERON_0007233\",\n",
+    "    \"UBERON_0000112\",\n",
+    "    \"UBERON_8000003\",\n",
+    "    \"UBERON_0014857\",\n",
+    "    \"UBERON_0009849\",\n",
+    "    \"UBERON_0034920\",\n",
+    "    \"UBERON_0000069\",\n",
+    "    \"UBERON_0000109\",\n",
+    "    \"UBERON_8000001\",\n",
+    "    \"UBERON_0000068\",\n",
+    "    \"UBERON_0018685\",\n",
+    "    \"UBERON_0000107\",\n",
+    "    \"UBERON_0007222\",\n",
+    "    \"UBERON_0000092\",\n",
+    "    \"UBERON_0018378\",\n",
+    "    \"UBERON_0014864\",\n",
+    "    \"UBERON_0004730\",\n",
+    "    \"UBERON_0000111\",\n",
+    "    \"UBERON_0007220\",\n",
+    "    \"UBERON_0014405\",\n",
+    "    \"UBERON_0014862\",\n",
+    "    \"UBERON_8000000\",\n",
+    "    \"UBERON_0000071\",\n",
+    "    \"UBERON_0014860\",\n",
+    "    \"UBERON_0012101\",\n",
+    "    \"UBERON_0000113\",\n",
+    "    \"UBERON_0014858\",\n",
+    "    \"UBERON_0007232\",\n",
+    "    \"UBERON_0000070\",\n",
+    "    \"UBERON_0000110\",\n",
+    "    \"UBERON_8000002\",\n",
+    "    \"UBERON_0014856\",\n",
+    "    \"UBERON_0004728\",\n",
+    "    \"UBERON_0034919\",\n",
+    "    \"UBERON_0000108\",\n",
+    "    \"UBERON_0000066\",\n",
+    "    \"UBERON_0004707\",\n",
+    "    \"UBERON_0000105\",\n",
+    "    \"UBERON_0018241\",\n",
+    "    \"UBERON_0007221\",\n",
+    "    \"UBERON_0014406\",\n",
+    "    \"UBERON_0014863\",\n",
+    "    \"UBERON_0004729\",\n",
+    "    \"UBERON_0014861\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 368,
+   "id": "d5538452-e69a-4d49-b385-4e737c2a8905",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uc = [onto.search_one(iri = f'http://purl.obolibrary.org/obo/{c}') for c in uberon_classes]\n",
+    "\n",
+    "m_uberon = create_mapping(uc, \"UBERON\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 369,
+   "id": "dad71f23-d601-4454-92dc-32940d477064",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"ontology_mapping.json\", \"w\") as f:\n",
+    "    d = {}\n",
+    "    d.update(m_human)\n",
+    "    d.update(m_mouse)\n",
+    "    d.update(m_uberon)\n",
+    "    json.dump(d, f)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Notebook used to compute ancestors for nodes in human, mouse and UBERON (only a subset) ontologies.