### PR TITLE
Use backed mode to read H5AD when validating

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -391,12 +391,6 @@ class Validator:
 
         return
 
-    def _get_matrix_by_name(
-        self, matrix_name: str
-    ) -> Union[sparse.spmatrix, np.ndarray]:
-        matrix_getter = operator.attrgetter(matrix_name)
-        return matrix_getter(self.adata)
-
     def _get_matrix_format(self, matrix: Union[np.ndarray, sparse.spmatrix]) -> str:
         """
         Given a matrix, returns the format as one of: csc, csr, coo, dense

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1,6 +1,5 @@
 import logging
 import math
-import operator
 import re
 import sys
 from datetime import datetime

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -165,7 +165,7 @@ good_uns = {
 # ---
 # 4. Creating expression matrix,
 # X has integer values and non_raw_X has real values
-X = numpy.zeros([good_obs.shape[0], good_var.shape[0]])
+X = numpy.zeros([good_obs.shape[0], good_var.shape[0]], dtype=numpy.float32)
 non_raw_X = sparse.csr_matrix(X.copy())
 non_raw_X[0, 0] = 1.5
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -251,7 +251,9 @@ class TestObs(BaseValidationTest):
         """
 
         # Not a valid term
-        self.validator.adata.obs["assay_ontology_term_id"][0] = "EFO:0009310"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "assay_ontology_term_id"
+        ] = "EFO:0009310"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -268,7 +270,10 @@ class TestObs(BaseValidationTest):
         """
 
         # Not a valid term
-        self.validator.adata.obs["assay_ontology_term_id"][0] = "CL:000001"
+        # self.validator.adata.obs["assay_ontology_term_id"][0] = "CL:000001"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "assay_ontology_term_id"
+        ] = "CL:000001"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -279,7 +284,9 @@ class TestObs(BaseValidationTest):
         )
 
         # Not a valid child
-        self.validator.adata.obs["assay_ontology_term_id"][0] = "EFO:0000001"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "assay_ontology_term_id"
+        ] = "EFO:0000001"
         self.validator.errors = []
         self.validator.validate_adata()
         self.assertEqual(
@@ -291,7 +298,9 @@ class TestObs(BaseValidationTest):
         )
 
         # Includes extraneous text
-        self.validator.adata.obs["assay_ontology_term_id"][0] = "EFO:0010183 (sci-plex)"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "assay_ontology_term_id"
+        ] = "EFO:0010183 (sci-plex)"
         self.validator.errors = []
         self.validator.validate_adata()
         self.assertEqual(
@@ -308,7 +317,9 @@ class TestObs(BaseValidationTest):
         """
 
         # Not a valid term
-        self.validator.adata.obs["cell_type_ontology_term_id"][0] = "EFO:0000001"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "cell_type_ontology_term_id"
+        ] = "EFO:0000001"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -326,9 +337,11 @@ class TestObs(BaseValidationTest):
         this MUST be the most accurate HsapDv term.
         """
 
-        self.validator.adata.obs["organism_ontology_term_id"][0] = "NCBITaxon:9606"
-        self.validator.adata.obs["development_stage_ontology_term_id"][
-            0
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "organism_ontology_term_id"
+        ] = "NCBITaxon:9606"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "development_stage_ontology_term_id"
         ] = "EFO:0000001"
         self.validator.validate_adata()
         self.assertEqual(
@@ -346,11 +359,16 @@ class TestObs(BaseValidationTest):
         this MUST be the most accurate MmusDv term
         """
 
-        self.validator.adata.obs["organism_ontology_term_id"][0] = "NCBITaxon:10090"
-        self.validator.adata.obs["development_stage_ontology_term_id"][
-            0
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "organism_ontology_term_id"
+        ] = "NCBITaxon:10090"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "development_stage_ontology_term_id"
         ] = "EFO:0000001"
