### PR TITLE
feat: generate diff between gencode releases when processing new GENCODE files

### DIFF
--- a/cellxgene_schema_cli/scripts/gene_processing.py
+++ b/cellxgene_schema_cli/scripts/gene_processing.py
@@ -1,3 +1,4 @@
+import csv
 import gzip
 import os
 import sys
@@ -169,9 +170,41 @@ def process_gene_info(gene_info: dict) -> None:
     """
     print("download", gene_info["description"])
     temp_file_path, _ = urllib.request.urlretrieve(gene_info["url"])
+    previous_ref_filepath = os.path.join(env.ONTOLOGY_DIR, f"previous_{gene_info['description']}.csv.gz")
+    os.rename(gene_info["new_file"], previous_ref_filepath)
     print("process", gene_info["description"])
     gene_info["processor"](temp_file_path, gene_info["new_file"])
+    generate_gene_ref_diff(gene_info["description"], gene_info["new_file"], previous_ref_filepath)
     print("finish", gene_info["description"])
+
+
+def generate_gene_ref_diff(output_filename: str, current_ref_filepath: str, previous_ref_filepath: str) -> None:
+    """
+    Compare the previous gene reference CSV to the newest generated CSV. Report a text file with every
+    Ensembl ID available in the previous gene reference CSV that is no longer found in the newest.
+    :param output_filename: Filename for output diff textfile
+    :param current_ref_filepath: Full filepath for the new processed gene csv
+    :param previous_ref_filepath: Full filepath for the previous processed gene csv
+    """
+    new_ref_gene_ids = set()
+    with gzip.open(current_ref_filepath, "rt") as f:
+        for row in csv.reader(f):
+            gene_id = row[0]
+            new_ref_gene_ids.add(gene_id)
+
+    removed_gene_ids = []
+    with gzip.open(previous_ref_filepath, "rt") as f:
+        for row in csv.reader(f):
+            gene_id = row[0]
+            if gene_id not in new_ref_gene_ids:
+                removed_gene_ids.append(gene_id)
+
+    diff_filepath = os.path.join(env.ONTOLOGY_DIR, f"{output_filename}_diff.txt")
+    with open(diff_filepath, "w") as f:
+        for gene_id in removed_gene_ids:
+            f.write(f"{gene_id}\n")
+
+    os.remove(previous_ref_filepath)
 
 
 def main():


### PR DESCRIPTION
https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/4814

- Output diff file will live where processed ontology files live. The 'migrate' script that will automate the 'Lattice Algorithm' for removing deprecated terms will be part of the cellxgene_schema_cli package as well.
- Only accounts for gene IDs that were 'deprecated' (i.e. ID appeared previously, no longer appears in new reference files). It does not detect IDs that changed