### PR TITLE
feat: standardize 'id' attribute usage

### DIFF
--- a/notebooks/curation_api/R/create_collection_R.ipynb
+++ b/notebooks/curation_api/R/create_collection_R.ipynb
@@ -186,7 +186,7 @@
     ")\n",
     "stop_for_status(res)\n",
     "res_content <- content(res)\n",
-    "collection_id <- res_content$collection_id\n",
+    "collection_id <- res_content$id\n",
     "print(\"New private Collection id:\")\n",
     "print(collection_id)\n",
     "print(\"New private Collection url:\")\n",

--- a/notebooks/curation_api/R/create_dataset_R.ipynb
+++ b/notebooks/curation_api/R/create_dataset_R.ipynb
@@ -13,7 +13,7 @@
    "id": "74560383",
    "metadata": {},
    "source": [
-    "The script in this notebook creates a new, empty Dataset in the specified Collection. After creation, you can use the returned `dataset_id` with either the `upload_local_datafile_to_dataset_R.ipynb` notebook or the `upload_datafile_from_link_to_dataset_R.ipynb` notebook to populate the newly created Dataset with the contents of your datafile.\n",
+    "The script in this notebook creates a new, empty Dataset in the specified Collection. After creation, you can use the returned Dataset `id` with either the `upload_local_datafile_to_dataset_R.ipynb` notebook or the `upload_datafile_from_link_to_dataset_R.ipynb` notebook to populate the newly created Dataset with the contents of your datafile.\n",
     "\n",
     "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the CZ CELLxGENE Discover data portal after logging in)."
    ]
@@ -168,7 +168,7 @@
     "res <- POST(url=url, add_headers(`Authorization`=bearer_token, `Content-Type`=\"application/json\"))\n",
     "stop_for_status(res)\n",
     "res_content <- content(res)\n",
-    "dataset_id <- res_content$dataset_id\n",
+    "dataset_id <- res_content$id\n",
     "print(str_interp(\"New empty Dataset with id ${dataset_id} in Collection at url:\"))\n",
     "print(str_interp(\"${site_url}/collections/${collection_id}\"))"
    ]

--- a/notebooks/curation_api/R/create_revision_R.ipynb
+++ b/notebooks/curation_api/R/create_revision_R.ipynb
@@ -168,7 +168,7 @@
     "res <- POST(url=url, add_headers(`Authorization`=bearer_token, `Content-Type`=\"application/json\"))\n",
     "stop_for_status(res)\n",
     "res_content <- content(res)\n",
-    "revision_id <- res_content$revision_id\n",
+    "revision_id <- res_content$id\n",
     "cat(\"Revision id:\\n\")\n",
     "cat(str_interp(\"${revision_id}\\n\"))\n",
     "cat(\"Revision url:\\n\")\n",

--- a/notebooks/curation_api/R/upload_local_datafile_to_dataset_R.ipynb
+++ b/notebooks/curation_api/R/upload_local_datafile_to_dataset_R.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the CZ CELLxGENE Discover data portal after logging in).\n",
     "\n",
-    "_For **new** Datasets_: You must separately create a Dataset (the `create_dataset.ipynb` notebook). Then, use the returned Dataset `dataset_id` as the suffix (append to the `UploadKeyPrefix` returned from the `/s3-upload-credentials` endpoint) of the S3 upload key. See code below, or read more detailed instructions about how to submit Datasets via S3 upload in [the description for the credentials endpoint](https://api.cellxgene.cziscience.com/curation/ui/#/collection/backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.upload_s3.get).\n",
+    "_For **new** Datasets_: You must separately create a Dataset (the `create_dataset.ipynb` notebook). Then, use the returned Dataset `id` as the suffix (append to the `UploadKeyPrefix` returned from the `/s3-upload-credentials` endpoint) of the S3 upload key. See code below, or read more detailed instructions about how to submit Datasets via S3 upload in [the description for the credentials endpoint](https://api.cellxgene.cziscience.com/curation/ui/#/collection/backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.upload_s3.get).\n",
     "\n",
     "_For **replacing/updating** existing Datasets_: Uploads to a Dataset id that is already populated with data will result in the existing Dataset being replaced by a new Dataset created from the datafile that you are uploading.\n",
     "\n",

