### PR TITLE
chore: update schema workflows to run on manual dispatch rather than auto-triggers

### DIFF
--- a/.github/workflows/minor-schema-version-bump.yml
+++ b/.github/workflows/minor-schema-version-bump.yml
@@ -1,13 +1,7 @@
 name: Minor Schema Version Bump Workflow
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/all_ontology.json.gz'
-      - '**/cellxgene_schema_cli/cellxgene_schema/ontology_files/*.csv.gz'
-      - '**/.github/workflows/minor-schema-version-bump.yml'
+  workflow_dispatch
 
 permissions:
   id-token: write

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -1,12 +1,7 @@
 name: Trigger Schema Migration
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '**/cellxgene_schema_cli/cellxgene_schema/migrate.py'
-      - '**/.github/workflows/trigger-schema-migration.yml'
+  workflow_dispatch
 
 jobs:
   publish-to-pypi:


### PR DESCRIPTION
## Reason for Change

- https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/573
- Required to not auto-dispatch major schema version updates (otherwise, we will be forced to schedule and enforce ontology/gene reference file bumps as the last update we make to major schema version updates, lest we trigger the bump workflow prematurely)

## Changes

- trigger workflows related to dry-run, pypi publish, migrate PR creation, batch job run manually rather than on updates to specific files (we might want to update these files without accidentally triggering these workflows)

## Testing

- N/A, github action syntax for this operation is well-documented and testing would require triggering workflow steps we don't want to run

## Notes for Reviewer