### PR TITLE
fix(schema-migrate): add tests for migrate.py

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -2,8 +2,34 @@ import anndata as ad
 
 from . import utils
 
-# AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
 # fmt: off
+# ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
+# Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
+
+# Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
+# 'Replaced By' is not available for a deprecated term.
+
+# If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
+# add them here.
+ONTOLOGY_TERM_MAPS = {
+    "assay": {
+    },
+    "cell_type": {
+    },
+    "development_stage": {
+    },
+    "disease": {
+    },
+    "organism": {
+    },
+    "self_reported_ethnicity": {
+    },
+    "sex": {
+    },
+    "tissue": {
+    },
+}
+
 DEPRECATED_FEATURE_IDS = [
 ]
 # fmt: on
@@ -16,27 +42,8 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
         dataset = dataset.to_memory()
 
-    # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
-    # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
-
-    # Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
-    # 'Replaced By' is not available for a deprecated term.
-
-    # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
-    # add them here.
-    ontology_term_maps = {
-        "assay": {},
-        "cell_type": {},
-        "development_stage": {},
-        "disease": {},
-        "organism": {},
-        "self_reported_ethnicity": {},
-        "sex": {},
-        "tissue": {},
-    }
-
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ontology_term_maps.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -13,7 +13,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw and DEPRECATED_FEATURE_IDS:
+    if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
         dataset = dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -2,6 +2,12 @@ import anndata as ad
 
 from . import utils
 
+# AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
+# fmt: off
+DEPRECATED_FEATURE_IDS = [
+]
+# fmt: on
+
 
 def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
