### PR TITLE
feat: fail when raw matrix var count > raw var count

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -802,10 +802,9 @@ class Validator:
                 self.is_seurat_convertible = False
 
         if self.adata.raw and self.adata.raw.X.shape[1] != self.adata.raw.var.shape[0]:
-            self.warnings.append(
-                "This dataset cannot be converted to the .rds (Seurat v4) format. "
-                "There is a mismatch in the number of variables in the raw matrix and the raw var key-indexed "
-                "variables."
+            self.errors.append(
+                "This dataset has a mismatch between 1) the number of variables in the raw matrix and 2) the number of "
+                "raw var key-indexed variables. These counts must be identical."
             )
             self.is_seurat_convertible = False
 

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -328,5 +328,6 @@ class TestSeuratConvertibility(unittest.TestCase):
         raw.var.drop("ENSSASG00005000004", axis=0, inplace=True)
         self.validation_helper(matrix, raw)
         self.validator._validate_seurat_convertibility()
-        self.assertTrue(len(self.validator.warnings) == 1)
+        self.assertTrue(len(self.validator.errors) == 1)
         self.assertFalse(self.validator.is_seurat_convertible)
+        self.assertFalse(self.validator.is_valid)


### PR DESCRIPTION
This commit escalates the response from the validator when the raw matrix variable count does not exactly equal the count of key-indexed variables in raw.var: instead of producing a warning, it produces an error and fails validation.

## Reason for Change

- #418 

## Changes

- Change warning to failure

## Testing

- Unit test updated
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer