### PR TITLE
chore: add raw API calls in Python

### DIFF
--- a/notebooks/curation_api/R/create_collection_R.ipynb
+++ b/notebooks/curation_api/R/create_collection_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -42,27 +63,6 @@
    "outputs": [],
    "source": [
     "api_key_file_path <- \"path/to/api-key.txt\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/create_dataset_from_local_file_R.ipynb
+++ b/notebooks/curation_api/R/create_dataset_from_local_file_R.ipynb
@@ -57,6 +57,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c1cf4dae",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80427063",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"aws.s3\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2d8964bc",
    "metadata": {},
    "source": [
@@ -139,27 +160,6 @@
    "outputs": [],
    "source": [
     "collection_id <- \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c1cf4dae",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "80427063",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"aws.s3\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/create_dataset_from_local_file_R.ipynb
+++ b/notebooks/curation_api/R/create_dataset_from_local_file_R.ipynb
@@ -13,21 +13,46 @@
    "id": "1ff1ec6e",
    "metadata": {},
    "source": [
-    "The script in this notebook performs the upload of a local datafile to a given Collection (as identified by its Collection uuid), where the datafile becomes a Dataset accessible via the Data Portal UI.\n",
+    "_\\*\\*The sample code in this notebook limits s3 upload durations to 12 hours. If you think your large file upload may take longer than that, please make use of the `upload_local_datafile` function, whose underlying code supports unlimited upload duration, as seen in the `python/create_dataset_from_local_file.ipynb` notebook.\\*\\*_\n",
+    "\n",
+    "The script in this notebook performs the upload of a local datafile to a given Collection (as identified by its Collection id), where the datafile becomes a Dataset accessible via the Data Portal UI.\n",
     "\n",
     "In order to use this script, you must...\n",
     "- have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)\n",
-    "- know the id of the Collection to which you wish to upload the datafile (from `/collections/<collection_id>` in url path in Data Portal UI)\n",
+    "- know the id of the Collection to which you wish to upload the datafile (taken from `/collections/<collection_id>` in url path in Data Portal UI when viewing the Collection)\n",
     "\n",
-    "**For new Dataset uploads**:\n",
-    "- You must decide upon a string tag (the `curator_tag`) to use to uniquely identify the resultant Dataset within its Collection. This tag must *NOT* be the tag of an existing Dataset within this Collection (read on below), and it must _NOT_ conform to the uuid format.\n",
+    "_For **NEW** Dataset uploads_:\n",
+    "- You must decide upon a string identifier (a \"curator tag\") to use to uniquely identify the resultant Dataset within its Collection. This tag **MUST NOT** be the tag of an existing Dataset within this Collection (otherwise the existing Dataset will be updated; read on below), and it **MUST NOT** conform to the uuid format.\n",
     "\n",
-    "**For replacing/updating existing Datasets**:\n",
-    "- Uploads to a curator tag for which there already exists a Dataset in the given Collection will result in the existing Dataset being replaced by the new Dataset created from the datafile that you are uploading.\n",
-    "- Alternatively, while not necessarily recommended, an existing dataset _may_ be targeted for replacement by using the Dataset's Cellxgene uuid as the tag when writing to S3.\n",
-    "- You can only add/replace Datasets in private Collections or revision Collections.\n",
+    "_For **replacing/updating** existing Datasets_:\n",
+    "- Uploads to a curator tag for which there already exists a Dataset in the given Collection will result in the existing Dataset being replaced by the new Dataset created from the datafile that you \n",
+    "are uploading.\n",
+    "- Alternatively, an existing dataset may be targeted for replacement by using the Dataset's Cellxgene id as the identifier when writing to S3.\n",
     "\n",
-    "For all uploads, the `.h5ad` suffix must be appended to the tag in the S3 write key. See example below."
+    "\n",
+    "You can only add/replace Datasets in _private_ Collections or _private revisions_ of published Collections.\n",
+    "\n",
+    "Curator tags are only unique _within_ a given Collection.\n",
+    "\n",
+    "See examples of _add_ vs _replace_ behavior with different identifiers:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db18a750",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "identifier = \"new_unused_tag\"\n",
+    "# A new Dataset with curator tag 'new_unused_tag' is created from the local datafile and is added to the given Collection\n",
+    "\n",
+    "identifier = \"existing/Dataset_tag\"\n",
+    "# The existing Dataset with curator tag 'existing/Dataset_tag' in the given Collection gets replaced by a new \n",
+    "Dataset created from the local datafile\n",
+    "\n",
+    "identifier = \"abcdef01-2345-6789-abcd-ef01234576789\"\n",
+    "# Existing Dataset with id 'abcdef01-2345-6789-abcd-ef01234576789' gets replaced. If no such Dataset exists in the given Collection with this id, no action is taken.\n",
+    "```"
    ]
   },
   {
@@ -66,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ce19b8b0",
    "metadata": {},
    "outputs": [],
@@ -79,7 +104,7 @@
    "id": "104aea94",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter your chosen `identifier` (see 'identifier' behavior rules in heading above) which will serve as a unique identifier _within this Collection_ for the resultant Dataset. **Must possess the '.h5ad' suffix**.</font>\n",
+    "<font color='#bc00b0'>(Required) Enter your chosen `identifier` (see 'identifier' behavior rules in heading above) which will serve as a unique identifier _within this Collection_ for the resultant Dataset.</font>\n",
     "    \n",
     "When using curator tags, we recommmend using a tagging scheme that 1) makes sense to you, and 2) will help organize and facilitate your \n",
     "automation of future uploads for adding new Datasets and replacing existing Datasets. Remember that curator tags can be used as the identifier when _adding or replacing_ Datasets, whereas Dataset id's (uuid's) can only be used as the identifier when _replacing_ Datasets."
@@ -87,12 +112,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "a4e9b33a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier <- \"arbitrary/tag/chosen-by-you.h5ad\"  # Or \"<dataset_id>.h5ad\""
+    "identifier <- \"arbitrary/tag/chosen-by-you\"  # Or \"<dataset_id>\""
    ]
   },
   {
@@ -203,7 +228,7 @@
    "id": "a79b1f19",
    "metadata": {},
    "source": [
-    "### Retrieve temporary s3 write credentials. These credentials will only work for _this_ Collection."
+    "### Retrieve temporary s3 write credentials"
    ]
   },
   {

--- a/notebooks/curation_api/R/create_dataset_from_upload_link_R.ipynb
+++ b/notebooks/curation_api/R/create_dataset_from_upload_link_R.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier <- \"the_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier <- \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {
@@ -210,7 +210,7 @@
     "url <- str_interp(\"${api_url_base}${upload_path}\")\n",
     "res <- PUT(url=url, body=toJSON(body), add_headers(`Authorization`=bearer_token, `Content-Type`=\"application/json\"))\n",
     "stop_for_status(res)\n",
-    "print(res$status_code)\n"
+    "print(res$status_code)"
    ]
   }
  ],

