### PR TITLE
demo: bump CL ontology and GENCODE versions

### DIFF
--- a/.github/workflows/publish-minor-to-pypi.yml
+++ b/.github/workflows/publish-minor-to-pypi.yml
@@ -27,13 +27,12 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+        # TODO: re-add `bumpversion --config-file .bumpversion.cfg prerel --allow-dirty --tag` && 'git push origin --tags'
       - name: Bump and tag release version
         run: |
           pip install bumpversion
           pip install wheel
           bumpversion --config-file .bumpversion.cfg minor --allow-dirty
-          bumpversion --config-file .bumpversion.cfg prerel --allow-dirty --tag
-          git push origin --tags
       - name: Build dist
         run: >-
           make pydist

--- a/cellxgene_schema_cli/cellxgene_schema/ontology_files/gene_info.yml
+++ b/cellxgene_schema_cli/cellxgene_schema/ontology_files/gene_info.yml
@@ -4,11 +4,11 @@ ercc:
 human:
   description: homo_sapiens
   url: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{version}/gencode.v{version}.primary_assembly.annotation.gtf.gz
-  version: 38
+  version: 43
 mouse:
   description: mus_musculus
   url: http://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_mouse/release_{version}/gencode.v{version}.primary_assembly.annotation.gtf.gz
-  version: M27
+  version: M32
 sars_cov_2:
   description: sars_cov_2
   url: ftp://ftp.ensemblgenomes.org/pub/viruses/gtf/sars_cov_2/Sars_cov_2.ASM985889v3.101.gtf.gz

--- a/cellxgene_schema_cli/cellxgene_schema/ontology_files/owl_info.yml
+++ b/cellxgene_schema_cli/cellxgene_schema/ontology_files/owl_info.yml
@@ -1,6 +1,7 @@
 CL:
-  latest: 2022-09-15
+  latest: new
   urls:
+    new: https://github.com/obophenotype/cell-ontology/releases/download/v2023-05-22/cl.owl
     2022-09-15: https://github.com/obophenotype/cell-ontology/raw/v2022-09-15/cl.owl
     2022-06-18: https://github.com/obophenotype/cell-ontology/raw/v2022-06-18/cl.owl
     2021-08-10: https://github.com/obophenotype/cell-ontology/raw/v2021-08-10/cl.owl


### PR DESCRIPTION
 + temp. only release cellxgene-schema rc to test PyPI