### PR TITLE
feat: add code for actually downloading assets

### DIFF
--- a/notebooks/curation_api/R/get_dataset_assets_R.ipynb
+++ b/notebooks/curation_api/R/get_dataset_assets_R.ipynb
@@ -5,7 +5,7 @@
    "id": "c5490d93",
    "metadata": {},
    "source": [
-    "# Fetch download links for a Dataset's available assets"
+    "# Download a Dataset's available assets"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "74560383",
    "metadata": {},
    "source": [
-    "The script in this notebook retrieves download links for a Dataset's assets.\n",
+    "The script in this notebook retrieves download links for a Dataset and then uses those links to download all available assets.\n",
     "\n",
     "Fetching a Dataset requires only the Collection id and the Dataset id; it does not require an API key/access token."
    ]
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "ca707859",
    "metadata": {},
    "outputs": [],
@@ -130,8 +130,32 @@
     "assets_path <- str_interp(\"/curation/v1/collections/${collection_id}/datasets/${dataset_id}/assets\")\n",
     "url <- str_interp(\"${api_url_base}${assets_path}\")\n",
     "res <- GET(url=url, add_headers(`Content-Type`=\"application/json\"))\n",
-    "stop_for_status(res)\n",
-    "print(content(res))"
+    "stop_for_status(res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80a72811",
+   "metadata": {},
+   "source": [
+    "### Use download links to download assets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f048346",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assets <- content(res)$assets\n",
+    "for (asset in assets) {\n",
+    "    download_filename <- str_interp(\"${collection_id}_${dataset_id}_${asset$filename}\")\n",
+    "    print(str_interp(\"Downloading ${asset$filetype} file to ${download_filename}... \"))\n",
+    "    res <- GET(asset$presigned_url, write_disk(download_filename))\n",
+    "    stop_for_status(res)\n",
+    "}\n",
+    "print(\"Done downloading assets\")"
    ]
   }
  ],

--- a/notebooks/curation_api/python/get_dataset_assets.ipynb
+++ b/notebooks/curation_api/python/get_dataset_assets.ipynb
@@ -5,7 +5,7 @@
    "id": "c5490d93",
    "metadata": {},
    "source": [
-    "# Fetch download links for a Dataset's available assets"
+    "# Download a Dataset's available assets"
    ]
   },
   {
@@ -13,7 +13,10 @@
    "id": "74560383",
    "metadata": {},
    "source": [
-    "The script in this notebook retrieves download links for a Dataset's assets.\n",
+    "The script in this notebook offers two approaches to downloading a Dataset's assets:\n",
+    "1) A direct download of _all_ available assets to local files of the form `{collection_id}_{dataset_id}.{filetype_ext}`\n",
+    "\n",
+    "2) Manual retrieval of presigned_url download links for individualized downloads of assets\n",
     "\n",
     "Fetching a Dataset requires only the Collection id and the Dataset id; it does not require an API key/access token."
    ]
@@ -35,7 +38,8 @@
    "source": [
     "from src.utils.config import set_api_access_config  # still required for setting api url env vars\n",
     "from src.utils.logger import set_log_level  # can set_log_level(\"ERROR\") for less logging; default is \"INFO\"\n",
-    "from src.dataset import get_assets"
+    "from src.dataset import download_assets, get_download_links_for_assets\n",
+    "import requests"
    ]
   },
   {
@@ -51,7 +55,7 @@
    "id": "4816c4cc",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter the id of the Collection that contains the Dataset for which you want to fetch download links</font>\n",
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection that contains the Dataset for which you want to download assets</font>\n",
     "\n",
     "_The Collection id can be found by looking at the url path in the address bar \n",
     "when viewing your Collection in the CZ CELLxGENE Discover data portal: `/collections/{collection_id}`._"
@@ -72,7 +76,7 @@
    "id": "a1600d22",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter the id of the Dataset for which you want to fetch download links</font>\n",
+    "<font color='#bc00b0'>(Required) Enter the id of the Dataset for which you want to download assets</font>\n",
     "\n",
     "_The Dataset id can be found by using the `/collections/{collection_id}` endpoint and filtering for the Dataset of interest OR by looking at the url path in the address when viewing your Dataset using the CZ CELLxGENE Explorer browser tool: `/e/{dataset_id}.cxg/`._"
    ]
@@ -110,19 +114,52 @@
    "id": "6085d322",
    "metadata": {},
    "source": [
-    "### Fetch asset download links"
+    "### 1) Download all assets directly to local files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cb3dd36b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Uncomment code below to download all assets\n",
+    "\n",
+    "# download_assets(collection_id, dataset_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2db0a60",
+   "metadata": {},
+   "source": [
+    "### OR\n",
+    "\n",
+    "### 2) Fetch list of assets with download links"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb3dd36b",
+   "id": "f55cc410",
    "metadata": {},
    "outputs": [],
    "source": [
-    "asset_links = get_assets(collection_id, dataset_id)\n",
-    "from pprint import pprint\n",
-    "pprint(asset_links)"
+    "# Uncomment code below to fetch download links and manually iterate through the download process\n",
+    "\n",
+    "# assets = get_download_links_for_assets(collection_id, dataset_id)\n",
+    "# for asset in assets:\n",
+    "#     download_filename = f\"{collection_id}_{dataset_id}_{asset['filename']}\"\n",
+    "#     print(f\"Downloading {asset['filetype']} file to {download_filename}... \")\n",
+    "#     with requests.get(asset[\"presigned_url\"], stream=True) as res:\n",
+    "#         res.raise_for_status()\n",
+    "#         with open(download_filename, \"wb\") as df:\n",
+    "#             for chunk in res.iter_content(chunk_size=1024 * 1024):\n",
+    "#                 df.write(chunk)\n",
+    "# print(\"Done downloading assets\")"
    ]
   }
  ],