--- a/notebooks/curation_api/R/create_dataset_from_upload_link_R.ipynb
+++ b/notebooks/curation_api/R/create_dataset_from_upload_link_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -101,27 +122,6 @@
    "outputs": [],
    "source": [
     "identifier <- \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/create_revision_R.ipynb
+++ b/notebooks/curation_api/R/create_revision_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -63,27 +84,6 @@
    "outputs": [],
    "source": [
     "collection_id <- \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/delete_collection_R.ipynb
+++ b/notebooks/curation_api/R/delete_collection_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -63,27 +84,6 @@
    "outputs": [],
    "source": [
     "collection_id <- \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/delete_dataset_R.ipynb
+++ b/notebooks/curation_api/R/delete_dataset_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -83,27 +104,6 @@
    "outputs": [],
    "source": [
     "identifier <- \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/delete_dataset_R.ipynb
+++ b/notebooks/curation_api/R/delete_dataset_R.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier <- \"the_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier <- \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {
@@ -194,7 +194,7 @@
     "url <- str_interp(\"${api_url_base}${dataset_path}\")\n",
     "res <- DELETE(url=url, query=query_params, add_headers(`Authorization`=bearer_token, `Content-Type`=\"application/json\"))\n",
     "stop_for_status(res)\n",
-    "print(res$status_code)\n"
+    "print(res$status_code)"
    ]
   }
  ],

--- a/notebooks/curation_api/R/get_collection_R.ipynb
+++ b/notebooks/curation_api/R/get_collection_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "97459362",
    "metadata": {},
    "source": [
@@ -45,27 +66,6 @@
    "outputs": [],
    "source": [
     "collection_id <- \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/get_collections_R.ipynb
+++ b/notebooks/curation_api/R/get_collections_R.ipynb
@@ -24,6 +24,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "97459362",
    "metadata": {},
    "source": [
@@ -65,27 +86,6 @@
    "source": [
     "query_params = list()\n",
     "# query_params[\"visibility\"] <- \"PRIVATE\"  # default is PUBLIC"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/get_dataset_R.ipynb
+++ b/notebooks/curation_api/R/get_dataset_R.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier <- \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the curator_tag: \"the_tag.h5ad\""
+    "identifier <- \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the curator_tag: \"the_tag\""
    ]
   },
   {
@@ -133,7 +133,7 @@
     "res <- GET(url=url, query=query_params, add_headers(`Content-Type`=\"application/json\"))\n",
     "stop_for_status(res)\n",
     "res_content <- content(res)\n",
-    "print(res_content)\n"
+    "print(res_content)"
    ]
   }
  ],

--- a/notebooks/curation_api/R/get_dataset_R.ipynb
+++ b/notebooks/curation_api/R/get_dataset_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -65,27 +86,6 @@
    "outputs": [],
    "source": [
     "identifier <- \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the curator_tag: \"the_tag\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/get_dataset_assets_R.ipynb
+++ b/notebooks/curation_api/R/get_dataset_assets_R.ipynb
@@ -59,12 +59,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ca707859",
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier <- \"the_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier <- \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {
@@ -134,7 +134,7 @@
     "    url=url, query=query_params, add_headers(`Content-Type`=\"application/json\")\n",
     ")\n",
     "stop_for_status(res)\n",
-    "print(content(res))\n"
+    "print(content(res))"
    ]
   }
  ],

--- a/notebooks/curation_api/R/get_dataset_assets_R.ipynb
+++ b/notebooks/curation_api/R/get_dataset_assets_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -65,27 +86,6 @@
    "outputs": [],
    "source": [
     "identifier <- \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/update_collection_R.ipynb
+++ b/notebooks/curation_api/R/update_collection_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -95,27 +116,6 @@
     "      )\n",
     "  )\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/update_curator_tag_R.ipynb
+++ b/notebooks/curation_api/R/update_curator_tag_R.ipynb
@@ -20,6 +20,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(\"readr\")\n",
+    "library(\"httr\")\n",
+    "library(\"stringr\")\n",
+    "library(\"rjson\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -104,27 +125,6 @@
    "outputs": [],
    "source": [
     "new_tag <- \"a_new_tag\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "library(\"readr\")\n",
-    "library(\"httr\")\n",
-    "library(\"stringr\")\n",
-    "library(\"rjson\")"
    ]
   },
   {

--- a/notebooks/curation_api/R/update_curator_tag_R.ipynb
+++ b/notebooks/curation_api/R/update_curator_tag_R.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier <- \"the_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier <- \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {
@@ -90,7 +90,7 @@
    "id": "aeb7861b",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter your new chosen curator tag. **Must possess the '.h5ad' suffix**.</font>\n",
+    "<font color='#bc00b0'>(Required) Enter your new chosen curator tag. **Cannot be empty**.</font>\n",
     "    \n",
     "When using curator tags, we recommmend using a tagging scheme that 1) makes sense to you, and 2) will help organize and facilitate your \n",
     "automation of future uploads for adding new Datasets and replacing existing Datasets."
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_tag <- \"a_new_tag.h5ad\""
+    "new_tag <- \"a_new_tag\""
    ]
   },
   {
@@ -217,7 +217,7 @@
     "    body=toJSON(body)\n",
     ")\n",
     "stop_for_status(res)\n",
-    "print(res$status_code)\n"
+    "print(res$status_code)"
    ]
   }
  ],

