### PR TITLE
chore: remove ancestry-related errors if a term is in wrong ontology

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -318,6 +318,10 @@ class Validator:
             term_id, column_name, curie_constraints["ontologies"]
         )
 
+        # If the term id does not belong to an allowed ontology, the subsequent checks are redundant
+        if self.errors:
+            return
+
         # If there are specified ancestors then make sure that this id is a valid child
         if "ancestors" in curie_constraints:
             self._validate_curie_ancestors(

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -226,9 +226,7 @@ class TestObs(unittest.TestCase):
         self.assertEqual(
             self.validator.errors,
             [
-                "ERROR: 'EFO:0009310' in 'assay_ontology_term_id' is a deprecated term id of 'EFO'.",
-                "ERROR: 'EFO:0009310' in 'assay_ontology_term_id' is not a child term id "
-                "of '[['EFO:0002772', 'EFO:0010183']]'.",
+                "ERROR: 'EFO:0009310' in 'assay_ontology_term_id' is a deprecated term id of 'EFO'."
             ],
         )
 
@@ -246,9 +244,7 @@ class TestObs(unittest.TestCase):
             self.validator.errors,
             [
                 "ERROR: 'CL:000001' in 'assay_ontology_term_id' is not a valid "
-                "ontology term id of 'EFO'.",
-                "ERROR: 'CL:000001' in 'assay_ontology_term_id' is not a child "
-                "term id of '[['EFO:0002772', 'EFO:0010183']]'.",
+                "ontology term id of 'EFO'."
             ],
         )
 
@@ -271,9 +267,7 @@ class TestObs(unittest.TestCase):
         self.assertEqual(
             self.validator.errors,
             [
-                "ERROR: 'EFO:0010183 (sci-plex)' in 'assay_ontology_term_id' is not a valid ontology term id of 'EFO'.",
-                "ERROR: 'EFO:0010183 (sci-plex)' in 'assay_ontology_term_id' is not a child term id of "
-                "'[['EFO:0002772', 'EFO:0010183']]'.",
+                "ERROR: 'EFO:0010183 (sci-plex)' in 'assay_ontology_term_id' is not a valid ontology term id of 'EFO'."
             ],
         )
 
@@ -356,11 +350,7 @@ class TestObs(unittest.TestCase):
                 "ERROR: 'EFO:0000001' in 'development_stage_ontology_term_id' is "
                 "not a valid ontology term id of 'UBERON'. When 'organism_ontology_term_id' is not 'NCBITaxon:10090' "
                 "nor 'NCBITaxon:9606', 'development_stage_ontology_term_id' MUST be a child term id of "
-                "'UBERON:0000105' excluding 'UBERON:0000071', or unknown.",
-                "ERROR: 'EFO:0000001' in 'development_stage_ontology_term_id' is not "
-                "a child term id of '[['UBERON:0000105']]'. When 'organism_ontology_term_id' is not 'NCBITaxon:10090' "
-                "nor 'NCBITaxon:9606', 'development_stage_ontology_term_id' MUST be a child term id of "
-                "'UBERON:0000105' excluding 'UBERON:0000071', or unknown.",
+                "'UBERON:0000105' excluding 'UBERON:0000071', or unknown."
             ],
         )
 


### PR DESCRIPTION
Note: this solves issue number 2 from the ticket.