### PR TITLE
feat(migrate): set migrate reviewers

### DIFF
--- a/.github/workflows/minor-schema-version-bump.yml
+++ b/.github/workflows/minor-schema-version-bump.yml
@@ -259,7 +259,7 @@ jobs:
           body: 'This is an automated PR to update migrate.py from schema_version ${{ env.old_version }}->${{ env.new_version }}.'
           branch: auto/update-convert-py-to-${{ env.new_version }}
           base: main
-          reviewers: bento007 # TODO assign curators
+          reviewers: ${{ vars.MIGRATION_REVIEWERS }}
           add-paths: |
             cellxgene_schema_cli/setup.py
             cellxgene_schema_cli/cellxgene_schema/__init__.py


### PR DESCRIPTION
Now the reviewers that are set when minor-schema-version-bump.yml can be changed using github variables. Before a new PR was required to modify this value. 
<img width="810" alt="Screenshot 2023-08-04 at 1 43 06 PM" src="https://github.com/chanzuckerberg/single-cell-curation/assets/1429913/79f8ffe2-0e23-47d5-89b5-b96390f0c0eb">