--- a/notebooks/curation_api/python/create_collection.ipynb
+++ b/notebooks/curation_api/python/create_collection.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.collection import create_collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -77,26 +97,6 @@
     "        }\n",
     "    ],\n",
     "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.collection import create_collection"
    ]
   },
   {

--- a/notebooks/curation_api/python/create_dataset_from_local_file.ipynb
+++ b/notebooks/curation_api/python/create_dataset_from_local_file.ipynb
@@ -55,6 +55,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "352deec2",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17d70d36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.dataset import upload_local_datafile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "50c6c402",
    "metadata": {},
    "source": [
@@ -137,26 +157,6 @@
    "outputs": [],
    "source": [
     "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "352deec2",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17d70d36",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.dataset import upload_local_datafile"
    ]
   },
   {

--- a/notebooks/curation_api/python/create_dataset_from_local_file.ipynb
+++ b/notebooks/curation_api/python/create_dataset_from_local_file.ipynb
@@ -20,17 +20,15 @@
     "- know the id of the Collection to which you wish to upload the datafile (taken from `/collections/<collection_id>` in url path in Data Portal UI when viewing the Collection)\n",
     "\n",
     "_For **NEW** Dataset uploads_:\n",
-    "- You must decide upon a string identifier (a \"curator tag\") to use to uniquely identify the resultant Dataset within its Collection. This tag **MUST NOT** be the tag of an existing Dataset within this Collection (otherwise the existing Dataset will be updated; read on below), and it **MUST NOT** conform to the uuid format. The tag suffix **MUST** be `.h5ad`.\n",
+    "- You must decide upon a string identifier (a \"curator tag\") to use to uniquely identify the resultant Dataset within its Collection. This tag **MUST NOT** be the tag of an existing Dataset within this Collection (otherwise the existing Dataset will be updated; read on below), and it **MUST NOT** conform to the uuid format.\n",
     "\n",
     "_For **replacing/updating** existing Datasets_:\n",
     "- Uploads to a curator tag for which there already exists a Dataset in the given Collection will result in the existing Dataset being replaced by the new Dataset created from the datafile that you \n",
     "are uploading.\n",
-    "- Alternatively, an existing dataset may be targeted for replacement by using the Dataset's Cellxgene id as the identifier when writing to S3. In this scenario, the id **MUST** have `.h5ad` appended as a suffix.\n",
+    "- Alternatively, an existing dataset may be targeted for replacement by using the Dataset's Cellxgene id as the identifier when writing to S3.\n",
     "\n",
     "\n",
     "You can only add/replace Datasets in _private_ Collections or _private revisions_ of published Collections.\n",
-    "\n",
-    "For all uploads, the `.h5ad` suffix must be appended to the identifier in the S3 write key.\n",
     "\n",
     "Curator tags are only unique _within_ a given Collection.\n",
     "\n",
@@ -43,13 +41,14 @@
    "metadata": {},
    "source": [
     "```\n",
-    "identifier = \"new_unused_tag.h5ad\"\n",
-    "# A new Dataset with curator tag 'new_unused_tag.h5ad' is created from the local datafile and added to the given Collection\n",
+    "identifier = \"new_unused_tag\"\n",
+    "# A new Dataset with curator tag 'new_unused_tag' is created from the local datafile and is added to the given Collection\n",
     "\n",
-    "identifier = \"existing/Dataset_tag.h5ad\"\n",
-    "# The existing Dataset with curator tag 'existing/Dataset_tag.h5ad' in the given Collection gets replaced by a new Dataset created from the local datafile\n",
+    "identifier = \"existing/Dataset_tag\"\n",
+    "# The existing Dataset with curator tag 'existing/Dataset_tag' in the given Collection gets replaced by a new \n",
+    "Dataset created from the local datafile\n",
     "\n",
-    "identifier = \"abcdef01-2345-6789-abcd-ef01234576789.h5ad\"\n",
+    "identifier = \"abcdef01-2345-6789-abcd-ef01234576789\"\n",
     "# Existing Dataset with id 'abcdef01-2345-6789-abcd-ef01234576789' gets replaced. If no such Dataset exists in the given Collection with this id, no action is taken.\n",
     "```"
    ]
@@ -103,7 +102,7 @@
    "id": "104aea94",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter your chosen `identifier` (see 'identifier' behavior rules in heading above) which will serve as a unique identifier _within this Collection_ for the resultant Dataset. **Must possess the '.h5ad' suffix**.</font>\n",
+    "<font color='#bc00b0'>(Required) Enter your chosen `identifier` (see 'identifier' behavior rules in heading above) which will serve as a unique identifier _within this Collection_ for the resultant Dataset.</font>\n",
     "    \n",
     "When using curator tags, we recommmend using a tagging scheme that 1) makes sense to you, and 2) will help organize and facilitate your \n",
     "automation of future uploads for adding new Datasets and replacing existing Datasets. Remember that curator tags can be used as the identifier when _adding or replacing_ Datasets, whereas Dataset id's (uuid's) can only be used as the identifier when _replacing_ Datasets."
@@ -116,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"arbitrary/tag/chosen-by-you.h5ad\"  # Or \"<dataset_id>.h5ad\""
+    "identifier = \"arbitrary/tag/chosen-by-you\"  # Or \"<dataset_id>\""
    ]
   },
   {

--- a/notebooks/curation_api/python/create_dataset_from_upload_link.ipynb
+++ b/notebooks/curation_api/python/create_dataset_from_upload_link.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.dataset import upload_datafile_from_link"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -101,26 +121,6 @@
    "outputs": [],
    "source": [
     "identifier = \"a_curator_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.dataset import upload_datafile_from_link"
    ]
   },
   {

--- a/notebooks/curation_api/python/create_dataset_from_upload_link.ipynb
+++ b/notebooks/curation_api/python/create_dataset_from_upload_link.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"a_curator_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier = \"a_curator_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {

--- a/notebooks/curation_api/python/create_revision.ipynb
+++ b/notebooks/curation_api/python/create_revision.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.collection import create_revision"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -63,26 +83,6 @@
    "outputs": [],
    "source": [
     "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.collection import create_revision"
    ]
   },
   {

--- a/notebooks/curation_api/python/delete_collection.ipynb
+++ b/notebooks/curation_api/python/delete_collection.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.collection import delete_collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -63,26 +83,6 @@
    "outputs": [],
    "source": [
     "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.collection import delete_collection"
    ]
   },
   {

--- a/notebooks/curation_api/python/delete_dataset.ipynb
+++ b/notebooks/curation_api/python/delete_dataset.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.dataset import delete_dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -83,26 +103,6 @@
    "outputs": [],
    "source": [
     "identifier = \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the tag: \"the_curator_tag\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.dataset import delete_dataset"
    ]
   },
   {

--- a/notebooks/curation_api/python/delete_dataset.ipynb
+++ b/notebooks/curation_api/python/delete_dataset.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the tag: \"the_curator_tag.h5ad\""
+    "identifier = \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the tag: \"the_curator_tag\""
    ]
   },
   {

--- a/notebooks/curation_api/python/example_workflow.ipynb
+++ b/notebooks/curation_api/python/example_workflow.ipynb
@@ -117,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"topdir/subdir/file.h5ad\"  # Or \"<dataset_id>.h5ad\""
+    "identifier = \"topdir/subdir/file\"  # Or \"<dataset_id>\""
    ]
   },
   {
@@ -154,7 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "second_identifier = \"other_tag.h5ad\"\n",
+    "second_identifier = \"other_tag\"\n",
     "upload_local_datafile(datafile_path, new_collection_id, second_identifier)"
    ]
   },
@@ -259,7 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "third_identifier = \"third.h5ad\"\n",
+    "third_identifier = \"third\"\n",
     "upload_local_datafile(datafile_path, revision_id, third_identifier)"
    ]
   },

