### PR TITLE
fix: Update suspension_type validation rules for Drop-seq assays

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/convert.py
+++ b/cellxgene_schema_cli/cellxgene_schema/convert.py
@@ -69,7 +69,7 @@ def convert(input_file, output_file):
     match_assays = {
         # 'EFO:0010010': ['cell', 'nucleus'], 
         'EFO:0008720': 'nucleus',
-        'EFO:0008722': 'cell',
+        # 'EFO:0008722': ['cell', 'nucleus'], ,
         'EFO:0030002': 'cell',
         'EFO:0008853': 'cell',
         'EFO:0030026': 'nucleus',
@@ -110,8 +110,12 @@ def convert(input_file, output_file):
             dataset.obs.loc[:, ["assay_ontology_term_id"]] = dataset.obs.astype("category")
         for item in dataset.obs["assay_ontology_term_id"].cat.categories:
             suspension_type_map[item] = assign_suspension_type(item)
-            print(f"Dataset contains row(s) with assay_ontology_term_id {item}. "
-                  f"Automatically assigned suspension_type {suspension_type_map[item]}")
+            if np.isnan(suspension_type_map[item]):
+                print(f"Dataset contains row(s) with assay_ontology_term_id {item}. These cannot be auto-assigned a "
+                      f"suspension type, please assign a suspension_type manually and validate.")
+            else:
+                print(f"Dataset contains row(s) with assay_ontology_term_id {item}. "
+                      f"Automatically assigned suspension_type {suspension_type_map[item]}")
         dataset.obs["suspension_type"] = dataset.obs.apply(lambda row: suspension_type_map.get(row.assay_ontology_term_id),
                                                            axis=1)
         dataset.obs.loc[:, ["suspension_type"]] = dataset.obs.astype("category")

--- a/cellxgene_schema_cli/cellxgene_schema/convert.py
+++ b/cellxgene_schema_cli/cellxgene_schema/convert.py
@@ -66,6 +66,9 @@ def convert(input_file, output_file):
             del dataset.obs[label]
 
     # Set suspension type
+
+    # mappings of assays (or assays + child term assays) to corresponding suspension_type
+    # valid assays with multiple possible suspension_types shown but commented out
     match_assays = {
         # 'EFO:0010010': ['cell', 'nucleus'], 
         'EFO:0008720': 'nucleus',

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/3_0_0.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/3_0_0.yaml
@@ -390,13 +390,14 @@ components:
                         enum:
                             - "nucleus"
                     -
-                        # If assay_ontology_term_id is EFO:0008722, 'suspension_type' MUST be 'cell'
+                        # If assay_ontology_term_id is EFO:0008722, 'suspension_type' MUST be 'cell' or 'nucleus'
                         rule: "assay_ontology_term_id == 'EFO:0008722'"
                         type: categorical
                         error_message_suffix: >- 
                             when 'assay_ontology_term_id' is EFO:0008722
                         enum:
                             - "cell"
+                            - "nucleus"
                     -
                         # If assay_ontology_term_id is EFO:0030002, 'suspension_type' MUST be 'cell'
                         rule: "assay_ontology_term_id == 'EFO:0030002'"

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -633,7 +633,7 @@ class TestObs(BaseValidationTest):
         the value of the suspension_type does not match the required value(s) in the table.
         """
         match_assays = {
-            'EFO:0010010': ['cell', 'nucleus'], 'EFO:0008720': ['nucleus'], 'EFO:0008722': ['cell'],
+            'EFO:0010010': ['cell', 'nucleus'], 'EFO:0008720': ['nucleus'], 'EFO:0008722': ['cell', 'nucleus'],
             'EFO:0030002': ['cell'], 'EFO:0008853': ['cell'], 'EFO:0030026': ['nucleus'],
             'EFO:0010550': ['cell', 'nucleus'], 'EFO:0008919': ['cell'], 'EFO:0008939': ['nucleus'],
             'EFO:0030027': ['nucleus'],

--- a/schema/3.0.0/schema.md
+++ b/schema/3.0.0/schema.md
@@ -575,7 +575,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
            </tr>
             <tr>
               <td><i>Drop-seq</i> [<a href="http://www.ebi.ac.uk/efo/EFO_0008722"><code>EFO:0008722</code></a>]</td>
-              <td><code>"cell"</code></td>
+              <td><code>"cell"</code> or <code>"nucleus"</code></td>
            </tr>
             <tr>
               <td><i>microwell-seq</i> [<a href="http://www.ebi.ac.uk/efo/EFO_0030002"><code>EFO:0030002</code></a>]</td>


### PR DESCRIPTION
#343 

Changes:
- updated 3.0.0 OpenAPI spec rules to allow obs rows with Drop-seq assays to have either nucleus OR cell as suspension_type
- updated convert script to account for not being able to auto-assign suspension_type to Drop-seq obs rows anymore + updated logged message to more clearly explain workflow where auto-assignment cannot be done.
- updated schema def doc
- update tests