### PR TITLE
demo: end-to-end ontology curator report workflow

### DIFF
--- a/.github/workflows/ontology_bump_dry_run.yml
+++ b/.github/workflows/ontology_bump_dry_run.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - demo # temp for dev testing and demos
     paths:
       - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/all_ontology.json.gz'
 

--- a/.github/workflows/ontology_process.yml
+++ b/.github/workflows/ontology_process.yml
@@ -7,6 +7,7 @@ on:
       - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/owl_info.yml'
     branches-ignore:
       - main
+      - demo # temp for dev testing and demos
 
 jobs:
   ontology-processing:

--- a/cellxgene_schema_cli/cellxgene_schema/ontology_files/owl_info.yml
+++ b/cellxgene_schema_cli/cellxgene_schema/ontology_files/owl_info.yml
@@ -1,20 +1,23 @@
 CL:
-  latest: 2022-09-15
+  latest: 2023-04-20
   urls:
+    2023-04-20: https://github.com/obophenotype/cell-ontology/releases/download/v2023-04-20/cl.owl
     2022-09-15: https://github.com/obophenotype/cell-ontology/raw/v2022-09-15/cl.owl
     2022-06-18: https://github.com/obophenotype/cell-ontology/raw/v2022-06-18/cl.owl
     2021-08-10: https://github.com/obophenotype/cell-ontology/raw/v2021-08-10/cl.owl
     2021-06-21: https://github.com/obophenotype/cell-ontology/raw/v2021-06-21/cl.owl
 EFO:
-  latest: 2022-09-15 EFO 3.46.0
+  latest: 2023-05-15 EFO 3.54.0
   urls:
+    2023-05-15 EFO 3.54.0: https://github.com/EBISPOT/efo/releases/download/v3.54.0/efo.owl
     2022-09-15 EFO 3.46.0: https://github.com/EBISPOT/efo/releases/download/v3.46.0/efo.owl
     2022-07-18 EFO 3.44.0: https://github.com/EBISPOT/efo/releases/download/v3.44.0/efo.owl
     2021-08-16 EFO 3.33.0: https://github.com/EBISPOT/efo/releases/download/v3.33.0/efo.owl
     2021-06-15 EFO 3.31.0: https://github.com/EBISPOT/efo/releases/download/v3.31.0/efo.owl
 HANCESTRO:
-  latest: 2022-07-18 (2.6)
+  latest: 2023-02-16 (2.7)
   urls:
+    2023-02-16 (2.7): https://github.com/EBISPOT/ancestro/raw/2.7/hancestro.owl
     2022-07-18 (2.6): https://github.com/EBISPOT/ancestro/raw/2.6/hancestro.owl
     2021-01-04 (2.5): https://github.com/EBISPOT/ancestro/raw/2.5/hancestro.owl
 HsapDv:
@@ -23,8 +26,9 @@ HsapDv:
     2020-03-10: http://purl.obolibrary.org/obo/hsapdv.owl
     2016-07-06 (0.1): https://github.com/obophenotype/developmental-stage-ontologies/raw/0.1/src/hsapdv/hsapdv.owl
 MONDO:
-  latest: 2022-09-06
+  latest: 2023-05-01
   urls:
+    2023-05-01: https://github.com/monarch-initiative/mondo/releases/download/v2023-05-01/mondo.owl
     2022-09-06: https://github.com/monarch-initiative/mondo/releases/download/v2022-09-06/mondo.owl
     2022-07-01: https://github.com/monarch-initiative/mondo/releases/download/v2022-07-01/mondo.owl
     2021-08-11: https://github.com/monarch-initiative/mondo/releases/download/v2021-08-11/mondo.owl
@@ -35,22 +39,25 @@ MmusDv:
     2020-03-10: http://purl.obolibrary.org/obo/mmusdv.owl
     2016-07-06 (0.1): https://github.com/obophenotype/developmental-stage-ontologies/raw/0.1/src/mmusdv/mmusdv.owl
 NCBITaxon:
-  latest: 2022-06-28
+  latest: 2023-02-24
   urls:
+    2023-02-24: https://github.com/obophenotype/ncbitaxon/releases/download/v2023-02-24/ncbitaxon.owl.gz
     2022-06-28: https://github.com/obophenotype/ncbitaxon/releases/download/v2022-06-28/ncbitaxon.owl.gz
     2021-06-10: https://github.com/obophenotype/ncbitaxon/releases/download/v2021-06-10/ncbitaxon.owl.gz
   children_of:
     - NCBITaxon:33208
 UBERON:
-  latest: 2022-08-19
+  latest: 2023-04-19
   urls:
+    2023-04-19: https://github.com/obophenotype/uberon/releases/download/v2023-04-19/uberon.owl
     2022-08-19: https://github.com/obophenotype/uberon/releases/download/v2022-08-19/uberon.owl
     2022-06-30: https://github.com/obophenotype/uberon/releases/download/v2022-06-30/uberon.owl
     2021-07-27: https://github.com/obophenotype/uberon/raw/v2021-07-27/uberon.owl
     2021-02-12: https://github.com/obophenotype/uberon/raw/v2021-02-12/uberon.owl
 PATO:
-  latest: 2022-08-10
+  latest: 2023-02-17
   urls:
+    2023-02-17: https://github.com/pato-ontology/pato/raw/v2023-02-17/pato.owl
     2022-08-10: https://github.com/pato-ontology/pato/raw/v2022-08-10/pato.owl
     2022-07-21: https://github.com/pato-ontology/pato/raw/v2022-07-21/pato.owl
     2021-08-06: https://github.com/pato-ontology/pato/raw/v2021-08-06/pato.owl


### PR DESCRIPTION
Update all pinned ontologies (except HsapDv + MmusDv) to latest releases, for demo purposes. 