-        self.validator.adata.obs["self_reported_ethnicity_ontology_term_id"][0] = "na"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0],
+            "self_reported_ethnicity_ontology_term_id",
+        ] = "na"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -368,11 +386,16 @@ class TestObs(BaseValidationTest):
         """
 
         # Fail case not an UBERON term
-        self.validator.adata.obs["organism_ontology_term_id"][0] = "NCBITaxon:10114"
-        self.validator.adata.obs["development_stage_ontology_term_id"][
-            0
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "organism_ontology_term_id"
+        ] = "NCBITaxon:10114"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "development_stage_ontology_term_id"
         ] = "EFO:0000001"
-        self.validator.adata.obs["self_reported_ethnicity_ontology_term_id"][0] = "na"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0],
+            "self_reported_ethnicity_ontology_term_id",
+        ] = "na"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -387,11 +410,16 @@ class TestObs(BaseValidationTest):
         # All other it MUST be children of UBERON:0000105 and not UBERON:0000071
         # Fail case UBERON:0000071
         self.validator.errors = []
-        self.validator.adata.obs["organism_ontology_term_id"][0] = "NCBITaxon:10114"
-        self.validator.adata.obs["development_stage_ontology_term_id"][
-            0
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "organism_ontology_term_id"
+        ] = "NCBITaxon:10114"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "development_stage_ontology_term_id"
         ] = "UBERON:0000071"
-        self.validator.adata.obs["self_reported_ethnicity_ontology_term_id"][0] = "na"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0],
+            "self_reported_ethnicity_ontology_term_id",
+        ] = "na"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -411,7 +439,9 @@ class TestObs(BaseValidationTest):
         """
 
         # Invalid ontology
-        self.validator.adata.obs["disease_ontology_term_id"][0] = "EFO:0000001"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "disease_ontology_term_id"
+        ] = "EFO:0000001"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -423,7 +453,9 @@ class TestObs(BaseValidationTest):
 
         # Invalid PATO term id
         self.validator.errors = []
-        self.validator.adata.obs["disease_ontology_term_id"][0] = "PATO:0001894"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "disease_ontology_term_id"
+        ] = "PATO:0001894"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -444,9 +476,12 @@ class TestObs(BaseValidationTest):
 
         # If organism_ontolology_term_id is "NCBITaxon:9606" for Homo sapiens,
         # this MUST be either a HANCESTRO term, "multiethnic", or "unknown" if unavailable.
-        self.validator.adata.obs["organism_ontology_term_id"][0] = "NCBITaxon:9606"
-        self.validator.adata.obs["self_reported_ethnicity_ontology_term_id"][
-            0
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "organism_ontology_term_id"
+        ] = "NCBITaxon:9606"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0],
+            "self_reported_ethnicity_ontology_term_id",
         ] = "EFO:0000001"
         self.validator.validate_adata()
         self.assertEqual(
@@ -463,12 +498,15 @@ class TestObs(BaseValidationTest):
         # development_stage_ontology_term_id has to be set to an appropriate mouse term id, otherwise there
         # will be an error in that field.
         self.validator.errors = []
-        self.validator.adata.obs["organism_ontology_term_id"][0] = "NCBITaxon:10090"
-        self.validator.adata.obs["development_stage_ontology_term_id"][
-            0
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "organism_ontology_term_id"
+        ] = "NCBITaxon:10090"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "development_stage_ontology_term_id"
         ] = "MmusDv:0000003"
-        self.validator.adata.obs["self_reported_ethnicity_ontology_term_id"][
-            0
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0],
+            "self_reported_ethnicity_ontology_term_id",
         ] = "EFO:0000001"
         self.validator.validate_adata()
         self.assertEqual(
@@ -489,9 +527,16 @@ class TestObs(BaseValidationTest):
         # Setting "organism_ontology_term_id" to "EFO:0000001" is the fail case. However since this represents neither
         # human nor mouse, then two other columns that are dependent on it need to be set appropriately to avoid
         # other error messages: "development_stage_ontology_term_id" and "self_reported_ethnicity_ontology_term_id"
-        self.validator.adata.obs["organism_ontology_term_id"][0] = "EFO:0000001"
-        self.validator.adata.obs["development_stage_ontology_term_id"][0] = "unknown"
-        self.validator.adata.obs["self_reported_ethnicity_ontology_term_id"][0] = "na"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "organism_ontology_term_id"
+        ] = "EFO:0000001"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "development_stage_ontology_term_id"
+        ] = "unknown"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0],
+            "self_reported_ethnicity_ontology_term_id",
+        ] = "na"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -508,7 +553,9 @@ class TestObs(BaseValidationTest):
         that this cell was derived from, depending on the type of biological sample:
         """
 
-        self.validator.adata.obs["tissue_ontology_term_id"][0] = "EFO:0000001"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "tissue_ontology_term_id"
+        ] = "EFO:0000001"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -524,8 +571,8 @@ class TestObs(BaseValidationTest):
         Cell Culture - MUST be a CL term appended with " (cell culture)"
         """
 
