### PR TITLE
feat: fix X_{suffix} validation and add test coverage

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -837,7 +837,7 @@ class Validator:
 
                 if len(key) <= 3:
                     self.errors.append(
-                        f"Embedding key in 'adata.obsm' {key} must have a suffix more than one character long."
+                        f"Embedding key in 'adata.obsm' {key} must have a suffix at least one character long."
                     )
                 if len(value.shape) < 2 or value.shape[0] != self.adata.n_obs or value.shape[1] < 2:
                     self.errors.append(

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -822,6 +822,11 @@ class Validator:
 
         obsm_with_x_prefix = 0
         for key, value in self.adata.obsm.items():
+            if " " in key:
+                self.errors.append(
+                    f"Embedding key {key} has whitespace in it, please remove it."
+                )
+
             if not isinstance(value, np.ndarray):
                 self.errors.append(
                     f"All embeddings have to be of 'numpy.ndarray' type, " f"'adata.obsm['{key}']' is {type(value)}')."
@@ -832,20 +837,26 @@ class Validator:
             if key.startswith("X_"):
                 obsm_with_x_prefix += 1
 
-                if not (np.issubdtype(value.dtype, np.integer) or np.issubdtype(value.dtype, np.floating)):
+                if len(key) <= 3:
                     self.errors.append(
-                        f"adata.obsm['{key}'] has an invalid data type. It should be "
-                        "float, integer, or unsigned integer of any precision (8, 16, 32, or 64 bits)."
+                        f"Embedding key in 'adata.obsm' {key} must have a suffix more than one character long."
                     )
-                if np.isinf(value).any() or np.isnan(value).any():
-                    self.errors.append(f"adata.obsm['{key}'] contains positive infinity or negative infinity values.")
-                if np.isnan(value).any():
-                    self.errors.append(f"adata.obsm['{key}'] contains NaN values.")
                 if len(value.shape) < 2 or value.shape[0] != self.adata.n_obs or value.shape[1] < 2:
                     self.errors.append(
                         f"All embeddings must have as many rows as cells, and at least two columns."
                         f"'adata.obsm['{key}']' has shape of '{value.shape}'."
                     )
+                if not (np.issubdtype(value.dtype, np.integer) or np.issubdtype(value.dtype, np.floating)):
+                    self.errors.append(
+                        f"adata.obsm['{key}'] has an invalid data type. It should be "
+                        "float, integer, or unsigned integer of any precision (8, 16, 32, or 64 bits)."
+                    )
+                else:
+                    # Check for inf/NaN values only if the dtype is numeric
+                    if np.isinf(value).any():
+                        self.errors.append(f"adata.obsm['{key}'] contains positive infinity or negative infinity values.")
+                    if np.all(np.isnan(value)):
+                        self.errors.append(f"adata.obsm['{key}'] contains all NaN values.")
 
         if obsm_with_x_prefix == 0:
             self.errors.append("At least one embedding in 'obsm' has to have a key with an 'X_' prefix.")

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -823,9 +823,7 @@ class Validator:
         obsm_with_x_prefix = 0
         for key, value in self.adata.obsm.items():
             if " " in key:
-                self.errors.append(
-                    f"Embedding key {key} has whitespace in it, please remove it."
-                )
+                self.errors.append(f"Embedding key {key} has whitespace in it, please remove it.")
 
             if not isinstance(value, np.ndarray):
                 self.errors.append(
@@ -854,7 +852,9 @@ class Validator:
                 else:
                     # Check for inf/NaN values only if the dtype is numeric
                     if np.isinf(value).any():
-                        self.errors.append(f"adata.obsm['{key}'] contains positive infinity or negative infinity values.")
+                        self.errors.append(
+                            f"adata.obsm['{key}'] contains positive infinity or negative infinity values."
+                        )
                     if np.all(np.isnan(value)):
                         self.errors.append(f"adata.obsm['{key}'] contains all NaN values.")
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1339,7 +1339,7 @@ class TestObsm(BaseValidationTest):
             ["ERROR: Embedding key X_ umap has whitespace in it, please remove it."],
         )
 
-    def test_obsm_shape(self):
+    def test_obsm_shape_one_column(self):
         """
         Curators MUST annotate one or more two-dimensional (m >= 2) embeddings
         """
@@ -1355,6 +1355,19 @@ class TestObsm(BaseValidationTest):
                 "of '(2, 1)'."
             ],
         )
