### PR TITLE
fix: update logic matching revision datasets to published collection to fit new data model

### DIFF
--- a/notebooks/curation_api/python/example_workflow.ipynb
+++ b/notebooks/curation_api/python/example_workflow.ipynb
@@ -289,22 +289,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for dataset in revision_info[\"datasets\"]:\n",
-    "    # Find revision Dataset that corresponds to the published version\n",
-    "    if dataset[\"original_id\"] == second_dataset_id:\n",
-    "        # Upload replacement datafile to the revision Dataset's id\n",
-    "        second_dataset_revision_id = dataset[\"id\"]\n",
-    "        upload_local_datafile(datafile_path, revision_id, second_dataset_revision_id)\n",
-    "        break"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "161994c1",
-   "metadata": {},
-   "source": [
-    "### Cancel the revision"
-   ]
+    "# Upload replacement datafile to the Dataset's id (same as in published collection) in the revision collection\n",
+    "upload_local_datafile(datafile_path, revision_id, second_dataset_id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Changes:
- Simplified call under 'Replace the Second Dataset'
- When creating a revision, the datasets now retain the same ID they have in the published version of the collection. Therefore, 'original_id' is no longer a necessary field to match revision datasets to their published versions, and thus has been deprecated. Instead, if a user would like to target a particular dataset for replacement in a revision, they simply have to pass along the collection revision ID + dataset's ID directly.