### PR TITLE
chore: update docs and logs to reference Seurat v4 instead of v3

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -927,14 +927,14 @@ class Validator:
             if effective_r_array_size > self.schema_def["max_size_for_seurat"]:
                 if is_sparse:
                     self.warnings.append(
-                        f"This dataset cannot be converted to the .rds (Seurat v3) format. "
+                        f"This dataset cannot be converted to the .rds (Seurat v4) format. "
                         f"{effective_r_array_size} nonzero elements in matrix {matrix_name} exceed the "
                         f"limitations in the R dgCMatrix sparse matrix class (2^31 - 1 nonzero "
                         f"elements)."
                     )
                 else:
                     self.warnings.append(
-                        f"This dataset cannot be converted to the .rds (Seurat v3) format. "
+                        f"This dataset cannot be converted to the .rds (Seurat v4) format. "
                         f"{effective_r_array_size} elements in at least one dimension of matrix "
                         f"{matrix_name} exceed the limitations in the R dgCMatrix sparse matrix class "
                         f"(2^31 - 1 nonzero elements)."

--- a/datasets/biccn-bakken/scripts/reformat_seurat.R
+++ b/datasets/biccn-bakken/scripts/reformat_seurat.R
@@ -1,4 +1,4 @@
-# Reformats from suerat V3 to anndata
+# Reformats from seurat to anndata
 # If sct transform is present saves that to main layer and saves counts to X
 
 library('sceasy')

--- a/datasets/biccn-bakken/scripts/reformat_seurat.R
+++ b/datasets/biccn-bakken/scripts/reformat_seurat.R
@@ -1,4 +1,4 @@
-# Reformats from seurat to anndata
+# Reformats from suerat V3 to anndata
 # If sct transform is present saves that to main layer and saves counts to X
 
 library('sceasy')

--- a/schema/3.0.0/schema.md
+++ b/schema/3.0.0/schema.md
@@ -38,7 +38,7 @@ This document is organized by:
 
 **AnnData.** The canonical data format for the cellxgene Data Portal is HDF5-backed [AnnData](https://anndata.readthedocs.io/en/latest) as written by version 0.8 of the anndata library.  Part of the rationale for selecting this format is to allow cellxgene to access both the data and metadata within a single file. The schema requirements and definitions for the AnnData `X`, `obs`, `var`, `raw.var`, `obsm`, and `uns` attributes are described below.
 
-All data submitted to the cellxgene Data Portal is automatically converted to a Seurat V3 object that can be loaded by the R package Seurat. See the [Seurat encoding](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/seurat_encoding.md) for further information.
+All data submitted to the cellxgene Data Portal is automatically converted to a Seurat V4 object that can be loaded by the R package Seurat. See the [Seurat encoding](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/seurat_encoding.md) for further information.
 
 **Organisms**. Data MUST be from a Metazoan organism or SARS-COV-2 and defined in the NCBI organismal classification. For data that is neither Human, Mouse, nor SARS-COV-2, features MUST be translated into orthologous genes from the pinned Human and Mouse gene annotations.
 

--- a/schema/3.0.0/seurat_encoding.md
+++ b/schema/3.0.0/seurat_encoding.md
@@ -10,13 +10,13 @@ Schema version: 3.0.0
 
 ## Overview
 
-All data submitted to the [cellxgene Data Portal](https://cellxgene.cziscience.com/) is automatically converted to a Seurat V3 object that can be loaded by the R package [Seurat](https://satijalab.org/seurat/).
+All data submitted to the [cellxgene Data Portal](https://cellxgene.cziscience.com/) is automatically converted to a Seurat V4 object that can be loaded by the R package [Seurat](https://satijalab.org/seurat/).
 
 This document describes the Seurat encoding for the converted data. <u><strong>Readers should be familiar with the [schema](./schema.md).</strong></u>
 
 ## Encoding
 
-The Seurat V3 object is stored using the [native serialization RDS format](https://cran.r-project.org/doc/manuals/r-release/R-ints.html#Serialization-Formats). The [serialization interfaces](https://stat.ethz.ch/R-manual/R-devel/library/base/html/readRDS.html) allow the object to be serialized to and restored from disk. 
+The Seurat V4 object is stored using the [native serialization RDS format](https://cran.r-project.org/doc/manuals/r-release/R-ints.html#Serialization-Formats). The [serialization interfaces](https://stat.ethz.ch/R-manual/R-devel/library/base/html/readRDS.html) allow the object to be serialized to and restored from disk. 
 
 A `local.rds` file downloaded from the cellxgene Data Portal can be read into an R session with the following code.
 


### PR DESCRIPTION
#[3290](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/3290)

