### PR TITLE
feat: GET /assets returns array directly

### DIFF
--- a/notebooks/curation_api/R/get_dataset_assets_R.ipynb
+++ b/notebooks/curation_api/R/get_dataset_assets_R.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assets <- content(res)$assets\n",
+    "assets <- content(res)\n",
     "for (asset in assets) {\n",
     "    download_filename <- str_interp(\"${collection_id}_${dataset_id}_${asset$filename}\")\n",
     "    print(str_interp(\"Downloading ${asset$filetype} file to ${download_filename}... \"))\n",

--- a/notebooks/curation_api/python/src/dataset.py
+++ b/notebooks/curation_api/python/src/dataset.py
@@ -75,7 +75,7 @@ def get_download_links_for_assets(collection_id: str, dataset_id: str):
         failure(logger, e)
         raise e
 
-    return res.json().get("assets")
+    return res.json()
 
 
 def download_assets(collection_id: str, dataset_id: str):

--- a/notebooks/curation_api/python_raw/get_dataset_assets.ipynb
+++ b/notebooks/curation_api/python_raw/get_dataset_assets.ipynb
@@ -127,8 +127,7 @@
     "assets_path = f\"/curation/v1/collections/{collection_id}/datasets/{dataset_id}/assets\"\n",
     "url = f\"{api_url_base}{assets_path}\"\n",
     "res = requests.get(url=url)\n",
-    "res.raise_for_status()\n",
-    "res_content = res.json()"
+    "res.raise_for_status()"
    ]
   },
   {
@@ -146,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assets = res_content[\"assets\"]\n",
+    "assets = res.json()\n",
     "for asset in assets:\n",
     "    download_filename = f\"{collection_id}_{dataset_id}_{asset['filename']}\"\n",
     "    print(f\"Downloading {asset['filetype']} file to {download_filename}... \")\n",


### PR DESCRIPTION
The assets array is no longer returned underneath a top-level '.assets' attribute