### PR TITLE
fix: push files with updated version as well as tags

### DIFF
--- a/.github/workflows/minor-schema-version-bump.yml
+++ b/.github/workflows/minor-schema-version-bump.yml
@@ -133,7 +133,7 @@ jobs:
           pip install wheel
           bumpversion --config-file .bumpversion.cfg minor --allow-dirty
           bumpversion --config-file .bumpversion.cfg prerel --allow-dirty --tag
-          git push origin --tags
+          git push origin --follow-tags
       - name: Build dist
         run: >-
           make pydist


### PR DESCRIPTION
- We were only pushing tags, but not the committed version updates to files updated by bumpversion. This arg should fix that