### PR TITLE
chore: proposed 'convert' script Template [DO NOT MERGE]

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -80,16 +80,18 @@ def remove_labels(input_file, output_file):
 
 @click.command(
     name="convert",
-    short_help="Convert an h5ad from version 2.0.0 to version 3.0.0",
-    help="Convert an h5ad from version 2.0.0 to version 3.0.0. No validation will be performed on either"
+    short_help="Convert an h5ad to the latest schema version.",
+    help="Convert an h5ad to the latest schema version. No validation will be performed on either"
     "the input or the output file.",
 )
 @click.argument("input_file", nargs=1, type=click.Path(exists=True, dir_okay=False))
 @click.argument("output_file", nargs=1, type=click.Path(exists=False, dir_okay=False))
-def convert(input_file, output_file):
+@click.option("--collection_id", default=None, type=str, help="Collection ID, if converting already published dataset")
+@click.option("--dataset_id", default=None, type=str, help="Dataset ID, if converting already published dataset")
+def convert(input_file, output_file, collection_id, dataset_id):
     from .convert import convert
 
-    convert(input_file, output_file)
+    convert(input_file, output_file, collection_id, dataset_id)
 
 
 schema_cli.add_command(schema_validate)

--- a/cellxgene_schema_cli/cellxgene_schema/convert.py
+++ b/cellxgene_schema_cli/cellxgene_schema/convert.py
@@ -2,150 +2,89 @@ import anndata as ad
 import numpy as np
 
 from . import ontology
-from .remove_labels import AnnDataLabelRemover
+from . import utils
 
 
-def convert(input_file, output_file):
+def convert(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file)
 
-    # Rename ethnicity_ontology_term_id field
-    dataset.obs.rename(
-        columns={"ethnicity_ontology_term_id": "self_reported_ethnicity_ontology_term_id"},
-        inplace=True,
-    )
+    # Set schema version
+    dataset.uns["schema_version"] = "3.1.0"
 
-    # Set schema version to 3.0.0
-    dataset.uns["schema_version"] = "3.0.0"
+    # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
+    # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
 
-    # Remove Deprecated uns Fields
-    deprecated_uns_fields = [
-        "X_normalization",
-        "default_field",
-        "layer_descriptions",
-        "tags",
-        "version",
-        "contributors",
-        "preprint_doi",
-        "project_description",
-        "project_links",
-        "project_name",
-        "publication_doi",
-    ]
-    for field in deprecated_uns_fields:
-        if field in dataset.uns:
-            del dataset.uns[field]
+    # Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
+    # 'Replaced By' is not available for a deprecated term.
 
