### PR TITLE
feat: update curation report to group reporting deprecated terms in datasets from the same collection

### DIFF
--- a/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
+++ b/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
@@ -56,8 +56,9 @@ def get_headers(base_url):
     return {"Authorization": f"Bearer {access_token}"}
 
 
-def map_deprecated_terms(curator_report_entry_map: dict, dataset: dict, collection_id: str, onto_map: dict,
-                         non_deprecated_term_cache: set) -> None:
+def map_deprecated_terms(
+    curator_report_entry_map: dict, dataset: dict, collection_id: str, onto_map: dict, non_deprecated_term_cache: set
+) -> None:
     """
     For a dataset, detects all deprecated ontology terms and, for each found, populates an entry in
     curator_report_entry_map with data required to report the deprecated term and any ontology-provided guidance
@@ -108,7 +109,7 @@ def map_deprecated_terms(curator_report_entry_map: dict, dataset: dict, collecti
                     non_deprecated_term_cache.add(ontology_term_id)
 
 
-def write_to_curator_report(output_file: str, curator_report_entry_map: dict, revision_map: dict=None) -> None:
+def write_to_curator_report(output_file: str, curator_report_entry_map: dict, revision_map: dict = None) -> None:
     """
     Writes curator report entries to output_file. Each entry reports a Collection ID, a Deprecated Term that has been
     detected in that collection, how many datasets are affected, and info derived from owl files that guide how to

