### PR TITLE
fix: automation bugs

### DIFF
--- a/.github/workflows/minor-schema-version-bump.yml
+++ b/.github/workflows/minor-schema-version-bump.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.x"
       - name: setup git
         run: |
           git config user.name github-actions
@@ -145,6 +145,7 @@ jobs:
           packages-dir: cellxgene_schema_cli/dist/
       - name: Install and Test Package from Test PyPI
         run: |
+          pip install -r cellxgene_schema_cli/requirements.txt
           pip install --index-url https://test.pypi.org/simple/ cellxgene-schema
           cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad
 # TODO: Uncomment once ready to release to prod PyPI

--- a/.github/workflows/minor-schema-version-bump.yml
+++ b/.github/workflows/minor-schema-version-bump.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
       - name: setup git
         run: |
           git config user.name github-actions
@@ -244,7 +244,7 @@ jobs:
           git config user.email github-actions@github.com
       - name: remove diff files
         run: |
-          git rm ./cellxgene_schema_cli/cellxgene_schema/ontology_files/*_diff.txt
+          git rm --ignore-unmatch ./cellxgene_schema_cli/cellxgene_schema/ontology_files/*_diff.txt
       - name: Bump Version
         run: |
           pip install bumpversion

--- a/.github/workflows/minor-schema-version-bump.yml
+++ b/.github/workflows/minor-schema-version-bump.yml
@@ -133,7 +133,6 @@ jobs:
           pip install wheel
           bumpversion --config-file .bumpversion.cfg minor --allow-dirty
           bumpversion --config-file .bumpversion.cfg prerel --allow-dirty --tag
-          git push origin --follow-tags
       - name: Build dist
         run: >-
           make pydist
@@ -155,6 +154,9 @@ jobs:
 #        with:
 #          password: ${{ secrets.PYPI_API_TOKEN }}
 #          package-dir: cellxgene_schema_cli/
+      - name: Push tags
+        run: |
+          git push origin --follow-tags
       - name: Trigger rebuild of Data Portal Processing Image
         run: |
           curl -X POST https://api.github.com/repos/chanzuckerberg/single-cell-data-portal/dispatches \
@@ -212,7 +214,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }} # checking out the lasted commit to this branch
+          ref: ${{ github.event.pull_request.head.ref }} # checking out the last commit to this branch
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -29,6 +29,7 @@ jobs:
           packages-dir: cellxgene_schema_cli/dist/
       - name: Install and Test Package from Test PyPI
         run: |
+          pip install -r cellxgene_schema_cli/requirements.txt
           pip install --index-url https://test.pypi.org/simple/ cellxgene-schema
           cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad
 # TODO: Uncomment once ready to release to prod PyPI

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -25,6 +25,16 @@ def replace_ontology_term(dataframe, ontology_name, update_map):
             dataframe[column_name] = dataframe[column_name].cat.remove_categories(old_term)
 
 
+def map_ontology_term(dataframe, ontology_name, map_from_column, update_map):
+    column_name = f"{ontology_name}_ontology_term_id"
+    if dataframe[column_name].dtype != "category":
+        dataframe[column_name] = dataframe[column_name].astype("category")
+    for map_value,new_term in update_map.items():
+        if new_term not in dataframe[column_name].cat.categories:
+            dataframe[column_name] = dataframe[column_name].cat.add_categories(new_term)
+        dataframe.loc[dataframe[map_from_column] == map_value, column_name] = new_term
+
+
 def remove_deprecated_features(adata: ad.AnnData, deprecated: List[str]) -> ad.AnnData:
     # Filter out genes that don't appear in the approved annotation
     var_to_keep = adata.var.index[~adata.var.index.isin(deprecated)].tolist()

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -29,7 +29,7 @@ def map_ontology_term(dataframe, ontology_name, map_from_column, update_map):
     column_name = f"{ontology_name}_ontology_term_id"
     if dataframe[column_name].dtype != "category":
         dataframe[column_name] = dataframe[column_name].astype("category")
-    for map_value,new_term in update_map.items():
+    for map_value, new_term in update_map.items():
         if new_term not in dataframe[column_name].cat.categories:
             dataframe[column_name] = dataframe[column_name].cat.add_categories(new_term)
         dataframe.loc[dataframe[map_from_column] == map_value, column_name] = new_term

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -33,6 +33,7 @@ def map_ontology_term(dataframe, ontology_name, map_from_column, update_map):
         if new_term not in dataframe[column_name].cat.categories:
             dataframe[column_name] = dataframe[column_name].cat.add_categories(new_term)
         dataframe.loc[dataframe[map_from_column] == map_value, column_name] = new_term
+    dataframe[column_name] = dataframe[column_name].cat.remove_unused_categories()
 
 
 def remove_deprecated_features(adata: ad.AnnData, deprecated: List[str]) -> ad.AnnData:

--- a/cellxgene_schema_cli/tests/test_utils.py
+++ b/cellxgene_schema_cli/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from cellxgene_schema.utils import remove_deprecated_features, replace_ontology_term
+from cellxgene_schema.utils import map_ontology_term, remove_deprecated_features, replace_ontology_term
 from fixtures.examples_validate import adata, adata_non_raw
 
 
@@ -56,7 +56,18 @@ def test_replace_ontology_term__with_replacement(adata_with_raw, deprecated_term
 
 def test_replace_ontology_term__no_replacement(adata_with_raw, deprecated_term_map_no_replacement_match):
     replace_ontology_term(adata_with_raw.obs, "assay", deprecated_term_map_no_replacement_match)
-
     expected = ["EFO:0009899", "EFO:0009918"]
     actual = adata_with_raw.obs["assay_ontology_term_id"].dtype.categories
     assert all(a == b for a, b in zip(actual, expected))
+
+
+def test_map_ontology_term__(adata_without_raw):
+    update_map = {"donor_1": "CL:0000001", "donor_2": "CL:0000002"}
+    map_ontology_term(adata_without_raw.obs, "cell_type", "donor_id", update_map)
+    expected = ["CL:0000001", "CL:0000002"]
+    actual = adata_without_raw.obs["cell_type_ontology_term_id"].dtype.categories
+    assert all(a == b for a, b in zip(actual, expected))
+    donor_1_rows = adata_without_raw.obs.loc[adata_without_raw.obs['donor_id'] == "donor_1"]
+    assert all(a == "CL:0000001" for a in donor_1_rows["cell_type_ontology_term_id"])
+    donor_2_rows = adata_without_raw.obs.loc[adata_without_raw.obs['donor_id'] == "donor_2"]
+    assert all(a == "CL:0000002" for a in donor_2_rows["cell_type_ontology_term_id"])

--- a/cellxgene_schema_cli/tests/test_utils.py
+++ b/cellxgene_schema_cli/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_map_ontology_term__(adata_without_raw):
     expected = ["CL:0000001", "CL:0000002"]
     actual = adata_without_raw.obs["cell_type_ontology_term_id"].dtype.categories
     assert all(a == b for a, b in zip(actual, expected))
-    donor_1_rows = adata_without_raw.obs.loc[adata_without_raw.obs['donor_id'] == "donor_1"]
+    donor_1_rows = adata_without_raw.obs.loc[adata_without_raw.obs["donor_id"] == "donor_1"]
     assert all(a == "CL:0000001" for a in donor_1_rows["cell_type_ontology_term_id"])
-    donor_2_rows = adata_without_raw.obs.loc[adata_without_raw.obs['donor_id'] == "donor_2"]
+    donor_2_rows = adata_without_raw.obs.loc[adata_without_raw.obs["donor_id"] == "donor_2"]
     assert all(a == "CL:0000002" for a in donor_2_rows["cell_type_ontology_term_id"])

--- a/scripts/compute_mappings/requirements.txt
+++ b/scripts/compute_mappings/requirements.txt
@@ -1,4 +1,4 @@
-awscli==1.29.1
+awscli==1.29.13
 owlready2==0.38
 pygraphviz==1.11 --global-option=build_ext --global-option="-I$(brew --prefix graphviz)/include" --global-option="-L$(brew --prefix graphviz)/lib"
 requests==2.31.0


### PR DESCRIPTION
- Fresh install of cellxgene_schema_cli requirements to ensure latest version is downloaded for test step after upload (if not, dependency resolver could try to install previous version to avoid conflicting dependencies) 
- add --ignore-unmatch flag to git rm *_diff files, to avoid error when no _diff files (i.e. no GENCODE update) exists 
- Update awscli pinned version for compute_mappings step (known error found in nested dependency)
- Add Jason's util function for migrate PRs
- Move push tags step until after we validate pypi upload