### PR TITLE
fix: add and validate fields that must be categorical strings

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/3_0_0.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/3_0_0.yaml
@@ -258,6 +258,7 @@ components:
                 type: bool
             donor_id:
                 type: categorical
+                subtype: str
             suspension_type:
                 type: categorical
                 error_message_suffix: "'suspension_type' MUST be one of 'cell', 'nucleus', or 'na'.'"

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -473,10 +473,16 @@ class Validator:
                     f"Column '{column_name}' in dataframe '{df_name}' must be categorical, not {column.dtype.name}."
                 )
             else:
-                if any(len(cat.strip()) == 0 for cat in column.dtype.categories):
-                    self.errors.append(
-                        f"Column '{column_name}' in dataframe '{df_name}' must not contain empty values."
-                    )
+                if column_def.get("subtype") == "str":
+                    if column.dtype.categories.dtype != "object" and column.dtype.categories.dtype != "string":
+                        self.errors.append(
+                            f"Column '{column_name}' in dataframe '{df_name}' must be object or string, not {column.dtype.categories.dtype}."
+                        )
+                    else:
+                        if any(len(cat.strip()) == 0 for cat in column.dtype.categories):
+                            self.errors.append(
+                                f"Column '{column_name}' in dataframe '{df_name}' must not contain empty values."
+                            )
 
                 if column.isnull().any():
                     self.errors.append(


### PR DESCRIPTION
Fix bug where ValueError is thrown and validation terminates early when columns are unexpectedly non-string categoricals 