--- a/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
+++ b/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
@@ -80,16 +80,16 @@ def map_deprecated_terms(curator_report_entry_map, dataset, collection_id, onto_
                         entry["needs_alert"] = False
                         entry["dataset_ct"] = 1
                         if "replaced_by" in ontology:
-                            entry["replaced_by"] = ontology['replaced_by']
+                            entry["replaced_by"] = ontology["replaced_by"]
                             replacement_term_ontology = ontology["replaced_by"].split(":")[0]
                             if replacement_term_ontology != term_prefix:
                                 entry["needs_alert"] = True
                         else:
                             entry["needs_alert"] = True
                             if "consider" in ontology:
-                                entry['consider'] = ontology['consider']
+                                entry["consider"] = ontology["consider"]
                             if "comments" in ontology:
-                                entry['comments'] = ontology['comments']
+                                entry["comments"] = ontology["comments"]
 
                         curator_report_entry_map[collection_id][ontology_term_id] = entry
                 else:
@@ -100,7 +100,7 @@ def write_to_curator_report(output_file, curator_report_entry_map, revision_map=
     with open(output_file, "a") as f:
         for collection_id in curator_report_entry_map.keys():
             for deprecated_term, entry in curator_report_entry_map[collection_id].items():
-                if entry['needs_alert']:
+                if entry["needs_alert"]:
                     f.write("ALERT: Requires Manual Curator Intervention\n")
                 f.write(f"Collection ID: {collection_id}\n")
                 if revision_map and collection_id in revision_map:
@@ -129,8 +129,9 @@ def dry_run(output_file):
         # for every dataset, check its ontology term metadata to see if any terms are deprecated. If so, report.
         f.write("Deprecated Terms in Public Datasets:\n\n")
     for dataset in datasets:
-        map_deprecated_terms(public_curator_report_entry_map, dataset, dataset["collection_id"], onto_map,
-                             non_deprecated_term_cache)
+        map_deprecated_terms(
+            public_curator_report_entry_map, dataset, dataset["collection_id"], onto_map, non_deprecated_term_cache
+        )
     write_to_curator_report(output_file, public_curator_report_entry_map)
 
     headers = get_headers(base_url)

--- a/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
+++ b/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
@@ -2,7 +2,6 @@
 import gzip
 import json
 import os
-
 from collections import defaultdict
 
 import requests
@@ -98,7 +97,7 @@ def map_deprecated_terms(curator_report_entry_map, dataset, collection_id, onto_
 
 def write_to_curator_report(output_file, curator_report_entry_map, revision_map=None):
     with open(output_file, "a") as f:
-        for collection_id in curator_report_entry_map.keys():
+        for collection_id in curator_report_entry_map:
             for deprecated_term, entry in curator_report_entry_map[collection_id].items():
                 if entry["needs_alert"]:
                     f.write("ALERT: Requires Manual Curator Intervention\n")

--- a/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
+++ b/schema_bump_dry_run_scripts/ontologies/ontology_bump_dry_run.py
@@ -3,6 +3,8 @@ import gzip
 import json
 import os
 
+from collections import defaultdict
+
 import requests
 
 BASE_API = {
@@ -55,46 +57,63 @@ def get_headers(base_url):
     return {"Authorization": f"Bearer {access_token}"}
 
 
-def report_deprecated_terms(
-    output_file, dataset, collection_id, onto_map, non_deprecated_term_cache, revision_of=False
-):
-    with open(output_file, "a") as f:
-        for ontology_type in ONTOLOGY_TYPES:
-            if ontology_type in dataset:
-                for ontology_term in dataset[ontology_type]:
-                    ontology_term_id = ontology_term["ontology_term_id"]
-                    if ontology_term_id in non_deprecated_term_cache:
-                        continue
-                    else:
-                        # all_ontologies is indexed by ontology prefix and term ID without suffixes,
-                        # so we must parse + build the search term
-                        ontology_id_parts = ontology_term_id.split(" ")[0].split(":")
-                        term_prefix = ontology_id_parts[0]
-                        ontology_index_id = f"{term_prefix}:{ontology_id_parts[1]}"
-                        ontology = onto_map[term_prefix][ontology_index_id]
+def map_deprecated_terms(curator_report_entry_map, dataset, collection_id, onto_map, non_deprecated_term_cache):
+    for ontology_type in ONTOLOGY_TYPES:
+        if ontology_type in dataset:
+            for ontology_term in dataset[ontology_type]:
+                ontology_term_id = ontology_term["ontology_term_id"]
+                if ontology_term_id in non_deprecated_term_cache:
+                    continue
+                else:
+                    # all_ontologies is indexed by ontology prefix and term ID without suffixes,
+                    # so we must parse + build the search term
+                    ontology_id_parts = ontology_term_id.split(" ")[0].split(":")
+                    term_prefix = ontology_id_parts[0]
+                    ontology_index_id = f"{term_prefix}:{ontology_id_parts[1]}"
+                    ontology = onto_map[term_prefix][ontology_index_id]
 
-                    if ontology["deprecated"]:
-                        replaced_in_diff_ontology = False
+                if ontology["deprecated"]:
+                    if ontology_term_id in curator_report_entry_map[collection_id]:
+                        curator_report_entry_map[collection_id][ontology_term_id]["dataset_ct"] += 1
+                    else:
+                        entry = dict()
+                        entry["needs_alert"] = False
+                        entry["dataset_ct"] = 1
                         if "replaced_by" in ontology:
+                            entry["replaced_by"] = ontology['replaced_by']
                             replacement_term_ontology = ontology["replaced_by"].split(":")[0]
                             if replacement_term_ontology != term_prefix:
-                                replaced_in_diff_ontology = True
-                        if "replaced_by" not in ontology or replaced_in_diff_ontology:
-                            f.write("ALERT: Requires Manual Curator Intervention\n")
-                        if revision_of:
-                            f.write(f"Note--In A Revision of: {revision_of}\n")
-                        f.write(f"Collection ID: {collection_id}\n")
-                        f.write(f"Dataset ID: {dataset['dataset_id']}\n")
-                        f.write(f"Deprecated Term: {ontology_term_id}\n")
-                        if "replaced_by" in ontology:
-                            f.write(f"Replaced By: {ontology['replaced_by']}\n")
-                        if "consider" in ontology:
-                            f.write(f"Consider: {ontology['consider']}\n")
-                        if "comments" in ontology:
-                            f.write(f"Comments: {ontology['comments']}\n")
-                        f.write("\n")
-                    else:
-                        non_deprecated_term_cache.add(ontology_term_id)
+                                entry["needs_alert"] = True
+                        else:
+                            entry["needs_alert"] = True
+                            if "consider" in ontology:
+                                entry['consider'] = ontology['consider']
+                            if "comments" in ontology:
+                                entry['comments'] = ontology['comments']
+
+                        curator_report_entry_map[collection_id][ontology_term_id] = entry
+                else:
+                    non_deprecated_term_cache.add(ontology_term_id)
+
+
+def write_to_curator_report(output_file, curator_report_entry_map, revision_map=None):
+    with open(output_file, "a") as f:
+        for collection_id in curator_report_entry_map.keys():
+            for deprecated_term, entry in curator_report_entry_map[collection_id].items():
+                if entry['needs_alert']:
+                    f.write("ALERT: Requires Manual Curator Intervention\n")
+                f.write(f"Collection ID: {collection_id}\n")
+                if revision_map and collection_id in revision_map:
+                    f.write(f"Note--In A Revision of: {revision_map[collection_id]}\n")
+                f.write(f"# of Affected Datasets: {entry['dataset_ct']}\n")
+                f.write(f"Deprecated Term: {deprecated_term}\n")
+                if "replaced_by" in entry:
+                    f.write(f"Replaced By: {entry['replaced_by']}\n")
+                if "consider" in entry:
+                    f.write(f"Consider: {entry['consider']}\n")
+                if "comments" in entry:
+                    f.write(f"Comments: {entry['comments']}\n")
+                f.write("\n")
 
 
 def dry_run(output_file):
@@ -105,22 +124,25 @@ def dry_run(output_file):
 
     base_url = BASE_API[os.getenv("corpus_env", default="dev")]
     datasets = fetch_public_datasets(base_url)
+    public_curator_report_entry_map = defaultdict(dict)
     with open(output_file, "w") as f:
         # for every dataset, check its ontology term metadata to see if any terms are deprecated. If so, report.
         f.write("Deprecated Terms in Public Datasets:\n\n")
     for dataset in datasets:
-        report_deprecated_terms(output_file, dataset, dataset["collection_id"], onto_map, non_deprecated_term_cache)
+        map_deprecated_terms(public_curator_report_entry_map, dataset, dataset["collection_id"], onto_map,
+                             non_deprecated_term_cache)
+    write_to_curator_report(output_file, public_curator_report_entry_map)
 
     headers = get_headers(base_url)
     private_collections = fetch_private_collections(base_url, headers)
-    open_revision_set = set()
     with open(output_file, "a") as f:
         f.write("\nDeprecated Terms in Private Datasets:\n\n")
+    revision_map = dict()
+    private_curator_report_entry_map = defaultdict(dict)
     for collection in private_collections:
-        revision_of = collection["revision_of"]
-        if revision_of:
-            open_revision_set.add(revision_of)
         collection_id = collection["collection_id"]
+        if collection["revision_of"]:
+            revision_map[collection_id] = collection["revision_of"]
         for ds in collection["datasets"]:
             dataset_id = ds["dataset_id"]
             # TODO: consider adding ontology fields to dataset preview response so a follow-up call isn't needed
@@ -128,13 +150,15 @@ def dry_run(output_file):
             # only process uploaded datasets
             if "processing_status" not in dataset_metadata or dataset_metadata["processing_status"] != "SUCCESS":
                 continue
-            report_deprecated_terms(
-                output_file, dataset_metadata, collection_id, onto_map, non_deprecated_term_cache, revision_of
+            map_deprecated_terms(
+                private_curator_report_entry_map, dataset_metadata, collection_id, onto_map, non_deprecated_term_cache
             )
-    if open_revision_set:
+    write_to_curator_report(output_file, private_curator_report_entry_map, revision_map)
+
+    if revision_map:
         with open(output_file, "a") as f:
             f.write("\nThe Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:\n")
-            for revision in open_revision_set:
+            for revision in revision_map.values():
                 f.write(f"{revision}\n")
 
 

--- a/schema_bump_dry_run_scripts/tests/fixtures/group_datasets_by_collection_expected
+++ b/schema_bump_dry_run_scripts/tests/fixtures/group_datasets_by_collection_expected
@@ -1,24 +1,24 @@
 Deprecated Terms in Public Datasets:
 
-ALERT: Requires Manual Curator Intervention
 Collection ID: public_coll_0
-# of Affected Datasets: 1
-Deprecated Term: EFO:0000006
-Replaced By: CL:0000006
+# of Affected Datasets: 2
+Deprecated Term: EFO:0000002
+Replaced By: EFO:0000001
 
 
 Deprecated Terms in Private Datasets:
 
 ALERT: Requires Manual Curator Intervention
 Collection ID: private_coll_0
-# of Affected Datasets: 1
-Deprecated Term: EFO:0000006
-Replaced By: CL:0000006
+# of Affected Datasets: 2
+Deprecated Term: EFO:0000005
+Consider: ['EFO:0000001', 'EFO:0000010']
+Comments: ['Consider removing this term entirely', 'Or using one from a different ontology']
 
 ALERT: Requires Manual Curator Intervention
 Collection ID: public_coll_0_revision
 Note--In A Revision of: public_coll_0
-# of Affected Datasets: 1
+# of Affected Datasets: 2
 Deprecated Term: EFO:0000006
 Replaced By: CL:0000006
 

--- a/schema_bump_dry_run_scripts/tests/fixtures/with_comments_and_considers_expected
+++ b/schema_bump_dry_run_scripts/tests/fixtures/with_comments_and_considers_expected
@@ -2,7 +2,7 @@ Deprecated Terms in Public Datasets:
 
 ALERT: Requires Manual Curator Intervention
 Collection ID: public_coll_0
-Dataset ID: public_ds_0
+# of Affected Datasets: 1
 Deprecated Term: EFO:0000003
 Comments: ['note: replace with EFO:0000001']
 
@@ -11,14 +11,14 @@ Deprecated Terms in Private Datasets:
 
 ALERT: Requires Manual Curator Intervention
 Collection ID: private_coll_0
-Dataset ID: private_ds_0
+# of Affected Datasets: 1
 Deprecated Term: EFO:0000004
 Consider: ['EFO:0000001', 'EFO:0000010']
 
 ALERT: Requires Manual Curator Intervention
-Note--In A Revision of: public_coll_0
 Collection ID: public_coll_0_revision
-Dataset ID: public_ds_0
+Note--In A Revision of: public_coll_0
+# of Affected Datasets: 1
 Deprecated Term: EFO:0000005
 Consider: ['EFO:0000001', 'EFO:0000010']
 Comments: ['Consider removing this term entirely', 'Or using one from a different ontology']

--- a/schema_bump_dry_run_scripts/tests/fixtures/with_replaced_by_expected
+++ b/schema_bump_dry_run_scripts/tests/fixtures/with_replaced_by_expected
@@ -1,7 +1,7 @@
 Deprecated Terms in Public Datasets:
 
 Collection ID: public_coll_0
-Dataset ID: public_ds_0
+# of Affected Datasets: 1
 Deprecated Term: EFO:0000002
 Replaced By: EFO:0000001
 
@@ -9,13 +9,13 @@ Replaced By: EFO:0000001
 Deprecated Terms in Private Datasets:
 
 Collection ID: private_coll_0
-Dataset ID: private_ds_0
+# of Affected Datasets: 1
 Deprecated Term: EFO:0000002
 Replaced By: EFO:0000001
 
-Note--In A Revision of: public_coll_0
 Collection ID: public_coll_0_revision
-Dataset ID: public_ds_0
+Note--In A Revision of: public_coll_0
+# of Affected Datasets: 1
 Deprecated Term: EFO:0000002
 Replaced By: EFO:0000001
 

--- a/schema_bump_dry_run_scripts/tests/test_ontology_bump_dry_run.py
+++ b/schema_bump_dry_run_scripts/tests/test_ontology_bump_dry_run.py
@@ -126,3 +126,26 @@ class TestOntologyBumpDryRun(TestCase):
         with NamedTemporaryFile() as tmp, open("fixtures/with_replaced_by_diff_ontology_expected", "rb") as expected:
             ontology_bump_dry_run.dry_run(tmp.name)
             self.assertListEqual(list(expected), list(tmp))
+
+    def test_group_datasets_by_collection(self):
+        self.public_datasets[0]["assay"].append({"ontology_term_id": "EFO:0000002"})
+        self.public_datasets.append({
+                "collection_id": "public_coll_0",
+                "dataset_id": "public_ds_1",
+                "assay": [{"ontology_term_id": "EFO:0000002"}],
+            })
+        self.private_collections[0]["datasets"][0]["assay"].append({"ontology_term_id": "EFO:0000005"})
+        self.private_collections[0]["datasets"].append({
+                "dataset_id": "private_ds_1",
+                "assay": [{"ontology_term_id": "EFO:0000005"}],
+                "processing_status": "SUCCESS",
+            })
+        self.private_collections[1]["datasets"][0]["assay"].append({"ontology_term_id": "EFO:0000006"})
+        self.private_collections[1]["datasets"].append({
+            "dataset_id": "revision_ds_0",
+            "assay": [{"ontology_term_id": "EFO:0000006"}],
+            "processing_status": "SUCCESS",
+        })
+        with NamedTemporaryFile() as tmp, open("fixtures/group_datasets_by_collection_expected", "rb") as expected:
+            ontology_bump_dry_run.dry_run(tmp.name)
+            self.assertListEqual(list(expected), list(tmp))

--- a/schema_bump_dry_run_scripts/tests/test_ontology_bump_dry_run.py
+++ b/schema_bump_dry_run_scripts/tests/test_ontology_bump_dry_run.py
@@ -129,23 +129,29 @@ class TestOntologyBumpDryRun(TestCase):
 
     def test_group_datasets_by_collection(self):
         self.public_datasets[0]["assay"].append({"ontology_term_id": "EFO:0000002"})
-        self.public_datasets.append({
+        self.public_datasets.append(
+            {
                 "collection_id": "public_coll_0",
                 "dataset_id": "public_ds_1",
                 "assay": [{"ontology_term_id": "EFO:0000002"}],
-            })
+            }
+        )
         self.private_collections[0]["datasets"][0]["assay"].append({"ontology_term_id": "EFO:0000005"})
-        self.private_collections[0]["datasets"].append({
+        self.private_collections[0]["datasets"].append(
+            {
                 "dataset_id": "private_ds_1",
                 "assay": [{"ontology_term_id": "EFO:0000005"}],
                 "processing_status": "SUCCESS",
-            })
+            }
+        )
         self.private_collections[1]["datasets"][0]["assay"].append({"ontology_term_id": "EFO:0000006"})
-        self.private_collections[1]["datasets"].append({
-            "dataset_id": "revision_ds_0",
-            "assay": [{"ontology_term_id": "EFO:0000006"}],
-            "processing_status": "SUCCESS",
-        })
+        self.private_collections[1]["datasets"].append(
+            {
+                "dataset_id": "revision_ds_0",
+                "assay": [{"ontology_term_id": "EFO:0000006"}],
+                "processing_status": "SUCCESS",
+            }
+        )
         with NamedTemporaryFile() as tmp, open("fixtures/group_datasets_by_collection_expected", "rb") as expected:
             ontology_bump_dry_run.dry_run(tmp.name)
             self.assertListEqual(list(expected), list(tmp))


### PR DESCRIPTION
- Decompose parsing into 1) a mapping function that runs the logic to detect deprecated terms + maps reporting data by collection ID and deprecated term, and 2) a function that iterates over the map and writes to the output file in the desired format
- Update writing logic to remove Dataset ID + replace with count of affected datasets in Collection for the detected deprecated term