### PR TITLE
refactor "gene symbol" term to "gene name"

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/ontology.py
+++ b/cellxgene_schema_cli/cellxgene_schema/ontology.py
@@ -39,7 +39,7 @@ def get_organism_from_feature_id(
 
 
 class GeneChecker:
-    """Handles checking gene ids, retrieves symbols"""
+    """Handles checking gene ids, retrieves gene names"""
 
     GENE_FILES = {
         SupportedOrganisms.HOMO_SAPIENS: os.path.join(
@@ -100,14 +100,14 @@ class GeneChecker:
 
         return gene_id in self.gene_dict
 
-    def get_symbol(self, gene_id) -> str:
+    def get_gene_name(self, gene_id) -> str:
         """
-        Gets symbol associated to the ENSEBML id
+        Gets gene name associated to the ENSEBML id
 
         :param str gene_id: ENSEMBL gene id
 
         :rtype str
-        :return A gene symbol
+        :return A gene name
         """
 
         if not self.is_valid_id(gene_id):

--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -177,7 +177,7 @@ class AnnDataLabelAppender:
 
         for i in ids:
             organism = ontology.get_organism_from_feature_id(i)
-            mapping_dict[i] = self.validator.gene_checkers[organism].get_symbol(i)
+            mapping_dict[i] = self.validator.gene_checkers[organism].get_gene_name(i)
 
         return mapping_dict
 

--- a/cellxgene_schema_cli/tests/test_ontology.py
+++ b/cellxgene_schema_cli/tests/test_ontology.py
@@ -27,7 +27,7 @@ class TestGeneChecker(unittest.TestCase):
                 gene_label = self.valid_genes[species][gene_id]
 
                 self.assertTrue(geneChecker.is_valid_id(gene_id))
-                self.assertEqual(geneChecker.get_symbol(gene_id), gene_label)
+                self.assertEqual(geneChecker.get_gene_name(gene_id), gene_label)
 
     def test_invalid_genes(self):
         for species in self.invalid_genes:
@@ -36,7 +36,7 @@ class TestGeneChecker(unittest.TestCase):
 
                 self.assertFalse(geneChecker.is_valid_id(gene_id))
                 with self.assertRaises(ValueError):
-                    geneChecker.get_symbol(gene_id)
+                    geneChecker.get_gene_name(gene_id)
 
 
 class TestOntologyChecker(unittest.TestCase):


### PR DESCRIPTION
Refactor method name from "gene symbol" term to "gene name" to more accurately reflect the underlying data attribute and avoid confusion.

The generated gene files (e.g. `genes_homo_sapiens.csv.gz` appear to contain gene _names_ rather than _symbols_, as that is what is extracted from the underlying source data (e.g. http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_38/gencode.v38.primary_assembly.annotation.gtf.gz).

example row:
```
chr1	HAVANA	gene	916865	921016	.	-	.	gene_id "ENSG00000223764.2"; gene_type "lncRNA"; gene_name "LINC02593"; level 2; hgnc_id "HGNC:53933"; havana_gene "OTTHUMG00000040718.2";
```