+
+    def test_obsm_shape_same_rows_and_columns(self):
+        """
+        The number of rows must be equal to the number of columns
+        """
+        # Create a 3 row array
+        arr1 = numpy.array([0, 0])
+        arr2 = numpy.array([0, 0])
+        arr3 = numpy.array([0, 0])
+        three_row_array = numpy.vstack((arr1, arr2, arr3))
+        with self.assertRaises(ValueError):
+            self.validator.adata.obsm["X_umap"] = three_row_array
+            self.validator.validate_adata()
 
 
 class TestAddingLabels(unittest.TestCase):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1278,8 +1278,10 @@ class TestObsm(BaseValidationTest):
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
-            ["ERROR: adata.obsm['X_umap'] has an invalid data type. It should be float, integer, or unsigned "
-             "integer of any precision (8, 16, 32, or 64 bits)."],
+            [
+                "ERROR: adata.obsm['X_umap'] has an invalid data type. It should be float, integer, or unsigned "
+                "integer of any precision (8, 16, 32, or 64 bits)."
+            ],
         )
 
     def test_obsm_values_nan(self):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1257,18 +1257,16 @@ class TestObsm(BaseValidationTest):
                 "'adata.obsm['X_tsne']' is <class 'pandas.core.frame.DataFrame'>')."
             ],
         )
-    
+
     def test_obsm_values_infinity(self):
         """
         values in obsm cannot have any infinity values
         """
-        self.validator.adata.obsm['X_umap'][0:100,1] = numpy.inf
+        self.validator.adata.obsm["X_umap"][0:100, 1] = numpy.inf
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
-            [
-                "ERROR: adata.obsm['X_umap'] contains positive infinity or negative infinity values."
-            ],
+            ["ERROR: adata.obsm['X_umap'] contains positive infinity or negative infinity values."],
         )
 
     def test_obsm_values_nan(self):
@@ -1277,13 +1275,13 @@ class TestObsm(BaseValidationTest):
         """
 
         # It's okay if only one value is NaN
-        self.validator.adata.obsm['X_umap'][0:100,1] = numpy.nan
+        self.validator.adata.obsm["X_umap"][0:100, 1] = numpy.nan
         self.validator.validate_adata()
         self.assertEqual(self.validator.errors, [])
 
         # It's not okay if all values are NaN
-        all_nan = numpy.full(self.validator.adata.obsm['X_umap'].shape, numpy.nan)
-        self.validator.adata.obsm['X_umap'] = all_nan
+        all_nan = numpy.full(self.validator.adata.obsm["X_umap"].shape, numpy.nan)
+        self.validator.adata.obsm["X_umap"] = all_nan
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
@@ -1314,7 +1312,7 @@ class TestObsm(BaseValidationTest):
             self.validator.errors,
             ["ERROR: Embedding key in 'adata.obsm' X_ must have a suffix more than one character long."],
         )
-    
+
     def test_obsm_key_name_valid(self):
         """
         Embedding keys with whitespace are not valid

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1269,6 +1269,19 @@ class TestObsm(BaseValidationTest):
             ["ERROR: adata.obsm['X_umap'] contains positive infinity or negative infinity values."],
         )
 
+    def test_obsm_values_str(self):
+        """
+        values in obsm must be numerical types, strings are not valid
+        """
+        all_string = numpy.full(self.validator.adata.obsm["X_umap"].shape, "test")
+        self.validator.adata.obsm["X_umap"] = all_string
+        self.validator.validate_adata()
+        self.assertEqual(
+            self.validator.errors,
+            ["ERROR: adata.obsm['X_umap'] has an invalid data type. It should be float, integer, or unsigned "
+             "integer of any precision (8, 16, 32, or 64 bits)."],
+        )
+
     def test_obsm_values_nan(self):
         """
         values in obsm cannot all be NaN
@@ -1310,7 +1323,7 @@ class TestObsm(BaseValidationTest):
         self.validator.validate_adata()
         self.assertEqual(
             self.validator.errors,
-            ["ERROR: Embedding key in 'adata.obsm' X_ must have a suffix more than one character long."],
+            ["ERROR: Embedding key in 'adata.obsm' X_ must have a suffix at least one character long."],
         )
 
     def test_obsm_key_name_valid(self):


### PR DESCRIPTION
## Reason for Change

https://github.com/chanzuckerberg/single-cell-curation/issues/590

## Changes

- fixes some of the issues caught by @jahilton:
  - only fail if all values are NaN, not if any values are NaN
  - having NaN should not result in the infinity error message getting picked up
  - validate that suffixes are at least one character
  - validate that keys don't have whitespace
  - gracefully fail if values have strings, aka don't fail on the `isinf` call
- adds test coverage for all of the new validation things added

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer