### PR TITLE
feat: release cellxgene-schema to test pypi

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.2-rc.0
+current_version = 3.0.3-rc.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0-rc.0
+current_version = 3.3.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.4.0-rc.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.0
+current_version = 3.0.2
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-rc.0
+current_version = 3.0.0-rc.1
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0-rc.0
+current_version = 3.2.0-rc.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1-rc.0
+current_version = 3.0.0-rc.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0-rc.1
+current_version = 3.1.0-rc.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0-rc.0
+current_version = 3.3.0-rc.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.0-rc.0
+current_version = 3.4.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.3-rc.0
+current_version = 3.0.1-rc.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-          packages-dir: cellxgene_schema_cli/
+          packages-dir: cellxgene_schema_cli/dist/
 # TODO: Uncomment once ready to release to prod PyPI
 #      - name: Publish distribution to PyPI
 #        if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,11 +23,13 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-      - name: Bump PyPI release version
+      - name: Bump and tag release version
         run: |
           pip install bumpversion
           pip install wheel
           bumpversion --config-file .bumpversion.cfg minor --allow-dirty
+          bumpversion --config-file .bumpversion.cfg prerel --allow-dirty --tag
+          git push origin --tags
       - name: Build dist
         run: >-
           make pydist

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,41 @@
+name: Publish cellxgene_schema_cli to PyPI and TestPyPI
+
+on:
+  push
+    branches:
+      - main
+      - nayib/deploy-to-test-pypi # TODO: remove, just for testing
+    paths:
+      - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/all_ontology.json.gz'
+      - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/*.csv.gz'
+      - '**/cellxgene_schema_cli/setup.py' # TODO: remove, just for testing
+
+jobs:
+  publish-to-pypi:
+    name: Build and publish Python distributions to TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Bump PyPI release version
+        run: >-
+          pip install bumpversion
+          bumpversion --config-file .bumpversion.cfg minor --allow-dirty
+      - name: Build dist
+        run: >-
+          make pydist
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        working-directory: cellxgene_schema_cli
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+# TODO: Uncomment once ready to release to prod PyPI
+#      - name: Publish distribution to PyPI
+#        if: startsWith(github.ref, 'refs/tags')
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-          package-dir: cellxgene_schema_cli/
+          packages-dir: cellxgene_schema_cli/
 # TODO: Uncomment once ready to release to prod PyPI
 #      - name: Publish distribution to PyPI
 #        if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish cellxgene_schema_cli to PyPI and TestPyPI
+name: Publish cellxgene_schema_cli to PyPI
 
 on:
   push:
@@ -28,6 +28,7 @@ jobs:
       - name: Bump PyPI release version
         run: |
           pip install bumpversion
+          pip install wheel
           bumpversion --config-file .bumpversion.cfg minor --allow-dirty
       - name: Build dist
         run: >-

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Bump PyPI release version
-        run: >-
+        run: |
           pip install bumpversion
           bumpversion --config-file .bumpversion.cfg minor --allow-dirty
       - name: Build dist

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,12 +4,9 @@ on:
   push:
     branches:
       - main
-      - nayib/deploy-to-test-pypi # TODO: remove, just for testing
     paths:
       - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/all_ontology.json.gz'
       - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/*.csv.gz'
-      - '**/.github/workflows/publish-to-pypi.yml' # TODO: remove, just for testing
-      - '**/cellxgene_schema_cli/setup.py' # TODO: remove, just for testing
 
 jobs:
   publish-to-pypi:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,7 +1,7 @@
 name: Publish cellxgene_schema_cli to PyPI and TestPyPI
 
 on:
-  push
+  push:
     branches:
       - main
       - nayib/deploy-to-test-pypi # TODO: remove, just for testing

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,6 +9,7 @@ on:
       - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/all_ontology.json.gz'
       - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/*.csv.gz'
       - '**/.github/workflows/publish-to-pypi.yml' # TODO: remove, just for testing
+      - '**/cellxgene_schema_cli/setup.py' # TODO: remove, just for testing
 
 jobs:
   publish-to-pypi:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   publish-to-pypi:
-    name: Build and publish Python distributions to TestPyPI
+    name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,6 +39,10 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: cellxgene_schema_cli/dist/
+      - name: Install and Test Package from Test PyPI
+        run: |
+          pip install --index-url https://test.pypi.org/simple/ cellxgene-schema
+          cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad
 # TODO: Uncomment once ready to release to prod PyPI
 #      - name: Publish distribution to PyPI
 #        if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/all_ontology.json.gz'
       - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/*.csv.gz'
-      - '**/cellxgene_schema_cli/setup.py' # TODO: remove, just for testing
+      - '**/.github/workflows/publish-to-pypi.yml' # TODO: remove, just for testing
 
 jobs:
   publish-to-pypi:
@@ -29,13 +29,14 @@ jobs:
           make pydist
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        working-directory: cellxgene_schema_cli
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
+          package-dir: cellxgene_schema_cli/
 # TODO: Uncomment once ready to release to prod PyPI
 #      - name: Publish distribution to PyPI
 #        if: startsWith(github.ref, 'refs/tags')
 #        uses: pypa/gh-action-pypi-publish@release/v1
 #        with:
 #          password: ${{ secrets.PYPI_API_TOKEN }}
+#          package-dir: cellxgene_schema_cli/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,11 +15,16 @@ jobs:
     name: Build and publish Python distributions to TestPyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+      - name: setup git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - name: Bump PyPI release version
         run: |
           pip install bumpversion

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.0.1-rc.0",
+    version="3.0.0-rc.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.3.0",
+    version="3.4.0-rc.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.2.0-rc.0",
+    version="3.3.0-rc.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.0.2-rc.0",
+    version="3.0.3-rc.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.3.0-rc.0",
+    version="3.3.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.1.0-rc.0",
+    version="3.2.0-rc.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.0.0-rc.1",
+    version="3.1.0-rc.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.0.0-rc.0",
+    version="3.0.0-rc.1",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.4.0",
+    version="3.0.2",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.0.3-rc.0",
+    version="3.0.1-rc.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="3.4.0-rc.0",
+    version="3.4.0",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -11,6 +11,7 @@ setup(
     author="Chan Zuckerberg Initiative",
     author_email="cellxgene@chanzuckerberg.com",
     description="Tool for applying and validating cellxgene integration schema to single cell datasets",
+    long_description="Tool for applying and validating cellxgene integration schema to single cell datasets",
     install_requires=requirements,
     python_requires=">=3.8",
     packages=["cellxgene_schema"],

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -10,7 +10,7 @@ setup(
     license="MIT",
     author="Chan Zuckerberg Initiative",
     author_email="cellxgene@chanzuckerberg.com",
-    description="Tool for applying and validating cellxgene integration schema to single cell datasets",
+    description="Tool for applying and validating cellxgene integration schema to single cell datasets.",
     install_requires=requirements,
     python_requires=">=3.8",
     packages=["cellxgene_schema"],

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -10,7 +10,7 @@ setup(
     license="MIT",
     author="Chan Zuckerberg Initiative",
     author_email="cellxgene@chanzuckerberg.com",
-    description="Tool for applying and validating cellxgene integration schema to single cell datasets.",
+    description="Tool for applying and validating cellxgene integration schema to single cell datasets",
     install_requires=requirements,
     python_requires=">=3.8",
     packages=["cellxgene_schema"],


### PR DESCRIPTION
- Set up to release new minor version to Test PyPI and PyPI when there are ontology/GENCODE reference file bumps in main
- For now, setting it to release as a release candidate for testing, and only to test PyPI. Will change once ready to bump in prod
- Added Test PyPI / PyPI API keys to Github secrets
- Test PyPI 3.1.0rc0 published release: https://test.pypi.org/project/cellxgene-schema/3.1.0rc0/
- Action triggering release above: https://github.com/chanzuckerberg/single-cell-curation/actions/runs/5125586931