--- a/notebooks/curation_api/python/create_dataset.ipynb
+++ b/notebooks/curation_api/python/create_dataset.ipynb
@@ -13,7 +13,7 @@
    "id": "74560383",
    "metadata": {},
    "source": [
-    "The script in this notebook creates a new, empty Dataset in the specified Collection. After creation, you can use the returned `dataset_id` with either the `upload_local_datafile_to_dataset.ipynb` notebook or the `upload_datafile_from_link_to_dataset.ipynb` notebook to populate the newly created Dataset with the contents of your datafile.\n",
+    "The script in this notebook creates a new, empty Dataset in the specified Collection. After creation, you can use the returned Dataset `id` with either the `upload_local_datafile_to_dataset.ipynb` notebook or the `upload_datafile_from_link_to_dataset.ipynb` notebook to populate the newly created Dataset with the contents of your datafile.\n",
     "\n",
     "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the CZ CELLxGENE Discover data portal after logging in)."
    ]

--- a/notebooks/curation_api/python/src/collection.py
+++ b/notebooks/curation_api/python/src/collection.py
@@ -24,7 +24,7 @@ def create_collection(collection_form_metadata: dict) -> str:
     except requests.HTTPError as e:
         failure(logger, e)
         raise e
-    collection_id = data.get("collection_id")
+    collection_id = data.get("id")
     success(logger, f"New private Collection id:\n{collection_id}\n",
             f"New private Collection url:\n{format_c_url(collection_id)}")
     return collection_id
@@ -41,7 +41,7 @@ def create_revision(collection_id: str) -> str:
     except requests.HTTPError as e:
         failure(logger, e)
         raise e
-    revision_id = data.get("revision_id")
+    revision_id = data.get("id")
     success(logger, f"Revision id:\n{revision_id}\n",
             f"Revision url:\n{format_c_url(revision_id)}")
     return revision_id

--- a/notebooks/curation_api/python/src/dataset.py
+++ b/notebooks/curation_api/python/src/dataset.py
@@ -31,7 +31,7 @@ def create_dataset(collection_id: str):
     except requests.HTTPError as e:
         failure(logger, e)
         raise e
-    dataset_id = data["dataset_id"]
+    dataset_id = data["id"]
     success(logger, f"Created new Dataset {dataset_id} in the Collection at {format_c_url(collection_id)}")
     return dataset_id
 

--- a/notebooks/curation_api/python/upload_local_datafile_to_dataset.ipynb
+++ b/notebooks/curation_api/python/upload_local_datafile_to_dataset.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the CZ CELLxGENE Discover data portal after logging in).\n",
     "\n",
-    "_For **new** Datasets_: You must separately create a Dataset (the `create_dataset.ipynb` notebook). Then, use the returned `dataset_id` as the suffix (append to the `UploadKeyPrefix` returned from the `/s3-upload-credentials` endpoint) of the S3 upload key. See code below, or read more detailed instructions about how to submit Datasets via S3 upload in [the description for the credentials endpoint](https://api.cellxgene.cziscience.com/curation/ui/#/collection/backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.upload_s3.get).\n",
+    "_For **new** Datasets_: You must separately create a Dataset (the `create_dataset.ipynb` notebook). Then, use the returned Dataset `id` as the suffix (append to the `UploadKeyPrefix` returned from the `/s3-upload-credentials` endpoint) of the S3 upload key. See code below, or read more detailed instructions about how to submit Datasets via S3 upload in [the description for the credentials endpoint](https://api.cellxgene.cziscience.com/curation/ui/#/collection/backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.upload_s3.get).\n",
     "\n",
     "_For **replacing/updating** existing Datasets_: Uploads to a Dataset id that is already populated with data will result in the existing Dataset being replaced by a new Dataset created from the datafile that you are uploading.\n",
     "\n",

--- a/notebooks/curation_api/python_raw/create_collection.ipynb
+++ b/notebooks/curation_api/python_raw/create_collection.ipynb
@@ -181,7 +181,7 @@
     "res = requests.post(url=url, json=collection_form_metadata, headers={\"Authorization\": bearer_token})\n",
     "res.raise_for_status()\n",
     "res_content = res.json()\n",
