### PR TITLE
feat: Add a Github Action that automatically closes stale PRs.

### DIFF
--- a/.github/workflows/close-inactive-prs.yml
+++ b/.github/workflows/close-inactive-prs.yml
@@ -1,0 +1,22 @@
+name: Close inactive pull requests
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-pr-stale: 14
+          days-before-pr-close: 3
+          stale-pr-message: "This PR has not seen any activity in the past 2 weeks; if no one comments or reviews it in the next 3 days, this PR will be closed."
+          close-pr-message: "This PR was closed because it has been inactive for 17 days, 3 days since being marked as stale. Please re-open if you still need this to be addressed."
+          stale-pr-label: "stale"
+          close-pr-label: "autoclosed"
+          exempt-draft-pr: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Reason for Change

As we move to CI/CD, some automation can help ensure that we're working towards trunk-based development and ensuring that non-draft PRs don't stay open too long without some movement. Ideally, this Github Action helps us with a few things:

1. PRs remain small so that they can be reviewed quickly and merged.
2. If a PR has be alive for more than 2 weeks, updates are required so that there is visibility as to why the PR is blocked. 
3. If the PR has to be alive for more than 2 weeks and is blocked, it reverts to being a draft PR or closed.

## Ticket Number
No ticket.

## Changes

### Additions

Add a Github Action that runs daily. Each day all active (non-draft) PRs older than 2 weeks are marked with a stale tag and a warning comment is made to update the PR. In another 3 days (3 days was chosen to accommodate long weekends + 1 day), the PR will be automatically closed.

### Deletions

None.

### Modifications

None.

## Testing steps

Not tested.

## Notes for Reviewer

None.
