### PR TITLE
feat: standardize format of 'replaced_by' field in all_ontology.json

### DIFF
--- a/cellxgene_schema_cli/scripts/ontology_processing.py
+++ b/cellxgene_schema_cli/scripts/ontology_processing.py
@@ -1,6 +1,7 @@
 import gzip
 import json
 import os
+import re
 import sys
 import urllib.request
 from threading import Thread
@@ -151,8 +152,8 @@ def _parse_owls(
                 onto_dict[onto.name][term_id]["deprecated"] = True
                 if onto_class.IAO_0100001 and onto_class.IAO_0100001.first():
                     # url --> term
-                    ontology_term = str(onto_class.IAO_0100001[0]).split("/")[-1]
-                    onto_dict[onto.name][term_id]["replaced_by"] = ontology_term
+                    ontology_term = re.findall(r"[^\W_]+", str(onto_class.IAO_0100001[0]))
+                    onto_dict[onto.name][term_id]["replaced_by"] = f"{ontology_term[-2]}:{ontology_term[-1]}"
                 else:
                     if hasattr(onto_class, "consider") and onto_class.consider:
                         onto_dict[onto.name][term_id]["consider"] = [str(c) for c in onto_class.consider]

--- a/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
+++ b/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
@@ -76,7 +76,7 @@ def report_deprecated_terms(
                     if ontology["deprecated"]:
                         replaced_in_diff_ontology = False
                         if "replaced_by" in ontology:
-                            replacement_term_ontology = ontology["replaced_by"].split("_")[0]
+                            replacement_term_ontology = ontology["replaced_by"].split(":")[0]
                             if replacement_term_ontology != term_prefix:
                                 replaced_in_diff_ontology = True
                         if "replaced_by" not in ontology or replaced_in_diff_ontology:

--- a/schema_bump_dry_run_scripts/tests/fixtures/with_replaced_by_diff_ontology_expected
+++ b/schema_bump_dry_run_scripts/tests/fixtures/with_replaced_by_diff_ontology_expected
@@ -4,7 +4,7 @@ ALERT: Requires Manual Curator Intervention
 Collection ID: public_coll_0
 Dataset ID: public_ds_0
 Deprecated Term: EFO:0000006
-Replaced By: CL_0000006
+Replaced By: CL:0000006
 
 
 Deprecated Terms in Private Datasets:
@@ -13,14 +13,14 @@ ALERT: Requires Manual Curator Intervention
 Collection ID: private_coll_0
 Dataset ID: private_ds_0
 Deprecated Term: EFO:0000006
-Replaced By: CL_0000006
+Replaced By: CL:0000006
 
 ALERT: Requires Manual Curator Intervention
 Note--In A Revision of: public_coll_0
 Collection ID: public_coll_0_revision
 Dataset ID: public_ds_0
 Deprecated Term: EFO:0000006
-Replaced By: CL_0000006
+Replaced By: CL:0000006
 
 
 The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:

--- a/schema_bump_dry_run_scripts/tests/fixtures/with_replaced_by_expected
+++ b/schema_bump_dry_run_scripts/tests/fixtures/with_replaced_by_expected
@@ -3,7 +3,7 @@ Deprecated Terms in Public Datasets:
 Collection ID: public_coll_0
 Dataset ID: public_ds_0
 Deprecated Term: EFO:0000002
-Replaced By: EFO_0000001
+Replaced By: EFO:0000001
 
 
 Deprecated Terms in Private Datasets:
@@ -11,13 +11,13 @@ Deprecated Terms in Private Datasets:
 Collection ID: private_coll_0
 Dataset ID: private_ds_0
 Deprecated Term: EFO:0000002
-Replaced By: EFO_0000001
+Replaced By: EFO:0000001
 
 Note--In A Revision of: public_coll_0
 Collection ID: public_coll_0_revision
 Dataset ID: public_ds_0
 Deprecated Term: EFO:0000002
-Replaced By: EFO_0000001
+Replaced By: EFO:0000001
 
 
 The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:

--- a/schema_bump_dry_run_scripts/tests/test_ontology_bump_dry_run.py
+++ b/schema_bump_dry_run_scripts/tests/test_ontology_bump_dry_run.py
@@ -16,7 +16,7 @@ class TestOntologyBumpDryRun(TestCase):
                 "EFO:0000002": {
                     "label": "obsolete term with replacement",
                     "deprecated": True,
-                    "replaced_by": "EFO_0000001",
+                    "replaced_by": "EFO:0000001",
                 },
                 "EFO:0000003": {
                     "label": "obsolete term without replacement, with comment",
@@ -37,7 +37,7 @@ class TestOntologyBumpDryRun(TestCase):
                 "EFO:0000006": {
                     "label": "obsolete term with replacement from a different ontology",
                     "deprecated": True,
-                    "replaced_by": "CL_0000006",
+                    "replaced_by": "CL:0000006",
                 },
             }
         }


### PR DESCRIPTION
https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/4837

- Standardize all 'replaced_by' fields using the format "<term>:<ID>" during ontology file processing
- Update dry run script to parse replaced_by prefix term using consistent delimiter ":", defined in processing file
- Reprocess ontology file to pick up standardized replaced_by's