### PR TITLE
chore: update tiledb to 0.21.4 to match data-portal

### DIFF
--- a/schema_bump_dry_run_scripts/genes/requirements.txt
+++ b/schema_bump_dry_run_scripts/genes/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.31.0
-tiledb==0.21.4
+tiledb==0.21.4 # Should match version pinned in single-cell-data-portal
 pandas==2.0.1
 pyarrow>=1.0.0
 jinja2==3.1.2

--- a/schema_bump_dry_run_scripts/genes/requirements.txt
+++ b/schema_bump_dry_run_scripts/genes/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.31.0
-tiledb==0.16.5
+tiledb==0.21.4
 pandas==2.0.1
 pyarrow>=1.0.0
 jinja2==3.1.2


### PR DESCRIPTION
Fixes seg faults on gencode dry run updates