-    "collection_id = res_content[\"collection_id\"]\n",
+    "collection_id = res_content[\"id\"]\n",
     "print(\"New private Collection id:\")\n",
     "print(collection_id)\n",
     "print(\"New private Collection url:\")\n",

--- a/notebooks/curation_api/python_raw/create_dataset.ipynb
+++ b/notebooks/curation_api/python_raw/create_dataset.ipynb
@@ -13,7 +13,7 @@
    "id": "74560383",
    "metadata": {},
    "source": [
-    "The script in this notebook creates a new, empty Dataset in the specified Collection. After creation, you can use the returned `dataset_id` with either the `upload_local_datafile_to_dataset.ipynb` notebook or the `upload_datafile_from_link_to_dataset.ipynb` notebook to populate the newly created Dataset with the contents of your datafile.\n",
+    "The script in this notebook creates a new, empty Dataset in the specified Collection. After creation, you can use the returned Dataset `id` with either the `upload_local_datafile_to_dataset.ipynb` notebook or the `upload_datafile_from_link_to_dataset.ipynb` notebook to populate the newly created Dataset with the contents of your datafile.\n",
     "\n",
     "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the CZ CELLxGENE Discover data portal after logging in)."
    ]
@@ -171,7 +171,7 @@
     "res.raise_for_status()\n",
     "res_content = res.json()\n",
     "print(res_content)\n",
-    "dataset_id = res_content[\"dataset_id\"]\n",
+    "dataset_id = res_content[\"id\"]\n",
     "print(f\"New empty Dataset with id {dataset_id} in Collection at url:\")\n",
     "print(f\"{site_url}/collections/{collection_id}\")"
    ]

--- a/notebooks/curation_api/python_raw/create_revision.ipynb
+++ b/notebooks/curation_api/python_raw/create_revision.ipynb
@@ -166,7 +166,7 @@
     "res = requests.post(url=url, headers={\"Authorization\": bearer_token})\n",
     "res.raise_for_status()\n",
     "res_content = res.json()\n",
-    "revision_id = res_content[\"revision_id\"]\n",
+    "revision_id = res_content[\"id\"]\n",
     "print(\"Revision id:\")\n",
     "print(revision_id)\n",
     "print(\"Revision url:\")\n",

--- a/notebooks/curation_api/python_raw/upload_local_datafile_to_dataset.ipynb
+++ b/notebooks/curation_api/python_raw/upload_local_datafile_to_dataset.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "In order to use this script, you must have a Curation API key (obtained from upper-righthand dropdown in the CZ CELLxGENE Discover data portal after logging in).\n",
     "\n",
-    "_For **new** Datasets_: You must separately create a Dataset (the `create_dataset.ipynb` notebook). Then, use the returned `dataset_id` as the suffix (append to the `UploadKeyPrefix` returned from the `/s3-upload-credentials` endpoint) of the S3 upload key. See code below, or read more detailed instructions about how to submit Datasets via S3 upload in [the description for the credentials endpoint](https://api.cellxgene.cziscience.com/curation/ui/#/collection/backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.upload_s3.get).\n",
+    "_For **new** Datasets_: You must separately create a Dataset (the `create_dataset.ipynb` notebook). Then, use the returned Dataset `id` as the suffix (append to the `UploadKeyPrefix` returned from the `/s3-upload-credentials` endpoint) of the S3 upload key. See code below, or read more detailed instructions about how to submit Datasets via S3 upload in [the description for the credentials endpoint](https://api.cellxgene.cziscience.com/curation/ui/#/collection/backend.corpora.lambdas.api.v1.curation.collections.collection_id.datasets.upload_s3.get).\n",
     "\n",
     "_For **replacing/updating** existing Datasets_: Uploads to a Dataset id that is already populated with data will result in the existing Dataset being replaced by a new Dataset created from the datafile that you are uploading.\n",
     "\n",


### PR DESCRIPTION
- "revision_id" -> "id"
- "collection_id" -> "id"
- "dataset_id" -> "id"