### PR TITLE
fix: include comments in all curator report entries

### DIFF
--- a/cellxgene_schema_cli/scripts/ontology_processing.py
+++ b/cellxgene_schema_cli/scripts/ontology_processing.py
@@ -150,6 +150,8 @@ def _parse_owls(
             if onto_class.deprecated and onto_class.deprecated.first():
                 # if deprecated, include information to determine replacement term(s)
                 onto_dict[onto.name][term_id]["deprecated"] = True
+                if onto_class.comment:
+                    onto_dict[onto.name][term_id]["comments"] = [str(c) for c in onto_class.comment]
                 if onto_class.IAO_0100001 and onto_class.IAO_0100001.first():
                     # url --> term
                     ontology_term = re.findall(r"[^\W_]+", str(onto_class.IAO_0100001[0]))
@@ -157,8 +159,6 @@ def _parse_owls(
                 else:
                     if hasattr(onto_class, "consider") and onto_class.consider:
                         onto_dict[onto.name][term_id]["consider"] = [str(c) for c in onto_class.consider]
-                    if onto_class.comment:
-                        onto_dict[onto.name][term_id]["comments"] = [str(c) for c in onto_class.comment]
             # Gets ancestors
             ancestors = _get_ancestors(onto_class, onto.name)
 

--- a/cellxgene_schema_cli/tests/test_utils.py
+++ b/cellxgene_schema_cli/tests/test_utils.py
@@ -51,7 +51,7 @@ def test_replace_ontology_term__with_replacement(adata_with_raw, deprecated_term
 
     expected = ["EFO:0009918", "EFO:0000001"]
     actual = adata_with_raw.obs["assay_ontology_term_id"].dtype.categories
-    assert all([a == b for a, b in zip(actual, expected)])
+    assert all(a == b for a, b in zip(actual, expected))
 
 
 def test_replace_ontology_term__no_replacement(adata_with_raw, deprecated_term_map_no_replacement_match):
@@ -59,4 +59,4 @@ def test_replace_ontology_term__no_replacement(adata_with_raw, deprecated_term_m
 
     expected = ["EFO:0009899", "EFO:0009918"]
     actual = adata_with_raw.obs["assay_ontology_term_id"].dtype.categories
-    assert all([a == b for a, b in zip(actual, expected)])
+    assert all(a == b for a, b in zip(actual, expected))

--- a/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
@@ -77,6 +77,8 @@ def map_deprecated_terms(
                         entry = dict()
                         entry["needs_alert"] = False
                         entry["dataset_ct"] = 1
+                        if "comments" in ontology:
+                            entry["comments"] = ontology["comments"]
                         if "replaced_by" in ontology:
                             entry["replaced_by"] = ontology["replaced_by"]
                             replacement_term_ontology = ontology["replaced_by"].split(":")[0]
@@ -85,13 +87,10 @@ def map_deprecated_terms(
                             else:
                                 if ontology_index_id not in replaced_by_map[ontology_type]:
                                     replaced_by_map[ontology_type][ontology_index_id] = ontology["replaced_by"]
-
                         else:
                             entry["needs_alert"] = True
                             if "consider" in ontology:
                                 entry["consider"] = ontology["consider"]
-                            if "comments" in ontology:
-                                entry["comments"] = ontology["comments"]
 
                         curator_report_entry_map[collection_id][ontology_term_id] = entry
                 else:

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/group_datasets_by_collection_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/group_datasets_by_collection_expected
@@ -21,6 +21,7 @@ Note--In A Revision of: public_coll_0
 # of Affected Datasets: 2
 Deprecated Term: EFO:0000006
 Replaced By: CL:0000006
+Comments: ['Comment adding context to replacement']
 
 
 The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_replaced_by_diff_ontology_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_replaced_by_diff_ontology_expected
@@ -5,6 +5,7 @@ Collection ID: public_coll_0
 # of Affected Datasets: 1
 Deprecated Term: EFO:0000006
 Replaced By: CL:0000006
+Comments: ['Comment adding context to replacement']
 
 
 Deprecated Terms in Private Datasets:
@@ -14,6 +15,7 @@ Collection ID: private_coll_0
 # of Affected Datasets: 1
 Deprecated Term: EFO:0000006
 Replaced By: CL:0000006
+Comments: ['Comment adding context to replacement']
 
 ALERT: Requires Manual Curator Intervention
 Collection ID: public_coll_0_revision
@@ -21,6 +23,7 @@ Note--In A Revision of: public_coll_0
 # of Affected Datasets: 1
 Deprecated Term: EFO:0000006
 Replaced By: CL:0000006
+Comments: ['Comment adding context to replacement']
 
 
 The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_replaced_by_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_replaced_by_expected
@@ -5,6 +5,12 @@ Collection ID: public_coll_0
 Deprecated Term: EFO:0000002
 Replaced By: EFO:0000001
 
+Collection ID: public_coll_0
+# of Affected Datasets: 1
+Deprecated Term: EFO:0000007
+Replaced By: EFO:0000070
+Comments: ['Comment adding context to replacement']
+
 
 Deprecated Terms in Private Datasets:
 

--- a/scripts/schema_bump_dry_run_ontologies/tests/test_ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/tests/test_ontology_bump_dry_run.py
@@ -39,6 +39,13 @@ class TestOntologyBumpDryRun(TestCase):
                     "label": "obsolete term with replacement from a different ontology",
                     "deprecated": True,
                     "replaced_by": "CL:0000006",
+                    "comments": ["Comment adding context to replacement"],
+                },
+                "EFO:0000007": {
+                    "label": "obsolete term with replacement and comment",
+                    "deprecated": True,
+                    "replaced_by": "EFO:0000070",
+                    "comments": ["Comment adding context to replacement"],
                 },
             }
         }
@@ -121,10 +128,13 @@ class TestOntologyBumpDryRun(TestCase):
             self.assertDictEqual(self.expected_replaced_by_map, json.load(tmp_json))
 
     def test_with_replaced_by(self):
-        self.public_datasets[0]["assay"].append({"ontology_term_id": "EFO:0000002"})
+        self.public_datasets[0]["assay"].extend(
+            [{"ontology_term_id": "EFO:0000002"}, {"ontology_term_id": "EFO:0000007"}]
+        )
         self.private_collections[0]["datasets"][0]["assay"].append({"ontology_term_id": "EFO:0000002"})
         self.private_collections[1]["datasets"][0]["assay"].append({"ontology_term_id": "EFO:0000002"})
         self.expected_replaced_by_map["assay"]["EFO:0000002"] = "EFO:0000001"
+        self.expected_replaced_by_map["assay"]["EFO:0000007"] = "EFO:0000070"
         with NamedTemporaryFile() as tmp, NamedTemporaryFile() as tmp_json, open(
             "fixtures/with_replaced_by_expected", "rb"
         ) as expected:


### PR DESCRIPTION
Issue: #533 

Changes:
- Will store comments for all deprecated entries in all_ontology json during ontology processing, and write them to curator report for all deprecated terms in the corpus (previously, we were skipping them on terms with replaced_by's) 