--- a/notebooks/curation_api/python/src/dataset.py
+++ b/notebooks/curation_api/python/src/dataset.py
@@ -58,7 +58,7 @@ def delete_dataset(collection_id: str, dataset_id: str):
         success(logger, success_message)
 
 
-def get_assets(collection_id: str, dataset_id: str):
+def get_download_links_for_assets(collection_id: str, dataset_id: str):
     """
     Fetch download links for assets for a Dataset
     :param collection_id: the id of the Collection to which the Dataset belongs
@@ -74,7 +74,32 @@ def get_assets(collection_id: str, dataset_id: str):
     except requests.HTTPError as e:
         failure(logger, e)
         raise e
-    return res.json()
+
+    return res.json().get("assets")
+
+
+def download_assets(collection_id: str, dataset_id: str):
+    """
+    Download assets locally for a Dataset
+    :param collection_id: the id of the Collection to which the Dataset belongs
+    :param dataset_id: Dataset id
+    :return: download links
+    """
+    assets_response = get_download_links_for_assets(collection_id, dataset_id)
+
+    try:
+        for asset in assets_response:
+            download_filename = f"{collection_id}_{dataset_id}_{asset['filename']}"
+            print(f"Downloading {asset['filetype']} file to {download_filename}... ")
+            with requests.get(asset["presigned_url"], stream=True) as res:
+                res.raise_for_status()
+                with open(download_filename, "wb") as df:
+                    for chunk in res.iter_content(chunk_size=1024 * 1024):
+                        df.write(chunk)
+    except requests.HTTPError as e:
+        failure(logger, e)
+        raise e
+    success(logger, "Finished downloading assets")
 
 
 def get_dataset(collection_id: str, dataset_id: str):

--- a/notebooks/curation_api/python_raw/get_dataset_assets.ipynb
+++ b/notebooks/curation_api/python_raw/get_dataset_assets.ipynb
@@ -5,7 +5,7 @@
    "id": "c5490d93",
    "metadata": {},
    "source": [
-    "# Fetch download links for a Dataset's available assets"
+    "# Download a Dataset's available assets"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "74560383",
    "metadata": {},
    "source": [
-    "The script in this notebook retrieves download links for a Dataset's assets.\n",
+    "The script in this notebook retrieves download links for a Dataset and then uses those links to download all available assets.\n",
     "\n",
     "Fetching a Dataset requires only the Collection id and the Dataset id; it does not require an API key/access token."
    ]
@@ -49,7 +49,7 @@
    "id": "0268c0a4",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter the id of the Collection that contains the Dataset for which you want to fetch download links</font>\n",
+    "<font color='#bc00b0'>(Required) Enter the id of the Collection that contains the Dataset for which you want to download assets</font>\n",
     "\n",
     "_The Collection id can be found by looking at the url path in the address bar \n",
     "when viewing your Collection in the CZ CELLxGENE Discover data portal: `/collections/{collection_id}`._"
@@ -70,7 +70,7 @@
    "id": "6d7371ef",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Enter the id of the Dataset for which you want to fetch download links</font>\n",
+    "<font color='#bc00b0'>(Required) Enter the id of the Dataset for which you want to download assets</font>\n",
     "\n",
     "_The Dataset id can be found by using the `/collections/{collection_id}` endpoint and filtering for the Dataset of interest OR by looking at the url path in the address when viewing your Dataset using the CZ CELLxGENE Explorer browser tool: `/e/{dataset_id}.cxg/`._"
    ]
@@ -110,7 +110,7 @@
    "id": "6085d322",
    "metadata": {},
    "source": [
-    "### Formulate request and fetch a Dataset's assets"
+    "### Formulate request and fetch asset download links"
    ]
   },
   {
@@ -128,8 +128,34 @@
     "url = f\"{api_url_base}{assets_path}\"\n",
     "res = requests.get(url=url)\n",
     "res.raise_for_status()\n",
-    "res_content = res.json()\n",
-    "print(res_content)"
+    "res_content = res.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3151f0a8",
+   "metadata": {},
+   "source": [
+    "### Use download links to download assets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3bdf081",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assets = res_content[\"assets\"]\n",
+    "for asset in assets:\n",
+    "    download_filename = f\"{collection_id}_{dataset_id}_{asset['filename']}\"\n",
+    "    print(f\"Downloading {asset['filetype']} file to {download_filename}... \")\n",
+    "    with requests.get(asset[\"presigned_url\"], stream=True) as res:\n",
+    "        res.raise_for_status()\n",
+    "        with open(download_filename, \"wb\") as df:\n",
+    "            for chunk in res.iter_content(chunk_size=1024 * 1024):\n",
+    "                df.write(chunk)\n",
+    "print(\"Done downloading assets\")"
    ]
   }
  ],


### PR DESCRIPTION
For python, python_raw, and R:
- update the assets notebooks 
- add code to perform download step after retrieving presigned urls

For python: 
- option to use one-step download function without handling presigned urls manually