### PR TITLE
fix: don't duplicate error logs about null entries on enum fields

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/3_0_0.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/3_0_0.yaml
@@ -261,11 +261,12 @@ components:
                 subtype: str
             suspension_type:
                 type: categorical
-                error_message_suffix: "'suspension_type' MUST be one of 'cell', 'nucleus', or 'na'.'"
                 enum:
                     - "cell"
                     - "nucleus"
                     - "na"
+                error_message_suffix: >-
+                    when 'assay_ontology_term_id' does not match one of the assays in the schema definition.
                 # if no dependencies are matched
                 warning_message: >-
                     Data contains assay(s) that are not represented in the 'suspension_type' schema definition table. Ensure you have

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -494,7 +494,8 @@ class Validator:
                                 f"Column '{column_name}' in dataframe '{df_name}' must not contain empty values."
                             )
 
-                if column.isnull().any():
+                # check for null values--skip on column defs with enums, since it will already be part of that check
+                if not column_def.get("enum") and column.isnull().any():
                     self.errors.append(
                         f"Column '{column_name}' in dataframe '{df_name}' must not contain NaN values."
                     )


### PR DESCRIPTION
Fix for logging duplicate issue flagged [here](https://github.com/chanzuckerberg/single-cell-curation/issues/343#issuecomment-1254024727)

Changes:
- Changed default error message suffix for suspension_type (i.e. scenario where assay does not match one in the assay-suspension type table defined in the schema definition) to provide more context
- Skip check/error logging for null values in categorical fields, IF categorical field is also an enum. Having both checks is extraneous, since checking against enum values will also, inherently, flag and log null values. So far, only suspension_type is both an enum and categorical, so it should be the only field affected. 