@@ -49,6 +55,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # ...
 
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
-    # No Changes
+    if DEPRECATED_FEATURE_IDS:
+        dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)
 
     dataset.write(output_file, compression="gzip")

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -12,7 +12,9 @@ DEPRECATED_FEATURE_IDS = [
 def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
-    dataset = ad.read_h5ad(input_file)
+    dataset = ad.read_h5ad(input_file, backed="r")
+    if dataset.raw:
+        dataset = dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
     # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -13,7 +13,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw:
+    if dataset.raw and DEPRECATED_FEATURE_IDS:
         dataset = dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS

--- a/cellxgene_schema_cli/cellxgene_schema/remove_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/remove_labels.py
@@ -3,9 +3,9 @@ import os
 
 import anndata as ad
 from pandas import DataFrame
-from utils import getattr_anndata
 
 from . import schema
+from .utils import getattr_anndata
 
 logger = logging.getLogger(__name__)
 

--- a/cellxgene_schema_cli/cellxgene_schema/remove_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/remove_labels.py
@@ -3,9 +3,9 @@ import os
 
 import anndata as ad
 from pandas import DataFrame
+from utils import getattr_anndata
 
 from . import schema
-from .validate import Validator
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class AnnDataLabelRemover:
         """
         for component_name in ["obs", "var", "raw.var"]:
             # If the component does not exist, skip (this is for raw.var)
-            component = Validator.getattr_anndata(self.adata, component_name)
+            component = getattr_anndata(self.adata, component_name)
             if component is None:
                 continue
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -2,7 +2,6 @@ import logging
 import math
 import os
 import re
-import sys
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -12,6 +11,7 @@ import pandas as pd
 import semver
 from pandas.core.computation.ops import UndefinedVariableError
 from scipy import sparse
+from utils import get_matrix_format, getattr_anndata, read_h5ad
 
 from . import env, ontology, schema
 
@@ -74,50 +74,6 @@ class Validator:
                         return stripped_term_id, id_suffix
 
         return term_id, id_suffix
-
-    @staticmethod
-    def getattr_anndata(adata: anndata.AnnData, attr: str = None):
-        """
-        same as getattr but handles the special case of "raw.var" for an anndata.AndData object
-
-        :param anndata.AnnData adata: the anndata.AnnData object from which to extract an attribute
-        :param str attr: name of the attribute to extract
-
-        :return the attribute or none if it does not exist
-        """
-
-        if attr == "raw.var":
-            if adata.raw:
-                return adata.raw.var
-            else:
-                return None
-        else:
-            return getattr(adata, attr)
-
-    def _read_h5ad(self, h5ad_path: Union[str, bytes, os.PathLike]):
-        """
-        Reads h5ad into self.adata
-        :params Union[str, bytes, os.PathLike] h5ad_path: path to h5ad to read
-
-        :rtype None
-        """
-        try:
-            self.adata = anndata.read_h5ad(h5ad_path, backed="r")
-
-            # This code, and AnnData in general, is optimized for row access.
-            # Running backed, with CSC, is prohibitively slow. Read the entire
-            # AnnData into memory if it is CSC.
-            if (self._get_matrix_format(self.adata.X) == "csc") or (
-                (self.adata.raw is not None) and (self._get_matrix_format(self.adata.raw.X) == "csc")
-            ):
-                logger.warning("Matrices are in CSC format; loading entire dataset into memory.")
-                self.adata = self.adata.to_memory()
-
-        except (OSError, TypeError):
-            logger.info(f"Unable to open '{h5ad_path}' with AnnData")
-            sys.exit(1)
-
-        self.h5ad_path = h5ad_path
 
     def _validate_encoding_version(self):
         import h5py
@@ -344,34 +300,6 @@ class Validator:
 
         return
 
-    def _get_matrix_format(self, matrix: Union[np.ndarray, sparse.spmatrix]) -> str:
-        """
-        Given a matrix, returns the format as one of: csc, csr, coo, dense
-        or unknown.
-
-        This mimics the scipy.sparse `format` property, but extends it to
-        support ndarray and other classes AnnData may proxy the matrix with.
-        """
-
-        # Note: the AnnData proxy classes DO support the `format_str` property, but
-        # doing a slice seemed safer, if less performant.  Using `format_str`, which
-        # currently works, uses private API:
-        #
-        # >>> return getattr(matrix, "format_str", "dense)
-        #
-        format = "unknown"
-        if self.adata.n_obs == 0 or self.adata.n_vars == 0:
-            format = "dense"
-        else:
-            matrix_slice = matrix[0:1, 0:1]
-            if isinstance(matrix_slice, sparse.spmatrix):
-                format = matrix_slice.format
-            elif isinstance(matrix_slice, np.ndarray):
-                format = "dense"
-
-        assert format in ["unknown", "csr", "csc", "coo", "dense"]
-        return format
-
     def _chunk_matrix(
         self,
         matrix: Union[np.ndarray, sparse.spmatrix],
@@ -404,7 +332,7 @@ class Validator:
         logger.debug(f"Counting non-zero values in {matrix_name}")
 
         nnz = 0
-        format = self._get_matrix_format(matrix)
+        format = get_matrix_format(self.adata, matrix)
         for matrix_chunk, _, _ in self._chunk_matrix(matrix):
             nnz += matrix_chunk.count_nonzero() if format != "dense" else np.count_nonzero(matrix_chunk)
 
@@ -429,7 +357,7 @@ class Validator:
         if sum(column) > 0:
             n_nonzero = 0
 
-            X_format = self._get_matrix_format(self.adata.X)
+            X_format = get_matrix_format(self.adata, self.adata.X)
             if X_format in ["csc", "csr", "coo"]:
                 n_nonzero = self.adata.X[:, column].count_nonzero()
 
@@ -741,7 +669,7 @@ class Validator:
         :rtype None
         """
 
-        df = self.getattr_anndata(self.adata, df_name)
+        df = getattr_anndata(self.adata, df_name)
         df_definition = self._get_component_def(df_name)
 
         # Validate index if needed
@@ -819,7 +747,7 @@ class Validator:
 
         # Check sparsity
         for x, x_name in to_validate:
-            matrix_format = self._get_matrix_format(x)
+            matrix_format = get_matrix_format(self.adata, x)
             if matrix_format == "csr":
                 continue
             assert format != "unknown"
@@ -853,7 +781,7 @@ class Validator:
             to_validate.append((self.adata.raw.X, "raw.X"))
         # Check length of component arrays
         for matrix, matrix_name in to_validate:
-            format = self._get_matrix_format(matrix)
+            format = get_matrix_format(self.adata, matrix)
             if format in ["csc", "csr", "coo"]:
                 effective_r_array_size = self._count_matrix_nonzero(matrix_name, matrix)
                 is_sparse = True
@@ -989,7 +917,7 @@ class Validator:
             x = self.adata.raw.X if raw_loc == "raw.X" else self.adata.X
 
             num_values_checked = 0
-            format = self._get_matrix_format(x)
+            format = get_matrix_format(self.adata, x)
             assert format != "unknown"
             self._raw_layer_exists = True
             for matrix_chunk, _, _ in self._chunk_matrix(x):
@@ -1088,7 +1016,7 @@ class Validator:
         for label_def in add_labels_def:
             reserved_name = label_def["to_column"]
 
-            if reserved_name in self.getattr_anndata(self.adata, component):
+            if reserved_name in getattr_anndata(self.adata, component):
                 self.errors.append(
                     f"Add labels error: Column '{reserved_name}' is a reserved column name "
                     f"of '{component}'. Remove it from h5ad and try again."
@@ -1103,7 +1031,7 @@ class Validator:
         for component, component_def in self.schema_def["components"].items():
             if "deprecated_columns" in component_def:
                 for column in component_def["deprecated_columns"]:
-                    if column in self.getattr_anndata(self.adata, component):
+                    if column in getattr_anndata(self.adata, component):
                         self.errors.append(f"The field '{column}' is present in '{component}', but it is deprecated.")
 
     def _check_invalid_columns(self):
@@ -1114,7 +1042,7 @@ class Validator:
         :rtype none
         """
         for component, _ in self.schema_def["components"].items():
-            df = self.getattr_anndata(self.adata, component)
+            df = getattr_anndata(self.adata, component)
             if df is None:
                 continue
             for column in df:
@@ -1137,13 +1065,13 @@ class Validator:
                 continue
 
             # Skip if component does not exist
-            if self.getattr_anndata(self.adata, component) is None:
+            if getattr_anndata(self.adata, component) is None:
                 continue
 
             # Do it for columns that are forbidden
             if "forbidden_columns" in component_def:
                 for column in component_def["forbidden_columns"]:
-                    if column in self.getattr_anndata(self.adata, component):
+                    if column in getattr_anndata(self.adata, component):
                         self.errors.append(f"Column '{column}' must not be present in '{component}'.")
 
             # If ignore_labels is set, we will skip all the subsequent label checks
@@ -1190,7 +1118,7 @@ class Validator:
         for component, component_def in self.schema_def["components"].items():
             logger.debug(f"Validating component: {component}")
             # Skip if component does not exist: only useful for adata.raw.var
-            if self.getattr_anndata(self.adata, component) is None:
+            if getattr_anndata(self.adata, component) is None:
                 if "required" in component_def:
                     self.errors.append(f"'{component}' is missing from adata and it's required.")
                 continue
@@ -1231,7 +1159,8 @@ class Validator:
 
         if h5ad_path:
             logger.debug("Reading the h5ad file...")
-            self._read_h5ad(h5ad_path)
+            self.adata = read_h5ad(h5ad_path)
+            self.h5ad_path = h5ad_path
             self._validate_encoding_version()
             logger.debug("Successfully read the h5ad file")
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -11,9 +11,9 @@ import pandas as pd
 import semver
 from pandas.core.computation.ops import UndefinedVariableError
 from scipy import sparse
-from utils import get_matrix_format, getattr_anndata, read_h5ad
 
 from . import env, ontology, schema
+from .utils import get_matrix_format, getattr_anndata, read_h5ad
 
 logger = logging.getLogger(__name__)
 

--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -3,10 +3,11 @@ import traceback
 from typing import Dict, List, Optional
 
 import pandas as pd
-from utils import getattr_anndata
 
 from cellxgene_schema import ontology
 from cellxgene_schema.validate import ONTOLOGY_CHECKER, Validator
+
+from .utils import getattr_anndata
 
 logger = logging.getLogger(__name__)
 

--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -3,6 +3,7 @@ import traceback
 from typing import Dict, List, Optional
 
 import pandas as pd
+from utils import getattr_anndata
 
 from cellxgene_schema import ontology
 from cellxgene_schema.validate import ONTOLOGY_CHECKER, Validator
@@ -224,7 +225,7 @@ class AnnDataLabelAppender:
         """
 
         # Set variables for readability
-        current_df = Validator.getattr_anndata(self.adata, component)
+        current_df = getattr_anndata(self.adata, component)
 
         if column == "index":
             original_column = pd.Series(current_df.index)
@@ -295,7 +296,7 @@ class AnnDataLabelAppender:
         """
         for component in ["obs", "var", "raw.var"]:
             # If the component does not exist, skip (this is for raw.var)
-            if Validator.getattr_anndata(self.adata, component) is None:
+            if getattr_anndata(self.adata, component) is None:
                 continue
 
             # Doing it for columns

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -152,23 +152,6 @@ var_expected = pd.DataFrame(
     ],
 )
 
-var_unmigrated = pd.DataFrame(
-    [
-        ["spike-in", False, "ERCC-00002 (spike-in control)", "NCBITaxon:32630"],
-        ["gene", False, "MACF1", "NCBITaxon:9606"],
-        ["gene", False, "Trp53", "NCBITaxon:10090"],
-        ["gene", False, "S", "NCBITaxon:2697049"],
-        ["dummy", False, "dummy", "dummy"],
-    ],
-    index=["ERCC-00002", "ENSG00000127603", "ENSMUSG00000059552", "ENSSASG00005000004", "DUMMY"],
-    columns=[
-        "feature_biotype",
-        "feature_is_filtered",
-        "feature_name",
-        "feature_reference",
-    ],
-)
-
 # ---
 # 3. Creating individual uns component
 good_uns = {
@@ -235,18 +218,59 @@ adata_with_labels = anndata.AnnData(
 )
 
 
-# X for testing with deprecated genes
-unmigrated_X = numpy.zeros([good_obs.shape[0], var_unmigrated.shape[0]], dtype=numpy.float32)
-unmigrated_non_raw_X = sparse.csr_matrix(unmigrated_X.copy())
-unmigrated_non_raw_X[0, 0] = 1.5
+# anndata for testing migration
+umigrated_obs = pd.DataFrame(
+    [
+        [
+            "cell_type:1",
+            "assay:1",
+            "disease:1",
+            "organism:1",
+            "sex:1",
+            "tissue:1",
+            "sre:1",
+            "development_stage:1",
+        ],
+        [
+            "cell_type:1",
+            "assay:1",
+            "disease:1",
+            "organism:1",
+            "sex:1",
+            "tissue:1",
+            "sre:1",
+            "development_stage:1",
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "organism_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+    ],
+)
 
+var_unmigrated = pd.DataFrame(
+    [
+        [False],
+        [False],
+    ],
+    index=["ENSSASG00005000004", "DUMMY"],
+    columns=[
+        "feature_is_filtered",
+    ],
+)
+
+unmigrated_X = numpy.zeros([good_obs.shape[0], var_unmigrated.shape[0]], dtype=numpy.float32)
 adata_with_lables_unmigrated = anndata.AnnData(
     X=sparse.csr_matrix(unmigrated_X),
-    obs=pd.concat([good_obs, obs_expected], axis=1),
+    obs=umigrated_obs,
     var=var_unmigrated,
-    uns=good_uns,
-    obsm=good_obsm,
+    obsm={"X_umap": numpy.zeros([unmigrated_X.shape[0], 2])},
 )
 adata_with_lables_unmigrated.raw = adata_with_lables_unmigrated.copy()
-adata_with_lables_unmigrated.X = unmigrated_non_raw_X
-adata_with_lables_unmigrated.raw.var.drop("feature_is_filtered", axis=1, inplace=True)

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -152,6 +152,23 @@ var_expected = pd.DataFrame(
     ],
 )
 
+var_unmigrated = pd.DataFrame(
+    [
+        ["spike-in", False, "ERCC-00002 (spike-in control)", "NCBITaxon:32630"],
+        ["gene", False, "MACF1", "NCBITaxon:9606"],
+        ["gene", False, "Trp53", "NCBITaxon:10090"],
+        ["gene", False, "S", "NCBITaxon:2697049"],
+        ["dummy", False, "dummy", "dummy"],
+    ],
+    index=["ERCC-00002", "ENSG00000127603", "ENSMUSG00000059552", "ENSSASG00005000004", "DUMMY"],
+    columns=[
+        "feature_biotype",
+        "feature_is_filtered",
+        "feature_name",
+        "feature_reference",
+    ],
+)
+
 # ---
 # 3. Creating individual uns component
 good_uns = {
@@ -168,6 +185,7 @@ good_uns = {
 X = numpy.zeros([good_obs.shape[0], good_var.shape[0]], dtype=numpy.float32)
 non_raw_X = sparse.csr_matrix(X.copy())
 non_raw_X[0, 0] = 1.5
+
 
 # ---
 # 5.Creating valid obsm
@@ -215,3 +233,20 @@ adata_with_labels = anndata.AnnData(
     uns=good_uns,
     obsm=good_obsm,
 )
+
+
+# X for testing with deprecated genes
+unmigrated_X = numpy.zeros([good_obs.shape[0], var_unmigrated.shape[0]], dtype=numpy.float32)
+unmigrated_non_raw_X = sparse.csr_matrix(unmigrated_X.copy())
+unmigrated_non_raw_X[0, 0] = 1.5
+
+adata_with_lables_unmigrated = anndata.AnnData(
+    X=sparse.csr_matrix(unmigrated_X),
+    obs=pd.concat([good_obs, obs_expected], axis=1),
+    var=var_unmigrated,
+    uns=good_uns,
+    obsm=good_obsm,
+)
+adata_with_lables_unmigrated.raw = adata_with_lables_unmigrated.copy()
+adata_with_lables_unmigrated.X = unmigrated_non_raw_X
+adata_with_lables_unmigrated.raw.var.drop("feature_is_filtered", axis=1, inplace=True)

--- a/cellxgene_schema_cli/tests/test_migrate.py
+++ b/cellxgene_schema_cli/tests/test_migrate.py
@@ -1,4 +1,3 @@
-import unittest
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -7,9 +6,33 @@ from cellxgene_schema.migrate import migrate
 from fixtures.examples_validate import adata_with_lables_unmigrated
 
 
-class TestMigrate(unittest.TestCase):
+class TestMigrate:
     def test_migrate(self):
-        with TemporaryDirectory() as tmp, patch("cellxgene_schema.migrate.DEPRECATED_FEATURE_IDS", ["DUMMY"]):
+        test_ONTOLOGY_TERM_MAPS = {
+            "assay": {
+                "assay:1": "assay:2",
+            },
+            "cell_type": {
+                "cell_type:1": "cell_type:2",
+            },
+            "development_stage": {
+                "development_stage:1": "development_stage:2",
+            },
+            "disease": {
+                "disease:1": "disease:2",
+            },
+            "organism": {
+                "organism:1": "organism:2",
+            },
+            "self_reported_ethnicity": {
+                "sre:1": "sre:2",
+            },
+            "sex": {"sex:1": "sex:2"},
+            "tissue": {"tissue:1": "tissue:2"},
+        }
+        with TemporaryDirectory() as tmp, patch("cellxgene_schema.migrate.DEPRECATED_FEATURE_IDS", ["DUMMY"]), patch(
+            "cellxgene_schema.migrate.ONTOLOGY_TERM_MAPS", test_ONTOLOGY_TERM_MAPS
+        ):
             result_h5ad = tmp + "result.h5ad"
             test_h5ad = tmp + "test.h5ad"
 

--- a/cellxgene_schema_cli/tests/test_migrate.py
+++ b/cellxgene_schema_cli/tests/test_migrate.py
@@ -1,23 +1,27 @@
 import unittest
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
+import anndata
 from cellxgene_schema.migrate import migrate
-from cellxgene_schema.validate import validate
-from fixtures.examples_validate import h5ad_valid
+from fixtures.examples_validate import adata_with_lables_unmigrated
 
 
 class TestMigrate(unittest.TestCase):
     def test_migrate(self):
-        with NamedTemporaryFile() as tmp:
+        with TemporaryDirectory() as tmp, patch("cellxgene_schema.migrate.DEPRECATED_FEATURE_IDS", ["DUMMY"]):
+            result_h5ad = tmp + "result.h5ad"
+            test_h5ad = tmp + "test.h5ad"
+
+            adata_with_lables_unmigrated.copy().write_h5ad(test_h5ad, compression="gzip")
             migrate(
-                input_file=h5ad_valid,
-                output_file=tmp.name,
+                input_file=test_h5ad,
+                output_file=result_h5ad,
                 collection_id="",
                 dataset_id="",
             )
 
-            success, errors, is_seurat_convertible = validate(tmp.name)
-
-            self.assertTrue(success)
-            self.assertListEqual(errors, [])
-            self.assertTrue(is_seurat_convertible)
+            adata = anndata.read_h5ad(result_h5ad)
+            assert not any(adata.var.index.isin(["DUMMY"]))
+            raw_adata = anndata.AnnData(adata.raw.X, var=adata.raw.var, obs=adata.obs)
+            assert not any(raw_adata.var.index.isin(["DUMMY"]))

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -6,6 +6,7 @@ import numpy
 import pandas as pd
 from cellxgene_schema.validate import Validator
 from cellxgene_schema.write_labels import AnnDataLabelAppender
+from utils import getattr_anndata
 
 # Tests for schema compliance of an AnnData object
 
@@ -803,7 +804,7 @@ class TestVar(BaseValidationTest):
         """
 
         # Swap first row for second one
-        var = Validator.getattr_anndata(self.validator.adata, "var")
+        var = getattr_anndata(self.validator.adata, "var")
 
         # First swap the index
         new_index = list(var.index)
@@ -836,7 +837,7 @@ class TestVar(BaseValidationTest):
                 self.validator.errors = []
 
                 # Duplicate 1st row in var and assign it to 2nd
-                component = Validator.getattr_anndata(self.validator.adata, component_name)
+                component = getattr_anndata(self.validator.adata, component_name)
                 new_index = list(component.index)
                 new_index[1] = new_index[0]
                 component.set_index(pd.Index(new_index), inplace=True)
@@ -865,7 +866,7 @@ class TestVar(BaseValidationTest):
                     self.validator.errors = []
                     self.validator.adata = examples.adata.copy()
 
-                    component = Validator.getattr_anndata(self.validator.adata, component_name)
+                    component = getattr_anndata(self.validator.adata, component_name)
                     component.drop(column, axis=1, inplace=True)
 
                     self.validator.validate_adata()
@@ -934,7 +935,7 @@ class TestVar(BaseValidationTest):
                 self.validator.adata = examples.adata.copy()
                 self.validator.errors = []
 
-                component = Validator.getattr_anndata(self.validator.adata, component_name)
+                component = getattr_anndata(self.validator.adata, component_name)
 
                 new_index = list(component.index)
                 new_index[0] = "ENSEBML_NOGENE"
@@ -962,7 +963,7 @@ class TestVar(BaseValidationTest):
                 self.validator.adata = examples.adata.copy()
                 self.validator.errors = []
 
-                component = Validator.getattr_anndata(self.validator.adata, component_name)
+                component = getattr_anndata(self.validator.adata, component_name)
 
                 new_index = list(component.index)
                 new_index[0] = "ENSG000"
@@ -987,7 +988,7 @@ class TestVar(BaseValidationTest):
                 self.validator.adata = examples.adata.copy()
                 self.validator.errors = []
 
-                component = Validator.getattr_anndata(self.validator.adata, component_name)
+                component = getattr_anndata(self.validator.adata, component_name)
 
                 new_index = list(component.index)
                 new_index[0] = "ERCC-000000"

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -6,7 +6,7 @@ import numpy
 import pandas as pd
 from cellxgene_schema.validate import Validator
 from cellxgene_schema.write_labels import AnnDataLabelAppender
-from utils import getattr_anndata
+from cellxgene_schema.utils import getattr_anndata
 
 # Tests for schema compliance of an AnnData object
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -4,9 +4,9 @@ from unittest.mock import patch
 import fixtures.examples_validate as examples
 import numpy
 import pandas as pd
+from cellxgene_schema.utils import getattr_anndata
 from cellxgene_schema.validate import Validator
 from cellxgene_schema.write_labels import AnnDataLabelAppender
-from cellxgene_schema.utils import getattr_anndata
 
 # Tests for schema compliance of an AnnData object
 

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -16,7 +16,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw and DEPRECATED_FEATURE_IDS:
+    if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
         dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -16,7 +16,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw:
+    if dataset.raw and DEPRECATED_FEATURE_IDS:
         dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -93,6 +93,6 @@ def migrate(input_file, output_file, collection_id, dataset_id):
 
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
     if DEPRECATED_FEATURE_IDS:
-    	dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)
+        dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)
 
     dataset.write(output_file, compression="gzip")

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -3,6 +3,15 @@ import anndata as ad
 from . import utils
 
 
