### PR TITLE
Don't copy the original anndata to write labels

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -382,7 +382,7 @@ class AnnDataLabelAppender:
         # Print errors if any
         if self.errors:
             for e, tb in self.errors:
-                logger.error(e, extra={"exec_info":tb})
+                logger.error(e, extra={"exec_info": tb})
             self.was_writing_successful = False
         else:
             self.was_writing_successful = True

--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -2,6 +2,7 @@ import logging
 import pandas as pd
 
 from typing import List, Dict, Optional
+import traceback
 
 from cellxgene_schema.validate import Validator, ONTOLOGY_CHECKER
 
@@ -30,11 +31,7 @@ class AnnDataLabelAppender:
                 "Validate AnnData first before attempting to write labels"
             )
 
-        if validator.adata.isbacked:
-            self.adata = validator.adata.to_memory()
-        else:
-            self.adata = validator.adata.copy()
-
+        self.adata = validator.adata
         self.validator = validator
         self.schema_def = validator.schema_def
         self.errors = []
@@ -379,13 +376,13 @@ class AnnDataLabelAppender:
         try:
             self.adata.write_h5ad(add_labels_file, compression="gzip")
         except Exception as e:
-            self.errors.append(f"Writing h5ad was unsuccessful, got exception '{e}'.")
+            tb = traceback.format_exc()
+            self.errors.append((f"Writing h5ad was unsuccessful, got exception '{e}'.", tb))
 
         # Print errors if any
         if self.errors:
-            self.errors = ["ERROR: " + i for i in self.errors]
-            for e in self.errors:
-                logger.error(e)
+            for e, tb in self.errors:
+                logger.error(e, extra={"exec_info":tb})
             self.was_writing_successful = False
         else:
             self.was_writing_successful = True

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -23,7 +23,7 @@ from fixtures.examples_validate import (
     good_uns,
     good_obsm,
     h5ad_valid,
-    h5ad_invalid
+    h5ad_invalid,
 )
 
 
@@ -107,7 +107,6 @@ class TestFieldValidation(unittest.TestCase):
 
 class TestAddLabelFunctions(unittest.TestCase):
     def setUp(self):
-
         # Set up test data
         self.test_adata = adata.copy()
         self.test_adata_with_labels = adata_with_labels
@@ -119,7 +118,6 @@ class TestAddLabelFunctions(unittest.TestCase):
         self.writer = AnnDataLabelAppender(validator)
 
     def test_get_dictionary_mapping_feature_id(self):
