### PR TITLE
feat: add --ignore-labels flag

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -30,12 +30,18 @@ def schema_cli():
     type=click.Path(exists=False, dir_okay=False, writable=True),
 )
 @click.option(
+    "-i",
+    "--ignore-labels",
+    help="Ignore ontology labels when validating",
+    is_flag=True
+)
+@click.option(
     "-v",
     "--verbose",
     help="When present will set logging level to debug",
     is_flag=True
 )
-def schema_validate(h5ad_file, add_labels_file, verbose):
+def schema_validate(h5ad_file, add_labels_file, ignore_labels, verbose):
     # Imports are very slow so we defer loading until Click arg validation has passed
 
     print("Loading dependencies")
@@ -47,7 +53,7 @@ def schema_validate(h5ad_file, add_labels_file, verbose):
     print("Loading validator modules")
     from .validate import validate
 
-    is_valid, _, _ = validate(h5ad_file, add_labels_file, verbose=verbose)
+    is_valid, _, _ = validate(h5ad_file, add_labels_file, ignore_labels, verbose=verbose)
     if is_valid:
         sys.exit(0)
     else:

--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -53,7 +53,7 @@ def schema_validate(h5ad_file, add_labels_file, ignore_labels, verbose):
     print("Loading validator modules")
     from .validate import validate
 
-    is_valid, _, _ = validate(h5ad_file, add_labels_file, ignore_labels, verbose=verbose)
+    is_valid, _, _ = validate(h5ad_file, add_labels_file, ignore_labels=ignore_labels, verbose=verbose)
     if is_valid:
         sys.exit(0)
     else:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -28,7 +28,7 @@ class Validator:
 
     schema_definitions_dir = env.SCHEMA_DEFINITIONS_DIR
 
-    def __init__(self):
+    def __init__(self, ignore_labels):
 
         # Set initial state
         self.errors = []
@@ -40,6 +40,7 @@ class Validator:
         self.invalid_feature_ids = []
         self._raw_layer_exists = None
         self.is_seurat_convertible: bool = True
+        self.ignore_labels = ignore_labels
 
         # Values will be instances of ontology.GeneChecker,
         # keys will be one of ontology.SupportedOrganisms
@@ -1171,6 +1172,10 @@ class Validator:
                             f"Column '{column}' must not be present in '{component}'."
                         )
 
+            # If ignore_labels is set, we will skip all the subsequent label checks
+            if self.ignore_labels:
+                continue
+
             # Do it for columns that map to columns
             for column, columns_def in component_def["columns"].items():
 
@@ -1291,6 +1296,7 @@ class Validator:
 def validate(
     h5ad_path: Union[str, bytes, os.PathLike],
     add_labels_file: str = None,
+    ignore_labels: bool = False,
     verbose: bool = False,
 ) -> (bool, list, bool):
     from .write_labels import AnnDataLabelAppender
@@ -1312,7 +1318,7 @@ def validate(
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.INFO, format="%(message)s")
-    validator = Validator()
+    validator = Validator(ignore_labels)
     validator.validate_adata(h5ad_path)
     logger.info(
         f"Validation complete in {datetime.now() - start} with status is_valid={validator.is_valid}"

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -28,7 +28,7 @@ class Validator:
 
     schema_definitions_dir = env.SCHEMA_DEFINITIONS_DIR
 
-    def __init__(self, ignore_labels):
+    def __init__(self, ignore_labels=False):
 
         # Set initial state
         self.errors = []

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1318,7 +1318,7 @@ def validate(
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.INFO, format="%(message)s")
-    validator = Validator(ignore_labels)
+    validator = Validator(ignore_labels=ignore_labels)
     validator.validate_adata(h5ad_path)
     logger.info(
         f"Validation complete in {datetime.now() - start} with status is_valid={validator.is_valid}"

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,4 +1,4 @@
-anndata==0.7.6
+anndata==0.8.0
 click==8.0.1
 coverage==6.3.2
 Cython==0.29.24

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,4 +1,4 @@
-anndata==0.8.0
+anndata==0.7.6
 click==8.0.1
 coverage==6.3.2
 Cython==0.29.24

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -203,7 +203,7 @@ adata_non_raw = anndata.AnnData(
 adata_with_labels = anndata.AnnData(
     X=sparse.csr_matrix(X),
     obs=pd.concat([good_obs, obs_expected], axis=1),
-    var=pd.concat([good_var, var_expected], axis=1),
+    var=var_expected,#pd.concat([good_var, var_expected], axis=1),
     uns=good_uns,
     obsm=good_obsm,
 )

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -203,7 +203,7 @@ adata_non_raw = anndata.AnnData(
 adata_with_labels = anndata.AnnData(
     X=sparse.csr_matrix(X),
     obs=pd.concat([good_obs, obs_expected], axis=1),
-    var=var_expected,#pd.concat([good_var, var_expected], axis=1),
+    var=var_expected,
     uns=good_uns,
     obsm=good_obsm,
 )

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -204,6 +204,32 @@ class TestAddLabelFunctions(unittest.TestCase):
             self.writer._get_mapping_dict_curie(ids, curie_constraints)
 
 
+class TestIgnoreLabelFunctions(unittest.TestCase):
+    
+    def setUp(self):
+        #Set up test data
+        self.test_adata = adata
+        self.test_adata_with_labels = adata_with_labels
+
+    def test_validating_labeled_h5ad_should_fail_if_no_flag_set(self):
+
+        validator = Validator()
+        validator.adata = self.test_adata_with_labels
+        is_valid = validator.validate_adata()
+
+        self.assertFalse(is_valid)
+
+    def test_validating_labeled_h5ad_should_pass_if_flag_set(self):
+
+        validator = Validator(ignore_labels=True)
+        import copy
+        validator.adata = copy.deepcopy(self.test_adata_with_labels)
+        validator.adata.uns["X_normalization"] = 'none'
+        is_valid = validator.validate_adata()
+
+        self.assertTrue(is_valid)
+
+
 class TestSeuratConvertibility(unittest.TestCase):
 
     def validation_helper(self, matrix):

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1,6 +1,7 @@
 import anndata
 import numpy as np
 import unittest
+import copy
 from scipy import sparse
 
 from cellxgene_schema.write_labels import AnnDataLabelAppender
@@ -221,7 +222,6 @@ class TestIgnoreLabelFunctions(unittest.TestCase):
     def test_validating_labeled_h5ad_should_pass_if_flag_set(self):
 
         validator = Validator(ignore_labels=True)
-        import copy
         validator.adata = copy.deepcopy(self.test_adata_with_labels)
         validator.adata.uns["X_normalization"] = 'none'
         is_valid = validator.validate_adata()

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -32,7 +32,6 @@ class TestFieldValidation(unittest.TestCase):
         ]["curie_constraints"]
 
     def test_schema_definition(self):
-
         """
         Tests that the definition of schema is well-defined
         """
@@ -205,9 +204,9 @@ class TestAddLabelFunctions(unittest.TestCase):
 
 
 class TestIgnoreLabelFunctions(unittest.TestCase):
-    
+
     def setUp(self):
-        #Set up test data
+        # Set up test data
         self.test_adata = adata
         self.test_adata_with_labels = adata_with_labels
 


### PR DESCRIPTION
Add an `--ignore-labels` flag. If true, the validator will not check for reserved column names that would be added by the `--add-labels` option.

This is useful if you want to validate a dataset that has already been uploaded to the cellxgene data portal.