+# fmt: off
+DEPRECATED_FEATURE_IDS = [
+	{% for feature in deprecated_feature_ids %}
+    "{{ feature }}",
+	{% endfor %}
+]
+# fmt: on
+
+
 def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
@@ -81,17 +90,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # ...
 
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
-    {% if deprecated_feature_ids %}
-    # fmt: off
-    deprecated_features_ids = [
-        {% for feature in deprecated_feature_ids %}
-        "{{ feature }}",
-        {% endfor %}
-    ]
-    # fmt: on
-    dataset = utils.remove_deprecated_features(dataset, deprecated_features_ids)
-    {% else %}
-    # No Changes
-    {% endif %}
+    if DEPRECATED_FEATURE_IDS:
+    	dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)
 
     dataset.write(output_file, compression="gzip")

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -15,7 +15,9 @@ DEPRECATED_FEATURE_IDS = [
 def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
-    dataset = ad.read_h5ad(input_file)
+    dataset = ad.read_h5ad(input_file, backed="r")
+    if dataset.raw:
+        dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
     # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -2,12 +2,62 @@ import anndata as ad
 
 from . import utils
 
-
 # fmt: off
+# ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
+# Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
+
+# Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
+# 'Replaced By' is not available for a deprecated term.
+
+# If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
+# add them here.
+ONTOLOGY_TERM_MAPS = {
+    "assay": {
+        {% for old, new in ontology_term_map.assay.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    },
+    "cell_type": {
+        {% for old, new in ontology_term_map.cell_type.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    },
+    "development_stage": {
+        {% for old, new in ontology_term_map.development_stage.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    },
+    "disease": {
+        {% for old, new in ontology_term_map.disease.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    },
+    "organism": {
+        {% for old, new in ontology_term_map.organism.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    },
+    "self_reported_ethnicity": {
+        {% for old, new in ontology_term_map.self_reported_ethnicity.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    },
+    "sex": {
+        {% for old, new in ontology_term_map.sex.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    },
+    "tissue": {
+        {% for old, new in ontology_term_map.tissue.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    },
+}
+
 DEPRECATED_FEATURE_IDS = [
-	{% for feature in deprecated_feature_ids %}
+    {% for feature in deprecated_feature_ids %}
     "{{ feature }}",
-	{% endfor %}
+    {% endfor %}
 ]
 # fmt: on
 
@@ -17,61 +67,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
 
     dataset = ad.read_h5ad(input_file, backed="r")
     if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
-        dataset =  dataset.to_memory()
-
-    # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
-    # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
-
-    # Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
-    # 'Replaced By' is not available for a deprecated term.
-
-    # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
-    # add them here.
-    ontology_term_maps = {
-        "assay": {
-            {% for old, new in ontology_term_map.assay.items() %}
-            "{{ old }}": "{{ new }}", # AUTOMATED
-            {% endfor %}
-        },
-        "cell_type": {
-            {% for old, new in ontology_term_map.cell_type.items() %}
-            "{{ old }}": "{{ new }}", # AUTOMATED
-            {% endfor %}
-        },
-        "development_stage": {
-            {% for old, new in ontology_term_map.development_stage.items() %}
-            "{{ old }}": "{{ new }}", # AUTOMATED
-            {% endfor %}
-        },
-        "disease": {
-            {% for old, new in ontology_term_map.disease.items() %}
-            "{{ old }}": "{{ new }}", # AUTOMATED
-            {% endfor %}
-        },
-        "organism": {
-            {% for old, new in ontology_term_map.organism.items() %}
-            "{{ old }}": "{{ new }}", # AUTOMATED
-            {% endfor %}
-        },
-        "self_reported_ethnicity": {
-            {% for old, new in ontology_term_map.self_reported_ethnicity.items() %}
-            "{{ old }}": "{{ new }}", # AUTOMATED
-            {% endfor %}
-        },
-        "sex": {
-            {% for old, new in ontology_term_map.sex.items() %}
-            "{{ old }}": "{{ new }}", # AUTOMATED
-            {% endfor %}
-        },
-        "tissue": {
-            {% for old, new in ontology_term_map.tissue.items() %}
-            "{{ old }}": "{{ new }}", # AUTOMATED
-            {% endfor %}
-        },
-    }
+        dataset = dataset.to_memory()
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ontology_term_maps.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -146,7 +146,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw and DEPRECATED_FEATURE_IDS:
+    if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
         dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -255,7 +255,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw and DEPRECATED_FEATURE_IDS:
+    if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
         dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -49,7 +49,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw:
+    if dataset.raw and DEPRECATED_FEATURE_IDS:
         dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
@@ -146,7 +146,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw:
+    if dataset.raw and DEPRECATED_FEATURE_IDS:
         dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
@@ -255,7 +255,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw:
+    if dataset.raw and DEPRECATED_FEATURE_IDS:
         dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -39,6 +39,12 @@ import anndata as ad
 from . import utils
 
 
+# fmt: off
+DEPRECATED_FEATURE_IDS = [
+]
+# fmt: on
+
+
 def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
@@ -93,7 +99,8 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # ...
 
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
-    # No Changes
+    if DEPRECATED_FEATURE_IDS:
+        dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)
 
     dataset.write(output_file, compression="gzip")"""
 
@@ -125,6 +132,12 @@ def test_generate_script__with_automated_replaced_by_map(template, tmpdir):
 import anndata as ad
 
 from . import utils
+
+
+# fmt: off
+DEPRECATED_FEATURE_IDS = [
+]
+# fmt: on
 
 
 def migrate(input_file, output_file, collection_id, dataset_id):
@@ -184,7 +197,8 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # ...
 
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
-    # No Changes
+    if DEPRECATED_FEATURE_IDS:
+        dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)
 
     dataset.write(output_file, compression="gzip")"""
 
@@ -223,6 +237,14 @@ def test_generate_script__with_gencode_changes(template, tmpdir):
 import anndata as ad
 
 from . import utils
+
+
+# fmt: off
+DEPRECATED_FEATURE_IDS = [
+    "ENSG00000223972",
+    "ENSG00000227232",
+]
+# fmt: on
 
 
 def migrate(input_file, output_file, collection_id, dataset_id):
@@ -279,13 +301,8 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # ...
 
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
-    # fmt: off
-    deprecated_features_ids = [
-        "ENSG00000223972",
-        "ENSG00000227232",
-    ]
-    # fmt: on
-    dataset = utils.remove_deprecated_features(dataset, deprecated_features_ids)
+    if DEPRECATED_FEATURE_IDS:
+        dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)
 
     dataset.write(output_file, compression="gzip")"""
     mock.patch("scripts.migration_assistant.generate_script.get_current_version", return_value=expected_output)

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -49,7 +49,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw and DEPRECATED_FEATURE_IDS:
+    if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
         dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -48,7 +48,9 @@ DEPRECATED_FEATURE_IDS = [
 def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
-    dataset = ad.read_h5ad(input_file)
+    dataset = ad.read_h5ad(input_file, backed="r")
+    if dataset.raw:
+        dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
     # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
@@ -143,7 +145,9 @@ DEPRECATED_FEATURE_IDS = [
 def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
-    dataset = ad.read_h5ad(input_file)
+    dataset = ad.read_h5ad(input_file, backed="r")
+    if dataset.raw:
+        dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
     # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
@@ -250,7 +254,9 @@ DEPRECATED_FEATURE_IDS = [
 def migrate(input_file, output_file, collection_id, dataset_id):
     print(f"Converting {input_file} into {output_file}")
 
-    dataset = ad.read_h5ad(input_file)
+    dataset = ad.read_h5ad(input_file, backed="r")
+    if dataset.raw:
+        dataset =  dataset.to_memory()
 
     # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
     # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -38,8 +38,34 @@ import anndata as ad
 
 from . import utils
 
-
 # fmt: off
+# ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
+# Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
+
+# Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
+# 'Replaced By' is not available for a deprecated term.
+
+# If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
+# add them here.
+ONTOLOGY_TERM_MAPS = {
+    "assay": {
+    },
+    "cell_type": {
+    },
+    "development_stage": {
+    },
+    "disease": {
+    },
+    "organism": {
+    },
+    "self_reported_ethnicity": {
+    },
+    "sex": {
+    },
+    "tissue": {
+    },
+}
+
 DEPRECATED_FEATURE_IDS = [
 ]
 # fmt: on
@@ -50,37 +76,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
 
     dataset = ad.read_h5ad(input_file, backed="r")
     if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
-        dataset =  dataset.to_memory()
-
-    # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
-    # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
-
-    # Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
-    # 'Replaced By' is not available for a deprecated term.
-
-    # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
-    # add them here.
-    ontology_term_maps = {
-        "assay": {
-        },
-        "cell_type": {
-        },
-        "development_stage": {
-        },
-        "disease": {
-        },
-        "organism": {
-        },
-        "self_reported_ethnicity": {
-        },
-        "sex": {
-        },
-        "tissue": {
-        },
-    }
+        dataset = dataset.to_memory()
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ontology_term_maps.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES
@@ -135,8 +134,37 @@ import anndata as ad
 
 from . import utils
 
-
 # fmt: off
+# ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
+# Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
+
+# Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
+# 'Replaced By' is not available for a deprecated term.
+
+# If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
+# add them here.
+ONTOLOGY_TERM_MAPS = {
+    "assay": {
+        "EFO:0000002": "EFO:0000001", # AUTOMATED
+    },
+    "cell_type": {
+        "CL:0000002": "CL:0000001", # AUTOMATED
+        "CL:0000004": "CL:0000003", # AUTOMATED
+    },
+    "development_stage": {
+    },
+    "disease": {
+    },
+    "organism": {
+    },
+    "self_reported_ethnicity": {
+    },
+    "sex": {
+    },
+    "tissue": {
+    },
+}
+
 DEPRECATED_FEATURE_IDS = [
 ]
 # fmt: on
@@ -147,40 +175,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
 
     dataset = ad.read_h5ad(input_file, backed="r")
     if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
-        dataset =  dataset.to_memory()
-
-    # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
-    # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
-
-    # Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
-    # 'Replaced By' is not available for a deprecated term.
-
-    # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
-    # add them here.
-    ontology_term_maps = {
-        "assay": {
-            "EFO:0000002": "EFO:0000001", # AUTOMATED
-        },
-        "cell_type": {
-            "CL:0000002": "CL:0000001", # AUTOMATED
-            "CL:0000004": "CL:0000003", # AUTOMATED
-        },
-        "development_stage": {
-        },
-        "disease": {
-        },
-        "organism": {
-        },
-        "self_reported_ethnicity": {
-        },
-        "sex": {
-        },
-        "tissue": {
-        },
-    }
+        dataset = dataset.to_memory()
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ontology_term_maps.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES
@@ -242,8 +240,34 @@ import anndata as ad
 
 from . import utils
 
-
 # fmt: off
+# ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
+# Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
+
+# Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
+# 'Replaced By' is not available for a deprecated term.
+
+# If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
+# add them here.
+ONTOLOGY_TERM_MAPS = {
+    "assay": {
+    },
+    "cell_type": {
+    },
+    "development_stage": {
+    },
+    "disease": {
+    },
+    "organism": {
+    },
+    "self_reported_ethnicity": {
+    },
+    "sex": {
+    },
+    "tissue": {
+    },
+}
+
 DEPRECATED_FEATURE_IDS = [
     "ENSG00000223972",
     "ENSG00000227232",
@@ -256,37 +280,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
 
     dataset = ad.read_h5ad(input_file, backed="r")
     if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
-        dataset =  dataset.to_memory()
-
-    # ONTOLOGY TERMS TO UPDATE ACROSS ALL DATASETS IN CORPUS
-    # Initialization is AUTOMATED for newly deprecated terms that have 'Replaced By' terms in their ontology files
-
-    # Curators should review the monthly 'Curator Report' and add deprecated term replacements to corresponding map if
-    # 'Replaced By' is not available for a deprecated term.
-
-    # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
-    # add them here.
-    ontology_term_maps = {
-        "assay": {
-        },
-        "cell_type": {
-        },
-        "development_stage": {
-        },
-        "disease": {
-        },
-        "organism": {
-        },
-        "self_reported_ethnicity": {
-        },
-        "sex": {
-        },
-        "tissue": {
-        },
-    }
+        dataset = dataset.to_memory()
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ontology_term_maps.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES


### PR DESCRIPTION
- modify migration template to move DEPRECATED_FEATURE_IDS and ONTOLOGY_TERM_MAPS to outside of the migrate function. This makes testing migrate easier, by allowing us to mock these variables easily.
- Add test h5ad for migration testing.
- extract common functions in validate.py to utils.py
- load h5ad to memory if it has raw and DEPRECATED_FEATURE_IDS.
- Move 