### PR TITLE
Add support to generate metrics about testing coverage in schema CLI and upload to Codecov

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -46,3 +46,5 @@ jobs:
           pip install pytest
       - name: Unit tests
         run: make unit-test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 	cd cellxgene_schema_cli/ && pip install -r requirements.txt && pip install .
 
 unit-test:
-	cd cellxgene_schema_cli && pytest
+	cd cellxgene_schema_cli && coverage run --source=cellxgene_schema -m unittest discover --start-directory=tests/ --verbose && coverage xml
 
 clean:
 	rm -rf cellxgene_schema_cli/build cellxgene_schema_cli/dist cellxgene_schema_cli/cellxgene_schema.egg-info

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,9 +1,10 @@
-wheel==0.37.0
-click==8.0.1
-Cython==0.29.24
 anndata==0.7.6
+click==8.0.1
+coverage==6.3.2
+Cython==0.29.24
 numpy==1.21.2
-pandas==1.3.2
 owlready2==0.34
-PyYaml==5.4.1
+pandas==1.3.2
 pytest==6.2.5
+PyYaml==5.4.1
+wheel==0.37.0

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # cellxgene curation tools
 
+[![codecov](https://codecov.io/gh/chanzuckerberg/single-cell-curation/branch/main/graph/badge.svg?token=J8OT7OXKHJ)](https://codecov.io/gh/chanzuckerberg/single-cell-curation)
+
 This repository contains documents and code used by cellxgene's curation team. Issues/suggestions pertaining to datasets and how they interact with cellxgene should be created here. 
 
 For information/issues about cellxgene and its portal please refer to:


### PR DESCRIPTION
## Changes

### Additions

- Add Codecov badge to the top level repo README.
- Upload coverage report to Codecov in push_test Github Action.

### Modifications

- Alphabetize `requirements.txt`
- Run `coverage` instead of `pytest` to execute unit tests so that coverage stats are generated.