-    # remove labels that are meant to be added by data portal
-    anndata_label_remover = AnnDataLabelRemover(dataset)
-    anndata_label_remover.remove_labels()
-    dataset = anndata_label_remover.adata
-
-    # remove 'ethnicity' label (needs to be done separately since its no longer in the schema definition)
-    if "ethnicity" in dataset.obs:
-        del dataset.obs["ethnicity"]
-
-    # Update deprecated ontologies with known direct replacements
-    disease_ontology_update_map = {
-        "MONDO:0008345": "MONDO:0800029",
-        "MONDO:0004553": "MONDO:0017853",
-    }
-    cell_type_ontology_update_map = {
-        "CL:0002609": "CL:0010012",
-        "CL:0011107": "CL:0000636",
-    }
-    assay_ontology_update_map = {
-        "EFO:0030002 (BD Rhapsody)": "EFO:0700003",
-        "EFO:0010183 (BD Rhapsody)": "EFO:0700003",
+    # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
+    # add them here.
+    ontology_term_maps = {
+        "assay": {
+            "EFO:0030002 (BD Rhapsody)": "EFO:0700003",  # AUTOMATED
+            "EFO:0010183 (BD Rhapsody)": "EFO:0700003",  # AUTOMATED
+        },
+        "cell_type": {
+            "CL:0002609": "CL:0010012",  # AUTOMATED
+            "CL:0011107": "CL:0000636",  # Curator-added (demonstrative example, curators do not need to annotate)
+        },
+        "development_stage": {},
+        "disease": {
+            "MONDO:0008345": "MONDO:0800029",  # Curator-added (demonstrative example, curators do not need to annotate)
+        },
+        "organism": {},
+        "self_reported_ethnicity": {},
+        "sex": {},
+        "tissue": {},
     }
 
-    def update_categorical_column_vals(dataframe, column_name, update_map):
-        if dataframe[column_name].dtype != "category":
-            dataframe[column_name] = dataframe[column_name].astype("category")
-        for deprecated_term, new_term in update_map.items():
-            if deprecated_term in dataframe[column_name].cat.categories:
-                # add new one if not already in category, else continue
-                if new_term not in dataframe[column_name].cat.categories:
-                    dataframe[column_name] = dataframe[column_name].cat.add_categories(new_term)
-                # replace in dataset
-                dataframe.loc[dataframe[column_name] == deprecated_term, column_name] = new_term
-                # remove deprecated_term from category
-                dataframe[column_name] = dataframe[column_name].cat.remove_categories(deprecated_term)
+    # AUTOMATED, DO NOT CHANGE
+    for ontology_name, deprecated_term_map in ontology_term_maps.items():
+        utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
 
-    update_categorical_column_vals(dataset.obs, "disease_ontology_term_id", disease_ontology_update_map)
-    update_categorical_column_vals(dataset.obs, "cell_type_ontology_term_id", cell_type_ontology_update_map)
-    update_categorical_column_vals(dataset.obs, "assay_ontology_term_id", assay_ontology_update_map)
+    # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES
+    # Use the template below to define dataset and collection specific ontology changes. Will only apply to dataset
+    # if it matches a condition.
+    # If no such changes are needed, leave blank
 
-    # Set suspension type
+    # if dataset_id == "<dataset_1_id>":
+    #   <no further logic necessary>
+    #   utils.replace_ontology_term(df, <ontology_name>, {"term_to_replace": "replacement_term", ...})
+    # elif dataset_id == "<dataset_2_id>":
+    #   <custom transformation logic beyond scope of util functions>
+    # elif collection_id == "<collection_1_id>":
+    #   <no further logic necessary>
+    #   utils.replace_ontology_term(df, <ontology_name>, {"term_to_replace": "replacement_term", ...})
+    # elif collection_id == "<collection_2_id>":
+    #   <custom transformation logic beyond scope of replace_ontology_term>
+    # ...
 
-    # mappings of assays (or assays + child term assays) to corresponding suspension_type
-    # valid assays with multiple possible suspension_types shown but commented out
-    match_assays = {
-        # 'EFO:0010010': ['cell', 'nucleus'],
-        "EFO:0008720": "nucleus",
-        # 'EFO:0008722': ['cell', 'nucleus'], ,
-        "EFO:0030002": "cell",
-        "EFO:0008853": "cell",
-        "EFO:0030026": "nucleus",
-        # 'EFO:0010550': ['cell', 'nucleus'],
-        "EFO:0008919": "cell",
-        "EFO:0008939": "nucleus",
-        "EFO:0030027": "nucleus",
-    }
+    # Example Curator Input
+    df = dataset.obs
+    if collection_id == "a48f5033-3438-4550-8574-cdff3263fdfd":
+        utils.replace_ontology_term(df, "assay", {"EFO:0008913": "EFO:0700010"})
+    elif dataset_id == "5cdbb2ea-c622-466d-9ead-7884ad8cb99f":
+        utils.replace_ontology_term(df, "cell_type", {"CL:0000561": "CL:4030027"})
+    elif dataset_id == "f8c77961-67a7-4161-b8c2-61c3f917b54f":
+        df["cell_type_ontology_term_id"] = df["cell_type_ontology_term_id"].cat.add_categories("CL:0004219")
+        df.loc[
+            (df['author_cell_type'] == "1.0") & (df['cell_type_ontology_term_id'] == "CL:0000561"),
+            "cell_type_ontology_term_id"
+        ] = "CL:0004219"
 
-    match_assays_or_children = {
-        # 'EFO:0030080': ['cell', 'nucleus'],
-        "EFO:0007045": "nucleus",
-        "EFO:0009294": "cell",
-        # 'EFO:0010184': ['cell', 'nucleus'],
-        "EFO:0009918": "na",
-        "EFO:0700000": "na",
-        "EFO:0030005": "na",
-    }
+        df.loc[
+            (df['author_cell_type'] == "5.0") & (df['cell_type_ontology_term_id'] == "CL:0000561"),
+            "cell_type_ontology_term_id"
+        ] = "CL:4030028"
 
-    ontology_checker = ontology.OntologyChecker()
+        df.loc[
+            (df['author_cell_type'] == "11.0") & (df['cell_type_ontology_term_id'] == "CL:0000561"),
+            "cell_type_ontology_term_id"
+        ] = "CL:0004232"
 
-    def assign_suspension_type(item):
-        if item in match_assays:
-            return match_assays[item]
-        else:
-            for k, v in match_assays_or_children.items():
-                try:
-                    if k == item or ontology_checker.is_descendent_of("EFO", item, k):
-                        return v
-                except Exception:
-                    return np.nan
-        return np.nan
+    # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
+    # No Changes
 
-    if "suspension_type" not in dataset.obs:
-        print("column 'suspension_type' not found in obs. Adding column and auto-assigning value where possible.")
-        suspension_type_map = {}
-        if dataset.obs["assay_ontology_term_id"].dtype != "category":
-            dataset.obs.loc[:, ["assay_ontology_term_id"]] = dataset.obs.astype("category")
-        for item in dataset.obs["assay_ontology_term_id"].cat.categories:
-            suspension_type_map[item] = assign_suspension_type(item)
-            if np.isnan(suspension_type_map[item]):
-                print(
-                    f"Dataset contains row(s) with assay_ontology_term_id {item}. These cannot be auto-assigned a "
-                    f"suspension type, please assign a suspension_type manually and validate."
-                )
-            else:
-                print(
-                    f"Dataset contains row(s) with assay_ontology_term_id {item}. "
-                    f"Automatically assigned suspension_type {suspension_type_map[item]}"
-                )
-        dataset.obs["suspension_type"] = dataset.obs.apply(
-            lambda row: suspension_type_map.get(row.assay_ontology_term_id), axis=1
-        )
-        dataset.obs.loc[:, ["suspension_type"]] = dataset.obs.astype("category")
-    else:
-        if dataset.obs["suspension_type"].dtype != "category":
-            dataset.obs.loc[:, ["suspension_type"]] = dataset.obs.astype("category")
-        print(f"suspension_type already exists in obs, with categories {dataset.obs['suspension_type'].cat.categories}")
-
-    print(
-        f"Automatable conversions completed. Please run 'cellxgene-schema validate {output_file}' to check for "
-        f"required manual changes, if any."
-    )
     dataset.write(output_file, compression="gzip")

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -1,0 +1,14 @@
+
+def replace_ontology_term(dataframe, ontology_name, update_map):
+    column_name = f"{ontology_name}_ontology_term_id"
+    if dataframe[column_name].dtype != "category":
+        dataframe[column_name] = dataframe[column_name].astype("category")
+    for old_term, new_term in update_map.items():
+        if old_term in dataframe[column_name].cat.categories:
+            # add new one if not already in category, else continue
+            if new_term not in dataframe[column_name].cat.categories:
+                dataframe[column_name] = dataframe[column_name].cat.add_categories(new_term)
+            # replace in dataset
+            dataframe.loc[dataframe[column_name] == old_term, column_name] = new_term
+            # remove deprecated_term from category
+            dataframe[column_name] = dataframe[column_name].cat.remove_categories(old_term)


### PR DESCRIPTION
- Proposed template for 'convert' script 
- Concept: During a schema version migration, the 'convert' command will be called against every public dataset in the corpus. It will encompass both general changes that must apply to every dataset in the corpus, and bespoke changes to specific collections/datasets. 
- An automated process will pre-populate a 'convert' command with any deterministic ontology term replacements + some necessary boilerplate and commented instructions. 
- Curators will then add to this PR (if necessary) to include non-deterministic changes like those tracked [here](https://github.com/chanzuckerberg/single-cell-curation/issues/373) or those flagged as needing Curator intervention in the proposed monthly ontology update deprecated terms report. 
- Once ready, Curator + On-call Engineer will approve PR, and the On-Call Engineer will merge + cut a new cellxgene-schema release and kick off an automated corpus migration. 

- The changes to the cli and utils files are one-time changes, not part of the proposed monthly automation
- We can discuss whether there are more useful 'util' functions to add for common dataframe transformation patterns; so far I only included one that I found useful. 

NOT INCLUDED in this demo but part of the proposed workflow: 
- updated ontology pinned files 
- updated downloaded ontologies