### PR TITLE
feat(4.0): Remove 5000 cell limit for raw validation

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -289,8 +289,8 @@ class Validator:
 
         return
 
+    @staticmethod
     def _chunk_matrix(
-        self,
         matrix: Union[np.ndarray, sparse.spmatrix],
         obs_chunk_size: Optional[int] = 10_000,
     ):
@@ -899,17 +899,15 @@ class Validator:
         else:
             return "X"
 
-    def _is_raw(self, max_values_to_check: int = 5000, force: bool = False) -> bool:
+    def _is_raw(self, force: bool = False) -> bool:
         """
-        Checks if the first non-zero "max_values_to_check" in the best guess for the raw matrix (adata.X or adata.raw.X)
+        Checks if the non-zero values for the raw matrix (adata.X or adata.raw.X)
         are integers. Returns False if at least one value is not an integer,
 
         True otherwise.
 
         Since this process is memory intensive, it will return a cache value if this function has been called before.
         If calculation needs to be repeated use `force = True`
-
-        :param int max_values_to_check: total values to check, default set to 5000 due to performance concerns.
 
         :rtype bool
         :return False if at least one value is not an integer, True otherwise
@@ -922,7 +920,6 @@ class Validator:
             raw_loc = self._get_raw_x_loc()
             x = self.adata.raw.X if raw_loc == "raw.X" else self.adata.X
 
-            num_values_checked = 0
             format = get_matrix_format(self.adata, x)
             assert format != "unknown"
             self._raw_layer_exists = True
@@ -930,10 +927,6 @@ class Validator:
                 data = matrix_chunk if isinstance(matrix_chunk, np.ndarray) else matrix_chunk.data
                 if (data % 1 > 0).any():
                     self._raw_layer_exists = False
-                    break
-
-                num_values_checked += matrix_chunk.nnz if format != "dense" else np.count_nonzero(matrix_chunk)
-                if num_values_checked > max_values_to_check:
                     break
 
         return self._raw_layer_exists


### PR DESCRIPTION
## Reason for Change

- #382
## Changes
- remove `max_values_to_check`  from `Validator._is_raw`
- Add unit test for the `Validator._is_raw`
- Used [memory_profiler](https://pypi.org/project/memory-profiler/) to verify memory usuage does not explode with this change. A 1,395,601 cell dataset used <5GB of memory. The original size of the file was 50GB.


## Testing
### Setup
1. Download the dataset: [Whole Taxonomy - DLPFC: Seattle Alzheimer's Disease Atlas (SEA-AD)](https://cellxgene.cziscience.com/collections/1ca90a2d-2943-483d-b678-b809bf464c30)
1. run `make install` to install the local cellxgene_schema version.
3. `run pip install memory_profiler`

4. *test.py* 
 ```python
import anndata
from cellxgene_schema.validate import Validator
from memory_profiler import profile

def test():
    func = profile(validator._is_raw)
    func()

if __name__ == "__main__":
    adata = anndata.read_h5ad("/single-cell-curation/local.h5ad", backed=True)
    validator = Validator()
    validator.adata = adata
    test()
```
5. `$ python -m memory_profiler test.py `
6.  `$ mprof run --multiprocess --python python test.py`

### Output
`$ python -m memory_profiler test.py `
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   902   2024.4 MiB   2024.4 MiB           1       def _is_raw(self, force: bool = False) -> bool:
   903                                                 """
   904                                                 Checks if the non-zero values for the raw matrix (adata.X or adata.raw.X)
   905                                                 are integers. Returns False if at least one value is not an integer,
   906                                         
   907                                                 True otherwise.
   908                                         
   909                                                 Since this process is memory intensive, it will return a cache value if this function has been called before.
   910                                                 If calculation needs to be repeated use `force = True`
   911                                         
   912                                                 :rtype bool
   913                                                 :return False if at least one value is not an integer, True otherwise
   914                                                 """
   915   2024.4 MiB      0.0 MiB           1           if force:
   916                                                     self._raw_layer_exists = None
   917                                         
   918   2024.4 MiB      0.0 MiB           1           if self._raw_layer_exists is None:
   919                                                     # Get potential raw_X
   920   2024.4 MiB      0.0 MiB           1               raw_loc = self._get_raw_x_loc()
   921   2024.4 MiB      0.0 MiB           1               x = self.adata.raw.X if raw_loc == "raw.X" else self.adata.X
   922                                         
   923   2024.6 MiB      0.1 MiB           1               format = get_matrix_format(self.adata, x)
   924   2024.6 MiB      0.0 MiB           1               assert format != "unknown"
   925   2024.6 MiB      0.0 MiB           1               self._raw_layer_exists = True
   926   4906.7 MiB -59210.0 MiB         141               for matrix_chunk, _, _ in self._chunk_matrix(x):
   927   4906.7 MiB -60877.5 MiB         140                   data = matrix_chunk if isinstance(matrix_chunk, np.ndarray) else matrix_chunk.data
   928   4904.0 MiB -60558.2 MiB         140                   if (data % 1 > 0).any():
   929                                                             self._raw_layer_exists = False
   930                                                             break
   931                                         
   932   4061.9 MiB   -844.8 MiB           1           return self._raw_layer_exists


Filename: is_raw.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     5   2024.4 MiB   2024.4 MiB           1   @profile
     6                                         def test():
     7   2024.4 MiB      0.0 MiB           1       func = profile(validator._is_raw)
     8   4062.1 MiB   2037.7 MiB           1       func()

```
`$ mprof run --multiprocess --python python test.py`
<img width="1152" alt="Screenshot 2023-09-19 at 1 16 18 PM" src="https://github.com/chanzuckerberg/single-cell-curation/assets/1429913/3977bb87-e5fb-4596-ab74-49a87b3bb4d5">


## Notes for Reviewer
Before these changes this was the performance or the above dataset
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   896   2332.0 MiB   2332.0 MiB           1       def _is_raw(self, max_values_to_check: int = 5000, force: bool = False) -> bool:
   897                                                 """
   898                                                 Checks if the first non-zero "max_values_to_check" in the best guess for the raw matrix (adata.X or adata.raw.X)
   899                                                 are integers. Returns False if at least one value is not an integer,
   900                                         
   901                                                 True otherwise.
   902                                         
   903                                                 Since this process is memory intensive, it will return a cache value if this function has been called before.
   904                                                 If calculation needs to be repeated use `force = True`
   905                                         
   906                                                 :param int max_values_to_check: total values to check, default set to 5000 due to performance concerns.
   907                                         
   908                                                 :rtype bool
   909                                                 :return False if at least one value is not an integer, True otherwise
   910                                                 """
   911   2332.0 MiB      0.0 MiB           1           if force:
   912                                                     self._raw_layer_exists = None
   913                                         
   914   2332.0 MiB      0.0 MiB           1           if self._raw_layer_exists is None:
   915                                                     # Get potential raw_X
   916   2332.0 MiB      0.0 MiB           1               raw_loc = self._get_raw_x_loc()
   917   2332.0 MiB      0.0 MiB           1               x = self.adata.raw.X if raw_loc == "raw.X" else self.adata.X
   918                                         
   919   2332.0 MiB      0.0 MiB           1               num_values_checked = 0
   920   2332.2 MiB      0.2 MiB           1               format = get_matrix_format(self.adata, x)
   921   2332.2 MiB      0.0 MiB           1               assert format != "unknown"
   922   2332.2 MiB      0.0 MiB           1               self._raw_layer_exists = True
   923   4175.4 MiB   1843.2 MiB           1               for matrix_chunk, _, _ in self._chunk_matrix(x):
   924   4175.4 MiB      0.0 MiB           1                   data = matrix_chunk if isinstance(matrix_chunk, np.ndarray) else matrix_chunk.data
   925   4230.3 MiB     54.9 MiB           1                   if (data % 1 > 0).any():
   926                                                             self._raw_layer_exists = False
   927                                                             break
   928                                         
   929   4230.3 MiB      0.0 MiB           1                   num_values_checked += matrix_chunk.nnz if format != "dense" else np.count_nonzero(matrix_chunk)
   930   4230.3 MiB      0.0 MiB           1                   if num_values_checked > max_values_to_check:
   931   4230.3 MiB      0.0 MiB           1                       break
   932                                         
   933   4230.3 MiB      0.0 MiB           1           return self._raw_layer_exists


Filename: is_raw.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     5   2332.0 MiB   2332.0 MiB           1   @profile
     6                                         def test():
     7   2332.0 MiB      0.0 MiB           1       func = profile(validator._is_raw)
     8   4230.3 MiB   1898.3 MiB           1       func()
```

<img width="1159" alt="Screenshot 2023-09-19 at 2 51 29 PM" src="https://github.com/chanzuckerberg/single-cell-curation/assets/1429913/a278ad9a-7b8c-4008-8ce5-83b15f444d68">

### Conclusion
It is much slower since we are looking over all of rows and reading in chunks.