### PR TITLE
chore: Added dataset deletion request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset-deletion-request.md
+++ b/.github/ISSUE_TEMPLATE/dataset-deletion-request.md
@@ -7,9 +7,9 @@ assignees: "jahilton"
 ---
 
 Dataset requested for deletion: 
-* 
+*  
 
-Justification
+Justification for removal
 * 
 
 ## Tasks

--- a/.github/ISSUE_TEMPLATE/dataset-deletion-request.md
+++ b/.github/ISSUE_TEMPLATE/dataset-deletion-request.md
@@ -1,0 +1,17 @@
+---
+name: Dataset Deletion
+about: Use this to request dataset deletion from CELLxGENE Discover.
+title: ""
+labels: "deletion"
+assignees: "jahilton"
+---
+
+Dataset requested for deletion: 
+* 
+
+Justification
+* 
+
+## Tasks
+- [ ] Deletion request approved
+- [ ] Dataset deleted from CELLxGENE Discover


### PR DESCRIPTION
Added a Github issue template for dataset deletion requests from data submitters.

The template includes:
* Prompts for the dataset requested for deletion and justification for deletion
* Auto-labeling the Github issue as `deletion`
* Auto-assignment to `jahilton` (for review and approval)
