### PR TITLE
fix: asset downloads for python/get_dataset_version.ipynb

### DIFF
--- a/notebooks/curation_api/python/get_dataset.ipynb
+++ b/notebooks/curation_api/python/get_dataset.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "from src.dataset import (\n",
-    "    # download_assets,\n",
+    "    download_assets,\n",
     "    get_dataset,\n",
     ")\n",
     "from src.utils.config import set_api_access_config  # still required for setting api url env vars"
@@ -134,35 +134,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b2aa4409",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Download Dataset Assets\n",
     "\n",
     "The dataset metadata provides download URLs for every asset associated with the current dataset version. For public collections, that means the most recently published version of a dataset. For private collections, that means the most recently successfully processed dataset version.\n",
     "\n",
     "These download URLs are permalinks to download the assets for this particular version of a dataset. If this dataset is revised, you would need to fetch the dataset metadata again to get the latest dataset version asset download links."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# Uncomment code below to locally download all dataset assets\n",
-    "\n",
-    "# download_assets([dataset])"
-   ],
+   "id": "53bce82d",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# Download assets\n",
+    "\n",
+    "download_assets([dataset])"
+   ]
   }
  ],
  "metadata": {
@@ -181,7 +181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/curation_api/python/get_dataset_version.ipynb
+++ b/notebooks/curation_api/python/get_dataset_version.ipynb
@@ -41,147 +41,147 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from src.dataset import (\n",
-    "    # download_assets,\n",
-    "    get_dataset_version,\n",
-    ")\n",
-    "from src.utils.config import set_api_access_config  # still required for setting api url env vars"
-   ],
+   "id": "1245e960",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from src.dataset import (\n",
+    "    download_assets,\n",
+    "    get_dataset_version,\n",
+    ")\n",
+    "from src.utils.config import set_api_access_config  # still required for setting api url env vars"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
-   ],
+   "id": "4762a149",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "995c6c88",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "<font color='#bc00b0'>(Required) Enter the id of the Dataset Version</font>\n",
     "\n",
     "_A Dataset Version id can be found by using the `/datasets/{dataset_id}/versions` OR `/collections/{collection_id}/versions` endpoints and filtering for the Dataset Version of interest OR by looking at the url path in the address when viewing your Dataset Version using the CZ CELLxGENE Explorer browser tool: `/e/{dataset_version_id}.cxg/`._"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "dataset_version_id = \"d9e341ad-4a28-4dba-b040-f1edf82c419f\""
-   ],
+   "id": "b2020ffd",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "dataset_version_id = \"abcdef01-2345-6789-abcd-ef0123456789\""
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Set url env vars"
-   ],
+   "id": "3ee5a3d8",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "### Set url env vars"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bf5728fb",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "set_api_access_config()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Fetch Dataset Version"
-   ],
+   "id": "75fdfb75",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "### Fetch Dataset Version"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e3e24d7d",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "dataset_version = get_dataset_version(dataset_version_id)\n",
     "from pprint import pprint\n",
     "\n",
     "pprint(dataset_version)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "508736b1",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Download Dataset Assets\n",
     "\n",
     "The dataset metadata provides download URLs for every asset associated with this particular dataset version.\n",
     "\n",
     "These download URLs are permalinks to download the assets for this dataset version."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# Uncomment code below to locally download all dataset version assets\n",
-    "\n",
-    "# download_assets([dataset_version], log_version_id=True)"
-   ],
+   "id": "0f737b15",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# Download assets\n",
+    "\n",
+    "download_assets([dataset_version], log_version_id=True)"
+   ]
   }
  ],
  "metadata": {
@@ -200,7 +200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
See issue - I'm just setting the default version of the notebooks to actually download the associated assets after performing the `GET` call for the metadata