### PR TITLE
feat: reject NaN values in curies

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -472,6 +472,14 @@ class Validator:
                 self._validate_feature_id(feature_id, df_name)
 
         if column_def.get("type") == "curie":
+
+            # Check for NaN values
+            if column.isnull().any():
+                self.errors.append(
+                    f"Column '{column_name}' in dataframe '{df_name}' must not contain NaN values."
+                )
+                return
+
             if "curie_constraints" not in column_def:
                 raise ValueError(
                     f"Corrupt schema definition, no 'curie_constraints' were found for '{column_name}'"

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -611,6 +611,17 @@ class TestObs(unittest.TestCase):
             ],
         )
 
+    def test_nan_values_must_be_rejected(self):
+        """
+        NaN values should not be allowed in dataframes
+        """
+        self.validator.adata.obs["tissue_ontology_term_id"][0] = numpy.nan
+        self.validator.validate_adata()
+        self.assertEqual(
+            self.validator.errors,
+            ["ERROR: Column 'tissue_ontology_term_id' in dataframe 'obs' must not contain NaN values."],
+        )
+
 
 class TestVar(unittest.TestCase):
 


### PR DESCRIPTION
Reject NaN values in curies. Normally, this shouldn't be needed as the curie validation will already catch this. If we do suffix stripping, though, it will break with the errors shown [at the beginning of this ticket](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-curation/211).

I believe this additional enforcement is desirable from a curator's perspective, even if it is more general than what was originally requested.