### PR TITLE
fix: update example_workflow curation notebook to fit redesigned, versioned data model

### DIFF
--- a/notebooks/curation_api/python/example_workflow.ipynb
+++ b/notebooks/curation_api/python/example_workflow.ipynb
@@ -310,8 +310,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "# After publish, the collection will now have a new permanent, canonical ID across versions.\n",
-    "# Use this ID for revisions.\n",
+    "# After publish, the collection will now have a new permanent, canonical ID that will stay constant across published versions.\n",
+    "# Use this ID to start a revision.\n",
     "collection_info = get_collection(new_collection_id)\n",
     "canonical_collection_id = collection_info['id']\n",
     "\n",

--- a/notebooks/curation_api/python/example_workflow.ipynb
+++ b/notebooks/curation_api/python/example_workflow.ipynb
@@ -19,18 +19,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c8c55fa",
-   "metadata": {},
    "outputs": [],
    "source": [
     "api_key_file_path = \"path/to/api-key-file\""
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc1650ce",
-   "metadata": {},
    "outputs": [],
    "source": [
     "collection_form_metadata = {\n",
@@ -52,21 +54,29 @@
     "        }\n",
     "    ],\n",
     "}"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "beec27c8",
-   "metadata": {},
    "source": [
     "### Set url and access token env vars"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a19e2db6",
-   "metadata": {},
    "outputs": [],
    "source": [
     "from src.utils.config import set_api_access_config\n",
@@ -74,237 +84,327 @@
     "from pprint import pprint\n",
     "\n",
     "set_api_access_config(api_key_file_path)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "958ac1fd",
-   "metadata": {},
    "source": [
     "### Create new private Collection"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8226a7c3",
-   "metadata": {},
    "outputs": [],
    "source": [
     "from src.collection import create_collection\n",
     "new_collection_id = create_collection(collection_form_metadata)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "69a4db34",
-   "metadata": {},
    "source": [
     "### Create new, empty Dataset"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2198be1",
-   "metadata": {},
    "outputs": [],
    "source": [
     "from src.dataset import create_dataset\n",
     "dataset_id = create_dataset(new_collection_id)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "0c71f0af",
-   "metadata": {},
    "source": [
     "### Determine local datafile and Dataset id"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "359516a2",
-   "metadata": {},
    "outputs": [],
    "source": [
     "datafile_path = \"/absolute/path/to-datafile.h5ad\""
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "f648e0b2",
-   "metadata": {},
    "source": [
     "### Upload file to Collection"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8bb640a",
-   "metadata": {},
    "outputs": [],
    "source": [
     "from src.dataset import upload_local_datafile\n",
     "upload_local_datafile(datafile_path, new_collection_id, dataset_id)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "77303a25",
-   "metadata": {},
    "source": [
     "### Create a second Dataset and upload datafile"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7afde78a",
-   "metadata": {},
    "outputs": [],
    "source": [
     "second_dataset_id = create_dataset(new_collection_id)\n",
     "upload_local_datafile(datafile_path, new_collection_id, second_dataset_id)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "0b6aa7eb",
-   "metadata": {},
    "source": [
     "### Update Collection"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f27173fc",
-   "metadata": {},
    "outputs": [],
    "source": [
     "from src.collection import update_collection\n",
     "update_collection(new_collection_id, collection_form_metadata)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "1ab3d37e",
-   "metadata": {},
    "source": [
     "### Retrieve the Collection metadata"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a31c6cc",
-   "metadata": {},
    "outputs": [],
    "source": [
     "from src.collection import get_collection\n",
     "collection_info = get_collection(new_collection_id)\n",
     "pprint(collection_info)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "647e6f17",
-   "metadata": {},
    "source": [
     "### <font color='#ff8000'>_\\*\\*Use the Data Portal UI to publish the Collection before proceeding (easy access via link above)\\*\\*_</font>"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "f0d13483",
-   "metadata": {},
    "source": [
     "### Create a revision of the Collection"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5de35ef8",
-   "metadata": {},
    "outputs": [],
    "source": [
+    "# After publish, the collection will now have a new permanent, canonical ID across versions.\n",
+    "# Use this ID for revisions.\n",
+    "collection_info = get_collection(new_collection_id)\n",
+    "canonical_collection_id = collection_info['id']\n",
+    "\n",
     "from src.collection import create_revision\n",
-    "revision_id = create_revision(new_collection_id)"
-   ]
+    "revision_id = create_revision(canonical_collection_id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "5c204fa9",
-   "metadata": {},
    "source": [
     "### Retrieve the revision Collection metadata"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9eaf5984",
-   "metadata": {},
    "outputs": [],
    "source": [
     "revision_info = get_collection(revision_id)\n",
     "pprint(revision_info)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "bade4136",
-   "metadata": {},
    "source": [
     "### Add a third Dataset (to the revision)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a3b23ee3",
-   "metadata": {},
    "outputs": [],
    "source": [
     "third_dataset_id = create_dataset(revision_id)\n",
     "upload_local_datafile(datafile_path, revision_id, third_dataset_id)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "9aeec327",
-   "metadata": {},
    "source": [
     "### Replace the second Dataset"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76883621",
-   "metadata": {},
    "outputs": [],
    "source": [
-    "for dataset in revision_info[\"datasets\"]:\n",
-    "    # Find revision Dataset that corresponds to the published version\n",
-    "    if dataset[\"original_id\"] == second_dataset_id:\n",
-    "        # Upload replacement datafile to the revision Dataset's id\n",
-    "        second_dataset_revision_id = dataset[\"id\"]\n",
-    "        upload_local_datafile(datafile_path, revision_id, second_dataset_revision_id)\n",
-    "        break"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "161994c1",
-   "metadata": {},
-   "source": [
-    "### Cancel the revision"
-   ]
+    "# Upload replacement datafile to the Dataset's id (same as in published collection) in the revision collection\n",
+    "upload_local_datafile(datafile_path, revision_id, second_dataset_id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Changes: 

1) Added 2 lines to block under 'Create a revision of the Collection'
- In the new data model, private collections will return a 'version' collection ID as the API response 'id' of a collection, whereas public collections will return a 'canonical' collection ID, which remains constant across all published versions of a collection. You may think of the public-facing canonical collection ID as a permanent pointer to the most recently published version of a collection, whereas private collection ID's point to a specific version. As a result, to start a new revision of a public collection, you must pass the API response collection 'id' that is returned AFTER publish of a collection, as you cannot start revisions off versions. You may fetch the canonical collection ID programmatically by calling GET collections/<collection_id> and passing in the private collection version ID after publish. 

2) Simplified call under 'Replace the Second Dataset'
- When creating a revision, the datasets now retain the same ID they have in the published version of the collection (this is because collection versions simply retain a list of dataset version IDs they point to, so on creation, a new revision just points to the same list its published version points to). Therefore, 'original_id' is no longer a necessary field to match revision datasets to their published versions, and thus has been deprecated. Instead, if a user would like to target a particular dataset for replacement in a revision, they simply have to pass along the collection revision ID + dataset's ID directly.