### PR TITLE
feat: validate raw matrix does not have more genes than raw var

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -50,6 +50,14 @@ def remove_deprecated_features(adata: ad.AnnData, deprecated: List[str]) -> ad.A
     return adata
 
 
+def get_num_vars_in_raw_matrix(adata: ad.AnnData) -> int:
+    return adata.raw.X.shape[1]
+
+
+def get_num_vars_in_raw_var(adata: ad.AnnData) -> int:
+    return adata.raw.var.shape[0]
+
+
 def get_matrix_format(adata: ad.AnnData, matrix: Union[np.ndarray, sparse.spmatrix]) -> str:
     """
     Given a matrix, returns the format as one of: csc, csr, coo, dense

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -50,14 +50,6 @@ def remove_deprecated_features(adata: ad.AnnData, deprecated: List[str]) -> ad.A
     return adata
 
 
-def get_num_vars_in_raw_matrix(adata: ad.AnnData) -> int:
-    return adata.raw.X.shape[1]
-
-
-def get_num_vars_in_raw_var(adata: ad.AnnData) -> int:
-    return adata.raw.var.shape[0]
-
-
 def get_matrix_format(adata: ad.AnnData, matrix: Union[np.ndarray, sparse.spmatrix]) -> str:
     """
     Given a matrix, returns the format as one of: csc, csr, coo, dense

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -802,7 +802,7 @@ class Validator:
                 self.is_seurat_convertible = False
 
         # Check to make sure raw.var has the same dimensionality as raw.X
-        if get_num_vars_in_raw_matrix(self.adata) != get_num_vars_in_raw_var(self.adata):
+        if self.adata.raw and get_num_vars_in_raw_matrix(self.adata) != get_num_vars_in_raw_var(self.adata):
             self.warnings.append(
                 f"This dataset cannot be converted to the .rds (Seurat v4) format. "
                 f"There is a mismatch in the number of variables in the raw matrix and the raw var key-indexed "

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -12,7 +12,7 @@ from pandas.core.computation.ops import UndefinedVariableError
 from scipy import sparse
 
 from . import ontology, schema
-from .utils import get_matrix_format, getattr_anndata, read_h5ad
+from .utils import get_matrix_format, getattr_anndata, read_h5ad, get_num_vars_in_raw_var, get_num_vars_in_raw_matrix
 
 logger = logging.getLogger(__name__)
 
@@ -800,6 +800,15 @@ class Validator:
                     )
 
                 self.is_seurat_convertible = False
+
+        # Check to make sure raw.var has the same dimensionality as raw.X
+        if get_num_vars_in_raw_matrix(self.adata) != get_num_vars_in_raw_var(self.adata):
+            self.warnings.append(
+                f"This dataset cannot be converted to the .rds (Seurat v4) format. "
+                f"There is a mismatch in the number of variables in the raw matrix and the raw var key-indexed "
+                f"variables."
+            )
+            self.is_seurat_convertible = False
 
     def _validate_embedding_dict(self):
         """

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -803,9 +803,9 @@ class Validator:
 
         if self.adata.raw and self.adata.raw.X.shape[1] != self.adata.raw.var.shape[0]:
             self.warnings.append(
-                f"This dataset cannot be converted to the .rds (Seurat v4) format. "
-                f"There is a mismatch in the number of variables in the raw matrix and the raw var key-indexed "
-                f"variables."
+                "This dataset cannot be converted to the .rds (Seurat v4) format. "
+                "There is a mismatch in the number of variables in the raw matrix and the raw var key-indexed "
+                "variables."
             )
             self.is_seurat_convertible = False
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -12,7 +12,7 @@ from pandas.core.computation.ops import UndefinedVariableError
 from scipy import sparse
 
 from . import ontology, schema
-from .utils import get_matrix_format, getattr_anndata, read_h5ad, get_num_vars_in_raw_var, get_num_vars_in_raw_matrix
+from .utils import get_matrix_format, getattr_anndata, read_h5ad
 
 logger = logging.getLogger(__name__)
 
@@ -801,8 +801,7 @@ class Validator:
 
                 self.is_seurat_convertible = False
 
-        # Check to make sure raw.var has the same dimensionality as raw.X
-        if self.adata.raw and get_num_vars_in_raw_matrix(self.adata) != get_num_vars_in_raw_var(self.adata):
+        if self.adata.raw and self.adata.raw.X.shape[1] != self.adata.raw.var.shape[0]:
             self.warnings.append(
                 f"This dataset cannot be converted to the .rds (Seurat v4) format. "
                 f"There is a mismatch in the number of variables in the raw matrix and the raw var key-indexed "

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -319,3 +319,17 @@ class TestSeuratConvertibility(unittest.TestCase):
         self.validator._validate_seurat_convertibility()
         self.assertTrue(len(self.validator.warnings) == 0)
         self.assertTrue(self.validator.is_seurat_convertible)
+
+    @mock.patch("cellxgene_schema.validate.get_num_vars_in_raw_var")
+    @mock.patch("cellxgene_schema.validate.get_num_vars_in_raw_matrix")
+    def test_seurat_raw_matrix_and_var_dimensionality(self, get_num_vars_in_raw_matrix_mock, get_num_vars_in_raw_var_mock):
+        # h5ad where raw matrix variable count != length of raw var variables array is not Seurat-convertible
+        get_num_vars_in_raw_matrix_mock.return_value = 2
+        get_num_vars_in_raw_var_mock.return_value = 1
+
+        validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata
+        validator._validate_seurat_convertibility()
+        assert len(validator.warnings) == 1
+        assert not validator.is_seurat_convertible

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -325,7 +325,7 @@ class TestSeuratConvertibility(unittest.TestCase):
         # h5ad where raw matrix variable count != length of raw var variables array is not Seurat-convertible
         matrix = sparse.csr_matrix(np.zeros([good_obs.shape[0], good_var.shape[0]], dtype=np.float32))
         raw = anndata.AnnData(X=matrix, var=good_var)
-        raw.var.drop('ENSSASG00005000004', axis=0, inplace=True)
+        raw.var.drop("ENSSASG00005000004", axis=0, inplace=True)
         self.validation_helper(matrix, raw)
         self.validator._validate_seurat_convertibility()
         self.assertTrue(len(self.validator.warnings) == 1)


### PR DESCRIPTION
I factored out the dimension attribute access so that testing could make use of `unittest.mock.patch`; the AnnData object appears to be somewhat resistant to my attempts to edit the actual `.raw.X` and `.raw.var`.