### PR TITLE
chore: update curator notebooks for new explicit id field names and version ids

### DIFF
--- a/notebooks/curation_api/R/create_collection_R.ipynb
+++ b/notebooks/curation_api/R/create_collection_R.ipynb
@@ -186,7 +186,7 @@
     ")\n",
     "stop_for_status(res)\n",
     "res_content <- content(res)\n",
-    "collection_id <- res_content$id\n",
+    "collection_id <- res_content$collection_id\n",
     "print(\"New private Collection id:\")\n",
     "print(collection_id)\n",
     "print(\"New private Collection url:\")\n",

--- a/notebooks/curation_api/R/create_dataset_R.ipynb
+++ b/notebooks/curation_api/R/create_dataset_R.ipynb
@@ -168,7 +168,7 @@
     "res <- POST(url=url, add_headers(`Authorization`=bearer_token, `Content-Type`=\"application/json\"))\n",
     "stop_for_status(res)\n",
     "res_content <- content(res)\n",
-    "dataset_id <- res_content$id\n",
+    "dataset_id <- res_content$dataset_id\n",
     "print(str_interp(\"New empty Dataset with id ${dataset_id} in Collection at url:\"))\n",
     "print(str_interp(\"${site_url}/collections/${collection_id}\"))"
    ]

--- a/notebooks/curation_api/R/create_revision_R.ipynb
+++ b/notebooks/curation_api/R/create_revision_R.ipynb
@@ -168,7 +168,7 @@
     "res <- POST(url=url, add_headers(`Authorization`=bearer_token, `Content-Type`=\"application/json\"))\n",
     "stop_for_status(res)\n",
     "res_content <- content(res)\n",
-    "revision_id <- res_content$id\n",
+    "revision_id <- res_content$collection_id\n",
     "cat(\"Revision id:\\n\")\n",
     "cat(str_interp(\"${revision_id}\\n\"))\n",
     "cat(\"Revision url:\\n\")\n",

--- a/notebooks/curation_api/python/example_workflow.ipynb
+++ b/notebooks/curation_api/python/example_workflow.ipynb
@@ -289,22 +289,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for dataset in revision_info[\"datasets\"]:\n",
-    "    # Find revision Dataset that corresponds to the published version\n",
-    "    if dataset[\"original_id\"] == second_dataset_id:\n",
-    "        # Upload replacement datafile to the revision Dataset's id\n",
-    "        second_dataset_revision_id = dataset[\"id\"]\n",
-    "        upload_local_datafile(datafile_path, revision_id, second_dataset_revision_id)\n",
-    "        break"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "161994c1",
-   "metadata": {},
-   "source": [
-    "### Cancel the revision"
-   ]
+    "# Upload replacement datafile to the Dataset's id (same as in published collection) in the revision collection\n",
+    "upload_local_datafile(datafile_path, revision_id, second_dataset_id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "code",

--- a/notebooks/curation_api/python/src/collection.py
+++ b/notebooks/curation_api/python/src/collection.py
@@ -24,7 +24,7 @@ def create_collection(collection_form_metadata: dict) -> str:
     except requests.HTTPError as e:
         failure(logger, e)
         raise e
-    collection_id = data.get("id")
+    collection_id = data.get("collection_id")
     success(logger, f"New private Collection id:\n{collection_id}\n",
             f"New private Collection url:\n{format_c_url(collection_id)}")
     return collection_id
@@ -41,7 +41,7 @@ def create_revision(collection_id: str) -> str:
     except requests.HTTPError as e:
         failure(logger, e)
         raise e
-    revision_id = data.get("id")
+    revision_id = data.get("collection_id")
     success(logger, f"Revision id:\n{revision_id}\n",
             f"Revision url:\n{format_c_url(revision_id)}")
     return revision_id

--- a/notebooks/curation_api/python/src/dataset.py
+++ b/notebooks/curation_api/python/src/dataset.py
@@ -31,7 +31,7 @@ def create_dataset(collection_id: str):
     except requests.HTTPError as e:
         failure(logger, e)
         raise e
-    dataset_id = data["id"]
+    dataset_id = data["dataset_id"]
     success(logger, f"Created new Dataset {dataset_id} in the Collection at {format_c_url(collection_id)}")
     return dataset_id
 

--- a/notebooks/curation_api/python_raw/create_collection.ipynb
+++ b/notebooks/curation_api/python_raw/create_collection.ipynb
@@ -181,7 +181,7 @@
     "res = requests.post(url=url, json=collection_form_metadata, headers={\"Authorization\": bearer_token})\n",
     "res.raise_for_status()\n",
     "res_content = res.json()\n",
-    "collection_id = res_content[\"id\"]\n",
+    "collection_id = res_content[\"collection_id\"]\n",
     "print(\"New private Collection id:\")\n",
     "print(collection_id)\n",
     "print(\"New private Collection url:\")\n",

--- a/notebooks/curation_api/python_raw/create_dataset.ipynb
+++ b/notebooks/curation_api/python_raw/create_dataset.ipynb
@@ -171,7 +171,7 @@
     "res.raise_for_status()\n",
     "res_content = res.json()\n",
     "print(res_content)\n",
-    "dataset_id = res_content[\"id\"]\n",
+    "dataset_id = res_content[\"dataset_id\"]\n",
     "print(f\"New empty Dataset with id {dataset_id} in Collection at url:\")\n",
     "print(f\"{site_url}/collections/{collection_id}\")"
    ]

--- a/notebooks/curation_api/python_raw/create_revision.ipynb
+++ b/notebooks/curation_api/python_raw/create_revision.ipynb
@@ -166,7 +166,7 @@
     "res = requests.post(url=url, headers={\"Authorization\": bearer_token})\n",
     "res.raise_for_status()\n",
     "res_content = res.json()\n",
-    "revision_id = res_content[\"id\"]\n",
+    "revision_id = res_content[\"collection_id\"]\n",
     "print(\"Revision id:\")\n",
     "print(revision_id)\n",
     "print(\"Revision url:\")\n",


### PR DESCRIPTION
Changes:
- update id references in curator notebooks to reference explicit field names (collection_id, dataset_id)
- remove original_id usage (deprecated)