-        self.validator.adata.obs["tissue_ontology_term_id"][
-            0
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "tissue_ontology_term_id"
         ] = "CL:0000057 (CELL culture)"
         self.validator.validate_adata()
         self.assertEqual(
@@ -542,7 +589,9 @@ class TestObs(BaseValidationTest):
         Organoid - MUST be an UBERON term appended with " (organoid)"
         """
 
-        self.validator.adata.obs["tissue_ontology_term_id"][0] = "CL:0000057 (ORGANOID)"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "tissue_ontology_term_id"
+        ] = "CL:0000057 (ORGANOID)"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -559,7 +608,9 @@ class TestObs(BaseValidationTest):
         This MUST be a child of PATOPATO:0001894 for phenotypic sex or "unknown" if unavailable
         """
 
-        self.validator.adata.obs["sex_ontology_term_id"][0] = "EFO:0000001"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "sex_ontology_term_id"
+        ] = "EFO:0000001"
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -660,8 +711,12 @@ class TestObs(BaseValidationTest):
                 self.validator.warnings = []
 
                 invalid_suspension_type = "na"
-                self.validator.adata.obs["suspension_type"][1] = invalid_suspension_type
-                self.validator.adata.obs["assay_ontology_term_id"][1] = assay
+                self.validator.adata.obs.loc[
+                    self.validator.adata.obs.index[1], "suspension_type"
+                ] = invalid_suspension_type
+                self.validator.adata.obs.loc[
+                    self.validator.adata.obs.index[1], "assay_ontology_term_id"
+                ] = assay
                 self.validator.validate_adata()
                 self.assertEqual(
                     self.validator.errors,
@@ -702,8 +757,12 @@ class TestObs(BaseValidationTest):
                     ] = self.validator.adata.obs[
                         "suspension_type"
                     ].cat.remove_unused_categories()
-                self.validator.adata.obs["assay_ontology_term_id"][1] = assay
-                self.validator.adata.obs["suspension_type"][1] = invalid_suspension_type
+                self.validator.adata.obs.loc[
+                    self.validator.adata.obs.index[1], "assay_ontology_term_id"
+                ] = assay
+                self.validator.adata.obs.loc[
+                    self.validator.adata.obs.index[1], "suspension_type"
+                ] = invalid_suspension_type
                 self.validator.validate_adata()
                 self.assertEqual(
                     self.validator.errors,
@@ -720,10 +779,12 @@ class TestObs(BaseValidationTest):
         values depend on the assay_ontology_term_id. MUST support matching against ancestor term rules if specified.
         """
         with self.subTest("failure"):
-            self.validator.adata.obs["assay_ontology_term_id"][
-                0
+            self.validator.adata.obs.loc[
+                self.validator.adata.obs.index[0], "assay_ontology_term_id"
             ] = "EFO:0030008"  # child of EFO:0009294
-            self.validator.adata.obs["suspension_type"][0] = "nucleus"
+            self.validator.adata.obs.loc[
+                self.validator.adata.obs.index[0], "suspension_type"
+            ] = "nucleus"
 
             self.validator.validate_adata()
             self.assertEqual(
@@ -736,8 +797,8 @@ class TestObs(BaseValidationTest):
             )
 
         with self.subTest("success"):
-            self.validator.adata.obs["assay_ontology_term_id"][
-                0
+            self.validator.adata.obs.loc[
+                self.validator.adata.obs.index[0], "assay_ontology_term_id"
             ] = "EFO:0008904"  # child of EFO:0007045
             self.validator.adata.obs["suspension_type"][0] = "nucleus"
 
@@ -752,7 +813,9 @@ class TestObs(BaseValidationTest):
         suspension_id categorical with str categories. This field MUST be "cell", "nucleus", or "na". The allowed
         values depend on the assay_ontology_term_id. MUST warn if the corresponding assay is not recognized.
         """
-        self.validator.adata.obs["assay_ontology_term_id"][1] = "EFO:0010183"
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[1], "assay_ontology_term_id"
+        ] = "EFO:0010183"
         self.validator.validate_adata()
         with self.subTest("no errors"):
             self.assertEqual(self.validator.errors, [])