-
         # Good
         ids = [
             "ERCC-00002",
@@ -143,7 +141,6 @@ class TestAddLabelFunctions(unittest.TestCase):
             self.writer._get_mapping_dict_feature_id(ids)
 
     def test_get_dictionary_mapping_feature_reference(self):
-
         # Good
         ids = [
             "ERCC-00002",
@@ -169,7 +166,6 @@ class TestAddLabelFunctions(unittest.TestCase):
             self.writer._get_mapping_dict_feature_id(ids)
 
     def test_get_dictionary_mapping_curie(self):
-
         # Good
         ids = ["CL:0000066", "CL:0000192"]
         labels = ["epithelial cell", "smooth muscle cell"]
@@ -241,7 +237,6 @@ class TestIgnoreLabelFunctions(unittest.TestCase):
         self.test_adata_with_labels = adata_with_labels
 
     def test_validating_labeled_h5ad_should_fail_if_no_flag_set(self):
-
         validator = Validator()
         validator.adata = self.test_adata_with_labels
         is_valid = validator.validate_adata()
@@ -249,7 +244,6 @@ class TestIgnoreLabelFunctions(unittest.TestCase):
         self.assertFalse(is_valid)
 
     def test_validating_labeled_h5ad_should_pass_if_flag_set(self):
-
         validator = Validator(ignore_labels=True)
         validator.adata = copy.deepcopy(self.test_adata_with_labels)
         is_valid = validator.validate_adata()
@@ -278,9 +272,19 @@ class TestValidate(unittest.TestCase):
             self.assertListEqual(errors, [])
             self.assertTrue(is_seurat_convertible)
             self.assertTrue(os.path.exists(labels_path))
+            expected_hash = (
+                "55fbc095218a01cad33390f534d6690af0ecd6593f27d7cd4d26e91072ea8835"
+            )
+            actual_hash = self.hash_file(labels_path)
+            original_hash = self.hash_file(h5ad_valid)
+            self.assertNotEqual(
+                original_hash,
+                expected_hash,
+                "Writing labels did not change the dataset from the " "original.",
+            )
             self.assertEqual(
-                "55fbc095218a01cad33390f534d6690af0ecd6593f27d7cd4d26e91072ea8835",
-                self.hash_file(labels_path),
+                expected_hash,
+                actual_hash,
                 "The shape of the h5ad has changed. Check that the generated file is correct and update the new hash "
                 "to match.",
             )

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -233,7 +233,6 @@ class TestAddLabelFunctions(unittest.TestCase):
         self.assertTrue(self.writer.errors)
 
 
-
 class TestIgnoreLabelFunctions(unittest.TestCase):
     def setUp(self):
         # Set up test data


### PR DESCRIPTION
fixes #416 

- remove the copy of the anndata when writing labels. This is safe because the original dataset is open in read only mode. Any changes made to the datasets are only captured in memory. Those changes are then written out to a different files.
- add the stack trace to error collected when writing labels. This is to help debugging in the future.
- add missing tests
- add a test to verify the label h5ad is generated consistently. This is to verify that present and future changes don't accidentally change the labeled output file. 

# Testing
Ran validation and wrote labels with this [raw.h5ad](https://s3.console.aws.amazon.com/s3/buckets/corpora-data-dev?region=us-west-2&prefix=00a3fb7e-cd16-4ea1-b7b3-5e915061ffe2) and was able to produce a new h5ad that had the has the same sha256 hash as [local.h5ad](https://s3.console.aws.amazon.com/s3/buckets/corpora-data-dev?region=us-west-2&prefix=00a3fb7e-cd16-4ea1-b7b3-5e915061ffe2)

## script
```python
import logging
import hashlib

from cellxgene_schema.validate import validate

logging.basicConfig(level=logging.INFO)

raw_file = "../raw.h5ad"
original_labeled_file = "../local.h5ad"
new_labeled_file = "../new.h5ad"


def hash(file_name):
    with open(file_name, 'rb') as f:
        # Read the contents of the file in chunks
        chunk_size = 1024
        hasher = hashlib.sha256()
        while chunk := f.read(chunk_size):
            hasher.update(chunk)
    return hasher.hexdigest()

if __name__ == "__main__":
    validate(raw_file, new_labeled_file)

    original_hash = hash(original_labeled_file)
    new_hash = hash(new_labeled_file)
    raw_hash = hash(raw_file)

    assert original_hash == new_hash
    assert new_hash != raw_hash

    print(f"raw hash: {raw_hash}")
    print(f"org hash: {original_hash}")
    print(f"new hash: {new_hash}")
```

## output
```
INFO:cellxgene_schema.validate:Starting validation...
WARNING:cellxgene_schema.validate:WARNING: Dataframe 'var' only has 136 rows. Features SHOULD NOT be filtered from expression matrix.
INFO:cellxgene_schema.validate:Validation complete in 0:00:00.293064 with status is_valid=True
INFO:cellxgene_schema.write_labels:Writing labels
INFO:cellxgene_schema.validate:H5AD label writing complete in 0:00:00.297082, was_writing_successful: True
raw hash: 8ff3e4f5b595ef0d2a2fe4351ed4162b2dea65a1c38ea1adfaa0ba61eae9cdde
org hash: 55fbc095218a01cad33390f534d6690af0ecd6593f27d7cd4d26e91072ea8835
new hash: 55fbc095218a01cad33390f534d6690af0ecd6593f27d7cd4d26e91072ea8835
```