--- a/notebooks/curation_api/python/get_collection.ipynb
+++ b/notebooks/curation_api/python/get_collection.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config  # still required for setting api url env vars\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.collection import get_collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -45,26 +65,6 @@
    "outputs": [],
    "source": [
     "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config  # still required for setting api url env vars\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.collection import get_collection"
    ]
   },
   {

--- a/notebooks/curation_api/python/get_collections.ipynb
+++ b/notebooks/curation_api/python/get_collections.ipynb
@@ -24,6 +24,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.collection import get_collections"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -46,26 +66,6 @@
    "outputs": [],
    "source": [
     "api_key_file_path = \"path/to/api-key-file\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.collection import get_collections"
    ]
   },
   {

--- a/notebooks/curation_api/python/get_dataset.ipynb
+++ b/notebooks/curation_api/python/get_dataset.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config  # still required for setting api url env vars\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.dataset import get_dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -65,26 +85,6 @@
    "outputs": [],
    "source": [
     "identifier = \"the_tag\" # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config  # still required for setting api url env vars\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.dataset import get_dataset"
    ]
   },
   {

--- a/notebooks/curation_api/python/get_dataset.ipynb
+++ b/notebooks/curation_api/python/get_dataset.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"the_tag.h5ad\" # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier = \"the_tag\" # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {

--- a/notebooks/curation_api/python/get_dataset_assets.ipynb
+++ b/notebooks/curation_api/python/get_dataset_assets.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config  # still required for setting api url env vars\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.dataset import get_assets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -65,26 +85,6 @@
    "outputs": [],
    "source": [
     "identifier = \"dataset/tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config  # still required for setting api url env vars\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.dataset import get_assets"
    ]
   },
   {

--- a/notebooks/curation_api/python/get_dataset_assets.ipynb
+++ b/notebooks/curation_api/python/get_dataset_assets.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"dataset/tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier = \"dataset/tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {

--- a/notebooks/curation_api/python/update_collection.ipynb
+++ b/notebooks/curation_api/python/update_collection.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.collection import update_collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -98,26 +118,6 @@
     "        }\n",
     "    ],\n",
     "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.collection import update_collection"
    ]
   },
   {

--- a/notebooks/curation_api/python/update_curator_tag.ipynb
+++ b/notebooks/curation_api/python/update_curator_tag.ipynb
@@ -20,6 +20,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0009d2d0",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadd3c12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.config import set_api_access_config\n",
+    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
+    "from src.dataset import update_curator_tag"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -104,26 +124,6 @@
    "outputs": [],
    "source": [
     "new_tag = \"new_tag\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0009d2d0",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aadd3c12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.utils.config import set_api_access_config\n",
-    "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.dataset import update_curator_tag"
    ]
   },
   {

--- a/notebooks/curation_api/python/update_curator_tag.ipynb
+++ b/notebooks/curation_api/python/update_curator_tag.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the current tag: \"current_curator_tag.h5ad\""
+    "identifier = \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the current tag: \"current_curator_tag\""
    ]
   },
   {
@@ -90,7 +90,7 @@
    "id": "5a5115e6",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter your new chosen curator tag. **Must possess the '.h5ad' suffix**.</font>\n",
+    "<font color='#bc00b0'>(Required) Enter your new chosen curator tag. **Cannot be empty**.</font>\n",
     "    \n",
     "When using curator tags, we recommmend using a tagging scheme that 1) makes sense to you, and 2) will help organize and facilitate your \n",
     "automation of future uploads for adding new Datasets and replacing existing Datasets."
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_tag = \"new_tag.h5ad\""
+    "new_tag = \"new_tag\""
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/create_collection.ipynb
+++ b/notebooks/curation_api/python_raw/create_collection.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Create a new private Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook creates a new private Collection.\n",
+    "\n",
+    "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "928aa50e",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9a0189",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4b6087b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key.txt\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e9be6c4",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ab5032b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e51b9169",
+   "metadata": {},
+   "source": [
+    "##### (optional, debug) verify status code of response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28978522",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(res.status_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce95a93a",
+   "metadata": {},
+   "source": [
+    "### Collection metadata (required)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c711049d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_form_metadata = {\n",
+    "    \"name\": \"Name\",  # required\n",
+    "    \"description\": \"A sample description\",  # required\n",
+    "    \"contact_name\": \"First Last\",  # required\n",
+    "    \"contact_email\": \"firstlast@email.com\",  # required\n",
+    "    \"links\": [\n",
+    "        {\n",
+    "            \"link_name\": \"sample protocol link\",\n",
+    "            \"link_url\": \"https://www.sample.link\",\n",
+    "            \"link_type\": \"PROTOCOL\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"link_name\": \"sample lab website\",\n",
+    "            \"link_url\": \"https://www.lab.website\",\n",
+    "            \"link_type\": \"LAB_WEBSITE\",\n",
+    "        }\n",
+    "    ],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and create new private Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collections_path = \"/curation/v1/collections\"\n",
+    "url = f\"{api_url_base}{collections_path}\"\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "res = requests.post(url=url, json=collection_form_metadata, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "res_content = res.json()\n",
+    "collection_id = res_content[\"collection_id\"]\n",
+    "print(\"New private Collection id:\")\n",
+    "print(collection_id)\n",
+    "print(\"New private Collection url:\")\n",
+    "print(f\"{site_url}/collections/{collection_id}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/create_collection.ipynb
+++ b/notebooks/curation_api/python_raw/create_collection.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -42,24 +60,6 @@
    "outputs": [],
    "source": [
     "api_key_file_path = \"path/to/api-key.txt\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/create_dataset_from_local_file.ipynb
+++ b/notebooks/curation_api/python_raw/create_dataset_from_local_file.ipynb
@@ -13,21 +13,46 @@
    "id": "1ff1ec6e",
    "metadata": {},
    "source": [
-    "The script in this notebook performs the upload of a local datafile to a given Collection (as identified by its Collection uuid), where the datafile becomes a Dataset accessible via the Data Portal UI.\n",
+    "_\\*\\*The sample code in this notebook limits s3 upload durations to 12 hours. If you think your large file upload may take longer than that, please make use of the `upload_local_datafile` function, whose underlying code supports unlimited upload duration, as seen in the `python/create_dataset_from_local_file.ipynb` notebook.\\*\\*_\n",
+    "\n",
+    "The script in this notebook performs the upload of a local datafile to a given Collection (as identified by its Collection id), where the datafile becomes a Dataset accessible via the Data Portal UI.\n",
     "\n",
     "In order to use this script, you must...\n",
     "- have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)\n",
-    "- know the id of the Collection to which you wish to upload the datafile (from `/collections/<collection_id>` in url path in Data Portal UI)\n",
+    "- know the id of the Collection to which you wish to upload the datafile (taken from `/collections/<collection_id>` in url path in Data Portal UI when viewing the Collection)\n",
     "\n",
-    "**For new Dataset uploads**:\n",
-    "- You must decide upon a string tag (the `curator_tag`) to use to uniquely identify the resultant Dataset within its Collection. This tag must *NOT* be the tag of an existing Dataset within this Collection (read on below), and it must _NOT_ conform to the uuid format.\n",
+    "_For **NEW** Dataset uploads_:\n",
+    "- You must decide upon a string identifier (a \"curator tag\") to use to uniquely identify the resultant Dataset within its Collection. This tag **MUST NOT** be the tag of an existing Dataset within this Collection (otherwise the existing Dataset will be updated; read on below), and it **MUST NOT** conform to the uuid format.\n",
     "\n",
-    "**For replacing/updating existing Datasets**:\n",
-    "- Uploads to a curator tag for which there already exists a Dataset in the given Collection will result in the existing Dataset being replaced by the new Dataset created from the datafile that you are uploading.\n",
-    "- Alternatively, while not necessarily recommended, an existing dataset _may_ be targeted for replacement by using the Dataset's Cellxgene uuid as the tag when writing to S3.\n",
-    "- You can only add/replace Datasets in private Collections or revision Collections.\n",
+    "_For **replacing/updating** existing Datasets_:\n",
+    "- Uploads to a curator tag for which there already exists a Dataset in the given Collection will result in the existing Dataset being replaced by the new Dataset created from the datafile that you \n",
+    "are uploading.\n",
+    "- Alternatively, an existing dataset may be targeted for replacement by using the Dataset's Cellxgene id as the identifier when writing to S3.\n",
     "\n",
-    "For all uploads, the `.h5ad` suffix must be appended to the tag in the S3 write key. See example below."
+    "\n",
+    "You can only add/replace Datasets in _private_ Collections or _private revisions_ of published Collections.\n",
+    "\n",
+    "Curator tags are only unique _within_ a given Collection.\n",
+    "\n",
+    "See examples of _add_ vs _replace_ behavior with different identifiers:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79c430d7",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "identifier = \"new_unused_tag\"\n",
+    "# A new Dataset with curator tag 'new_unused_tag' is created from the local datafile and is added to the given Collection\n",
+    "\n",
+    "identifier = \"existing/Dataset_tag\"\n",
+    "# The existing Dataset with curator tag 'existing/Dataset_tag' in the given Collection gets replaced by a new \n",
+    "Dataset created from the local datafile\n",
+    "\n",
+    "identifier = \"abcdef01-2345-6789-abcd-ef01234576789\"\n",
+    "# Existing Dataset with id 'abcdef01-2345-6789-abcd-ef01234576789' gets replaced. If no such Dataset exists in the given Collection with this id, no action is taken.\n",
+    "```"
    ]
   },
   {
@@ -79,7 +104,7 @@
    "id": "104aea94",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter your chosen `identifier` (see 'identifier' behavior rules in heading above) which will serve as a unique identifier _within this Collection_ for the resultant Dataset. **Must possess the '.h5ad' suffix**.</font>\n",
+    "<font color='#bc00b0'>(Required) Enter your chosen `identifier` (see 'identifier' behavior rules in heading above) which will serve as a unique identifier _within this Collection_ for the resultant Dataset.</font>\n",
     "    \n",
     "When using curator tags, we recommmend using a tagging scheme that 1) makes sense to you, and 2) will help organize and facilitate your \n",
     "automation of future uploads for adding new Datasets and replacing existing Datasets. Remember that curator tags can be used as the identifier when _adding or replacing_ Datasets, whereas Dataset id's (uuid's) can only be used as the identifier when _replacing_ Datasets."
@@ -202,7 +227,7 @@
    "id": "a79b1f19",
    "metadata": {},
    "source": [
-    "### Retrieve temporary s3 write credentials. These credentials will only work for _this_ Collection."
+    "### Retrieve temporary s3 write credentials"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/create_dataset_from_local_file.ipynb
+++ b/notebooks/curation_api/python_raw/create_dataset_from_local_file.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b68160f6",
+   "metadata": {},
+   "source": [
+    "# Upload a local datafile to add or replace a Dataset in a Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ff1ec6e",
+   "metadata": {},
+   "source": [
+    "The script in this notebook performs the upload of a local datafile to a given Collection (as identified by its Collection uuid), where the datafile becomes a Dataset accessible via the Data Portal UI.\n",
+    "\n",
+    "In order to use this script, you must...\n",
+    "- have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)\n",
+    "- know the id of the Collection to which you wish to upload the datafile (from `/collections/<collection_id>` in url path in Data Portal UI)\n",
+    "\n",
+    "**For new Dataset uploads**:\n",
+    "- You must decide upon a string tag (the `curator_tag`) to use to uniquely identify the resultant Dataset within its Collection. This tag must *NOT* be the tag of an existing Dataset within this Collection (read on below), and it must _NOT_ conform to the uuid format.\n",
+    "\n",
+    "**For replacing/updating existing Datasets**:\n",
+    "- Uploads to a curator tag for which there already exists a Dataset in the given Collection will result in the existing Dataset being replaced by the new Dataset created from the datafile that you are uploading.\n",
+    "- Alternatively, while not necessarily recommended, an existing dataset _may_ be targeted for replacement by using the Dataset's Cellxgene uuid as the tag when writing to S3.\n",
+    "- You can only add/replace Datasets in private Collections or revision Collections.\n",
+    "\n",
+    "For all uploads, the `.h5ad` suffix must be appended to the tag in the S3 write key. See example below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d8964bc",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f73c969a",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07a2424b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key.txt\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e84d52e",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the absolute path to the h5ad datafile to upload</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce19b8b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"/absolute/path/to-datafile.h5ad\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "104aea94",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter your chosen `identifier` (see 'identifier' behavior rules in heading above) which will serve as a unique identifier _within this Collection_ for the resultant Dataset. **Must possess the '.h5ad' suffix**.</font>\n",
+    "    \n",
+    "When using curator tags, we recommmend using a tagging scheme that 1) makes sense to you, and 2) will help organize and facilitate your \n",
+    "automation of future uploads for adding new Datasets and replacing existing Datasets. Remember that curator tags can be used as the identifier when _adding or replacing_ Datasets, whereas Dataset id's (uuid's) can only be used as the identifier when _replacing_ Datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4e9b33a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identifier = \"arbitrary/tag/chosen-by-you\"  # Or use the dataset id \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "463870f1",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection to which you wish to add this datafile as a Dataset</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`_. You can only add/replace Datasets in private Collections or private revisions of published Collections. In order to edit a published Collection, you must first create a revision of that Collection._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86483731",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1cf4dae",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80427063",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11de2fe6",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "decaeebc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1708156b",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93b0481d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea089d0e",
+   "metadata": {},
+   "source": [
+    "##### (optional, debug) verify status code of response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b01dc941",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(res.status_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a79b1f19",
+   "metadata": {},
+   "source": [
+    "### Retrieve temporary s3 write credentials. These credentials will only work for _this_ Collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4345fa14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_credentials_path = f\"/curation/v1/collections/{collection_id}/datasets/s3-upload-credentials\"\n",
+    "url = f\"{api_url_base}{s3_credentials_path}\"\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "res = requests.get(url, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "res_content = res.json()\n",
+    "print(res_content)\n",
+    "access_key_id = res_content[\"Credentials\"][\"AccessKeyId\"]\n",
+    "secret_access_key = res_content[\"Credentials\"][\"SecretAccessKey\"]\n",
+    "session_token = res_content[\"Credentials\"][\"SessionToken\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c14030d8",
+   "metadata": {},
+   "source": [
+    "### Extract formatted upload path from credentials endpoint response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d942695a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = res_content[\"Bucket\"]\n",
+    "key_prefix = res_content[\"UploadKeyPrefix\"]\n",
+    "upload_key = key_prefix + identifier\n",
+    "print(f\"Full S3 write path is s3://{bucket}/{upload_key}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f648e0b2",
+   "metadata": {},
+   "source": [
+    "### Upload file using temporary AWS S3 credentials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15514bce",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "session = boto3.Session(\n",
+    "    aws_session_token=session_token,\n",
+    "    aws_access_key_id=access_key_id,\n",
+    "    aws_secret_access_key=secret_access_key,\n",
+    ")\n",
+    "session.client(\"s3\").upload_file(\n",
+    "    Filename=filename,\n",
+    "    Bucket=bucket,\n",
+    "    Key=upload_key,\n",
+    ")\n",
+    "print(f\"Uploaded file {filename} to identifier {identifier} in Collection {collection_id}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/create_dataset_from_local_file.ipynb
+++ b/notebooks/curation_api/python_raw/create_dataset_from_local_file.ipynb
@@ -57,6 +57,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c1cf4dae",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80427063",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2d8964bc",
    "metadata": {},
    "source": [
@@ -139,25 +158,6 @@
    "outputs": [],
    "source": [
     "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c1cf4dae",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "80427063",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import boto3\n",
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/create_dataset_from_upload_link.ipynb
+++ b/notebooks/curation_api/python_raw/create_dataset_from_upload_link.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Create a Dataset with an upload link"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook creates a Dataset using a user-provided upload link to a datafile. Datasets can only be added or replaced in private Collections (including private revisions of published Collections).\n",
+    "\n",
+    "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "968f003d",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0268c0a4",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "530a8e3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key-file\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "904d1fc8",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the link to the h5ad datafile to upload</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb595ec3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datafile_link = \"https://some.download.link\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "905d23e3",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the (private) Collection that you want the resulting Dataset to belong to</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc99f9db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d7371ef",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the identifier of the Dataset</font>\n",
+    "\n",
+    "_The Dataset id and curator tag can both be found by using the `/collections/{collection_id}` endpoint and filtering for the Dataset of interest._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca707859",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identifier = \"the_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d612915",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9a2abf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da252c1a",
+   "metadata": {},
+   "source": [
+    "##### (optional, debug) verify status code of response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c64e405",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(res.status_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and upload a new dataset from a file link."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "upload_path = f\"/curation/v1/collections/{collection_id}/datasets/upload-link\"\n",
+    "body = {\"link\": datafile_link, \"curator_tag\": identifier}  # use `dataset_id` or `curator_tag`\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "url = f\"{api_url_base}{upload_path}\"\n",
+    "res = requests.put(url=url, json=body, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "print(res.status_code)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/create_dataset_from_upload_link.ipynb
+++ b/notebooks/curation_api/python_raw/create_dataset_from_upload_link.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -101,24 +119,6 @@
    "outputs": [],
    "source": [
     "identifier = \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/create_dataset_from_upload_link.ipynb
+++ b/notebooks/curation_api/python_raw/create_dataset_from_upload_link.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"the_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier = \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/create_revision.ipynb
+++ b/notebooks/curation_api/python_raw/create_revision.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -63,24 +81,6 @@
    "outputs": [],
    "source": [
     "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/create_revision.ipynb
+++ b/notebooks/curation_api/python_raw/create_revision.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Create a revision of a published Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook creates a private revision of a published Collection.\n",
+    "\n",
+    "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "928aa50e",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9a0189",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4b6087b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key.txt\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e9f83cb",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection for which you want to start a revision</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a15e03a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e9be6c4",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ab5032b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e51b9169",
+   "metadata": {},
+   "source": [
+    "##### (optional, debug) verify status code of response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28978522",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(res.status_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and create a revision of a public Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "revision_path = f\"/curation/v1/collections/{collection_id}/revision\"\n",
+    "url = f\"{api_url_base}{revision_path}\"\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "res = requests.post(url=url, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "res_content = res.json()\n",
+    "revision_id = res_content[\"revision_id\"]\n",
+    "print(\"Revision id:\")\n",
+    "print(revision_id)\n",
+    "print(\"Revision url:\")\n",
+    "print(f\"{site_url}/collections/{revision_id}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/delete_collection.ipynb
+++ b/notebooks/curation_api/python_raw/delete_collection.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -63,24 +81,6 @@
    "outputs": [],
    "source": [
     "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/delete_collection.ipynb
+++ b/notebooks/curation_api/python_raw/delete_collection.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Delete a private Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook deletes a private Collection (unpublished or revision). Published Collections can only be deleted via the UI; they cannot be deleted via the Curator API.\n",
+    "\n",
+    "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "928aa50e",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9a0189",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4b6087b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key.txt\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b71bce95",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the (private) Collection you want to delete</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a936c79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e9be6c4",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ab5032b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e51b9169",
+   "metadata": {},
+   "source": [
+    "##### (optional, debug) verify status code of response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28978522",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(res.status_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and delete a private Collection or revision"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "collections_path = f\"/curation/v1/collections/{collection_id}\"\n",
+    "url = f\"{api_url_base}{collections_path}\"\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "res = requests.delete(url=url, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "print(\"Deleted the Collection at url:\")\n",
+    "print(f\"{site_url}/collections/{collection_id}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/delete_dataset.ipynb
+++ b/notebooks/curation_api/python_raw/delete_dataset.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -83,24 +101,6 @@
    "outputs": [],
    "source": [
     "identifier = \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/delete_dataset.ipynb
+++ b/notebooks/curation_api/python_raw/delete_dataset.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Delete a Dataset from a private Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook deletes a Dataset from a private Collection. Datasets in published Collections can only be deleted (tombstoned) via the UI; they cannot be deleted via the Curator API.\n",
+    "\n",
+    "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "968f003d",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0268c0a4",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "530a8e3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key-file\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "905d23e3",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the (private) Collection that contains the Dataset that you want to delete</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc99f9db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d7371ef",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the identifier of the Dataset</font>\n",
+    "\n",
+    "_The Dataset id and curator tag can both be found by using the `/collections/{collection_id}` endpoint and filtering for the Dataset of interest._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca707859",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identifier = \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d612915",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9a2abf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da252c1a",
+   "metadata": {},
+   "source": [
+    "##### (optional, debug) verify status code of response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c64e405",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(res.status_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and delete a Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dataset_path = f\"/curation/v1/collections/{collection_id}/datasets\"\n",
+    "# use `dataset_id` or `curator_tag`\n",
+    "query_params = {\"curator_tag\": identifier}\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "url = f\"{api_url_base}{dataset_path}\"\n",
+    "res = requests.delete(url=url, params=query_params, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "print(res.status_code)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/get_collection.ipynb
+++ b/notebooks/curation_api/python_raw/get_collection.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "97459362",
    "metadata": {},
    "source": [
@@ -45,24 +63,6 @@
    "outputs": [],
    "source": [
     "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/get_collection.ipynb
+++ b/notebooks/curation_api/python_raw/get_collection.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Fetch a Collection with full Dataset metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook fetches full Collection metadata for a given Collection.\n",
+    "\n",
+    "Fetching an individual Collection requires only the Collection id, and not an API key/access token."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97459362",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb7eb2ae",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection you want to fetch</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "028f2db9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and fetch a Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "collection_path = f\"/curation/v1/collections/{collection_id}\"\n",
+    "collection_url = f\"{api_url_base}{collection_path}\"\n",
+    "res = requests.get(url=collection_url)\n",
+    "res.raise_for_status()\n",
+    "res_content = res.json()\n",
+    "print(res_content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/get_collections.ipynb
+++ b/notebooks/curation_api/python_raw/get_collections.ipynb
@@ -24,6 +24,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "97459362",
    "metadata": {},
    "source": [
@@ -66,24 +84,6 @@
     "query_params = {}\n",
     "# query_params[\"visibility\"] = \"PRIVATE\"  # default is PUBLIC\n",
     "# query_params[\"curator\"] = \"Curator Name\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/get_collections.ipynb
+++ b/notebooks/curation_api/python_raw/get_collections.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Fetch Collections index with Dataset previews"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook fetches... \n",
+    "- all public Collections (with query param `visibility=PUBLIC` or not set).\n",
+    "\n",
+    "or\n",
+    "- all accessible private Collections (with query param `visibility=PRIVATE`; access token required).\n",
+    "\n",
+    "In order to fetch private Collections with this script, you must have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in). You may fetch public Collections without an API key / access token."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97459362",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb7eb2ae",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required for fetching private Collections) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "028f2db9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key-file\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d71a3073",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Optional) Specify visibility and/or curator name</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9de682f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_params = {}\n",
+    "# query_params[\"visibility\"] = \"PRIVATE\"  # default is PUBLIC\n",
+    "# query_params[\"curator\"] = \"Curator Name\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f03503e",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d19ca5ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and fetch Collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "collections_path = \"/curation/v1/collections\"\n",
+    "url = f\"{api_url_base}{collections_path}\"\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "res = requests.get(url=url, params=query_params, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "res_content = res.json()\n",
+    "print(res_content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/get_dataset.ipynb
+++ b/notebooks/curation_api/python_raw/get_dataset.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Fetch full metadata for a Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook retrieves full metadata for a given Dataset, equivalent to a single entry in the `datasets` array that is returned on the Collection object from `GET /v1/collections/{collection_id}` (the `get_collection_R.ipynb` notebook example).\n",
+    "\n",
+    "Fetching a Dataset requires only the Collection id (and, for specification purposes, the Dataset identifier), and not an API key/access token."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "968f003d",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0268c0a4",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection that contains the Dataset for which you want to fetch full metadata</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "530a8e3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d7371ef",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the identifier of the Dataset</font>\n",
+    "\n",
+    "_The Dataset id and curator tag can both be found by using the `/collections/{collection_id}` endpoint and filtering for the Dataset of interest._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca707859",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identifier = \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the curator_tag: \"the_tag\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and fetch a Datasets metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dataset_path = f\"/curation/v1/collections/{collection_id}/datasets\"\n",
+    "query_params = {\"dataset_id\": identifier}  # or use {\"curator_tag\": <the_tag>}\n",
+    "url = f\"{api_url_base}{dataset_path}\"\n",
+    "res = requests.get(url=url, params=query_params)\n",
+    "res.raise_for_status()\n",
+    "res_content = res.json()\n",
+    "print(res_content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/get_dataset.ipynb
+++ b/notebooks/curation_api/python_raw/get_dataset.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -65,24 +83,6 @@
    "outputs": [],
    "source": [
     "identifier = \"01234567-89ab-cdef-0123-456789abcdef\"  # Or use the curator_tag: \"the_tag\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/get_dataset_assets.ipynb
+++ b/notebooks/curation_api/python_raw/get_dataset_assets.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -65,24 +83,6 @@
    "outputs": [],
    "source": [
     "identifier = \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/get_dataset_assets.ipynb
+++ b/notebooks/curation_api/python_raw/get_dataset_assets.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Fetch download links for a Dataset's available assets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook retrieves download links for a Dataset's assets.\n",
+    "\n",
+    "Fetching a Dataset assets requires only the Collection id (and, for specification purposes, the Dataset identifier), and not an API key/access token."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "968f003d",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0268c0a4",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection that contains the Dataset for which you want to fetch download links</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc99f9db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d7371ef",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the identifier (curator tag or Dataset id) of the Dataset whose curator tag you want to update</font>\n",
+    "\n",
+    "_The `dataset_id` and `curator_tag` can both be found using the_ `/collections/{collection_id}` _endpoint and filtering for these attributes on the Dataset of interest._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca707859",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identifier = \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and fetch a Dataset's assets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "assets_path = f\"/curation/v1/collections/{collection_id}/datasets/assets\"\n",
+    "query_params = {\"curator_tag\": identifier}  # Or use {\"dataset_id\": <id>}\n",
+    "url = f\"{api_url_base}{assets_path}\"\n",
+    "res = requests.get(url=url, params=query_params)\n",
+    "res.raise_for_status()\n",
+    "res_content = res.json()\n",
+    "print(res_content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/update_collection.ipynb
+++ b/notebooks/curation_api/python_raw/update_collection.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Update a Collection's metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook updates the metadata for a private Collection (revision or unpublished).\n",
+    "\n",
+    "In order to edit Collections with this script, you must have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "928aa50e",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9a0189",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ea46d33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key.txt\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18879e44",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection that you want to edit</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "477276b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c329a95d",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the updated Collection form metadata for your existing Collection. **Do not include attributes that you do not wish to change**. If a non-empty list of links is passed in, the existing links on the Collection will all be removed and replaced with the list of links that you provide here. If a DOI link is included but the DOI cannot be found on Crossref or is invalid, the entire request will be rejected.</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14578831",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_form_metadata = {\n",
+    "    \"name\": \"A new, updated name\",\n",
+    "    \"links\": [\n",
+    "        {\n",
+    "            \"link_name\": \"sample protocol link\",\n",
+    "            \"link_url\": \"https://www.sample.link\",\n",
+    "            \"link_type\": \"PROTOCOL\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"link_name\": \"sample lab website\",\n",
+    "            \"link_url\": \"https://www.lab.website\",\n",
+    "            \"link_type\": \"LAB_WEBSITE\",\n",
+    "        }\n",
+    "    ],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e9be6c4",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ab5032b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e51b9169",
+   "metadata": {},
+   "source": [
+    "##### (optional, debug) verify status code of response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28978522",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(res.status_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and update a Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "collection_path = f\"/curation/v1/collections/{collection_id}\"\n",
+    "url = f\"{api_url_base}{collection_path}\"\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "res = requests.patch(url=url, json=collection_form_metadata, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "res_content = res.json()\n",
+    "print(\"Updated the Collection at url:\")\n",
+    "print(f\"{site_url}/collections/{collection_id}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/update_collection.ipynb
+++ b/notebooks/curation_api/python_raw/update_collection.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "928aa50e",
    "metadata": {},
    "source": [
@@ -95,24 +113,6 @@
     "        }\n",
     "    ],\n",
     "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/update_curator_tag.ipynb
+++ b/notebooks/curation_api/python_raw/update_curator_tag.ipynb
@@ -20,6 +20,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "968f003d",
    "metadata": {},
    "source": [
@@ -104,24 +122,6 @@
    "outputs": [],
    "source": [
     "new_tag = \"a_new_tag\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edfb1272",
-   "metadata": {},
-   "source": [
-    "### Import dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1cff472c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests"
    ]
   },
   {

--- a/notebooks/curation_api/python_raw/update_curator_tag.ipynb
+++ b/notebooks/curation_api/python_raw/update_curator_tag.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5490d93",
+   "metadata": {},
+   "source": [
+    "# Update the curator tag for a Dataset in a private Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74560383",
+   "metadata": {},
+   "source": [
+    "The script in this notebook updates the curator tag for a Dataset in a private Collection.\n",
+    "\n",
+    "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the Data Portal UI after logging in)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "968f003d",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0268c0a4",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "530a8e3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key-file\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "905d23e3",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection that contains the relevant Dataset</font>\n",
+    "\n",
+    "_The Collection id can be found by looking at the url path in the address bar \n",
+    "when viewing your Collection in the UI of the Data Portal website:_ `collections/{collection_id}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc99f9db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_id = \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d7371ef",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter the identifier (curator tag or Dataset id) of the Dataset whose curator tag you want to update</font>\n",
+    "\n",
+    "_The `dataset_id` and `curator_tag` can both be found using the_ `/collections/{collection_id}` _endpoint and filtering for these attributes on the Dataset of interest._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca707859",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identifier = \"the_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aeb7861b",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Enter your new chosen curator tag. **Must possess the '.h5ad' suffix**.</font>\n",
+    "    \n",
+    "When using curator tags, we recommmend using a tagging scheme that 1) makes sense to you, and 2) will help organize and facilitate your \n",
+    "automation of future uploads for adding new Datasets and replacing existing Datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60da54d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_tag = \"a_new_tag.h5ad\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edfb1272",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cff472c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285a1ca4",
+   "metadata": {},
+   "source": [
+    "### Specify domain (and API url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea213f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain_name = \"cellxgene.cziscience.com\"\n",
+    "site_url = f\"https://{domain_name}\"\n",
+    "api_url_base = f\"https://api.{domain_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d612915",
+   "metadata": {},
+   "source": [
+    "### Use API key to obtain a temporary access token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9a2abf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(api_key_file_path) as f:\n",
+    "    api_key = f.read()\n",
+    "access_token_path = \"/curation/v1/auth/token\"\n",
+    "access_token_url = f\"{api_url_base}{access_token_path}\"\n",
+    "res = requests.post(access_token_url, headers={\"x-api-key\": api_key})\n",
+    "res.raise_for_status()\n",
+    "access_token = res.json().get(\"access_token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da252c1a",
+   "metadata": {},
+   "source": [
+    "##### (optional, debug) verify status code of response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c64e405",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(res.status_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6085d322",
+   "metadata": {},
+   "source": [
+    "### Formulate request and update a Dataset's curator_tag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3dd36b",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dataset_path = f\"/curation/v1/collections/{collection_id}/datasets\"\n",
+    "query_params = {\"curator_tag\": identifier}  # Or use {\"dataset_id\": <id>}\n",
+    "body = {\"curator_tag\": new_tag}\n",
+    "bearer_token = f\"Bearer {access_token}\"\n",
+    "url = f\"{api_url_base}{dataset_path}\"\n",
+    "res = requests.patch(url=url, params=query_params, json=body, headers={\"Authorization\": bearer_token})\n",
+    "res.raise_for_status()\n",
+    "print(res.status_code)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/curation_api/python_raw/update_curator_tag.ipynb
+++ b/notebooks/curation_api/python_raw/update_curator_tag.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "identifier = \"the_tag.h5ad\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
+    "identifier = \"the_tag\"  # Or use the id: \"01234567-89ab-cdef-0123-456789abcdef\""
    ]
   },
   {
@@ -90,7 +90,7 @@
    "id": "aeb7861b",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter your new chosen curator tag. **Must possess the '.h5ad' suffix**.</font>\n",
+    "<font color='#bc00b0'>(Required) Enter your new chosen curator tag. **Cannot be empty**.</font>\n",
     "    \n",
     "When using curator tags, we recommmend using a tagging scheme that 1) makes sense to you, and 2) will help organize and facilitate your \n",
     "automation of future uploads for adding new Datasets and replacing existing Datasets."
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_tag = \"a_new_tag.h5ad\""
+    "new_tag = \"a_new_tag\""
    ]
   },
   {


### PR DESCRIPTION
https://github.com/chanzuckerberg/single-cell-data-portal/issues/3102

Port of R notebooks to Python: the user can see how the requests are formulated manually, which the current Python notebooks do not make clear.