@@ -813,7 +876,9 @@ class TestObs(BaseValidationTest):
         """
         NaN values should not be allowed in dataframes
         """
-        self.validator.adata.obs["tissue_ontology_term_id"][0] = numpy.nan
+        self.validator.adata.obs.loc[
+            self.validator.adata.obs.index[0], "tissue_ontology_term_id"
+        ] = numpy.nan
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -250,7 +250,7 @@ class TestSeuratConvertibility(unittest.TestCase):
     def test_determine_seurat_convertibility(self):
         # Sparse matrix with too many nonzero values is not Seurat-convertible
         sparse_matrix_too_large = sparse.csr_matrix(
-            np.ones((good_obs.shape[0], good_var.shape[0]))
+            np.ones((good_obs.shape[0], good_var.shape[0]), dtype=np.float32)
         )
         self.validation_helper(sparse_matrix_too_large)
         self.validator._validate_seurat_convertibility()
@@ -259,7 +259,7 @@ class TestSeuratConvertibility(unittest.TestCase):
 
         # Reducing nonzero count by 1, to within limit, makes it Seurat-convertible
         sparse_matrix_with_zero = sparse.csr_matrix(
-            np.ones((good_obs.shape[0], good_var.shape[0]))
+            np.ones((good_obs.shape[0], good_var.shape[0]), dtype=np.float32)
         )
         sparse_matrix_with_zero[0, 0] = 0
         self.validation_helper(sparse_matrix_with_zero)
@@ -268,7 +268,9 @@ class TestSeuratConvertibility(unittest.TestCase):
         self.assertTrue(self.validator.is_seurat_convertible)
 
         # Dense matrices with a dimension that exceeds limit will fail -- zeros are irrelevant
-        dense_matrix_with_zero = np.zeros((good_obs.shape[0], good_var.shape[0]))
+        dense_matrix_with_zero = np.zeros(
+            (good_obs.shape[0], good_var.shape[0]), dtype=np.float32
+        )
         self.validation_helper(dense_matrix_with_zero)
         self.validator.schema_def["max_size_for_seurat"] = 2**2 - 1
         self.validator._validate_seurat_convertibility()
@@ -276,7 +278,7 @@ class TestSeuratConvertibility(unittest.TestCase):
         self.assertFalse(self.validator.is_seurat_convertible)
 
         # Dense matrices with dimensions in bounds but total count over will succeed
-        dense_matrix = np.ones((good_obs.shape[0], good_var.shape[0]))
+        dense_matrix = np.ones((good_obs.shape[0], good_var.shape[0]), dtype=np.float32)
         self.validation_helper(dense_matrix)
         self.validator.schema_def["max_size_for_seurat"] = 2**3 - 1
         self.validator._validate_seurat_convertibility()


### PR DESCRIPTION
Fixes #399

Primary change: significantly reduce memory use when validating CSR-formatted data. The `X` and `raw.X` are read incrementally, in chunks, dramatically reducing memory usage. Dense data is run in backed mode, and should also see reduced memory use. CSC is still loaded into memory as before, and has no change.

Changes:
* revise Validator() to use backed mode when reading AnnData
* incrementally compute over `X` and `raw.X`
* reformat validate.py to conform with repo Python style configuration
* clean up debt in tests related to Pandas and AnnData

Old and new code was compared:
* there is a slight performance penalty (less than 10%) for using backed mode on small to mid-sized datasets
* large CSR datasets now complete without an OOM failure (or excessive swapping).  This was tested to datasets significantly exceeding the size of main memory (eg., a 500GiB+ H5AD on a 64GiB machine with no swap).

Notes for reviewers:
* some of the logic in sparse determination and nnz counting was potentially a bit off - eg., how NaN is handled, or some of the manual calculation of sparsity differentiating between explicitly and implicitly stored zeros. The PR leaves the logic identical to the previous version (or at least that is my intent).
* the vast majority of AnnData datasets are CSR