### PR TITLE
fix: clean-up error message if only 1 ancestor is valid for ontology term

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -147,8 +147,11 @@ class Validator:
 
         if True not in checks:
             if errors:
-                all_ancestors = list(allowed_ancestors.values())
-                self.errors.append(f"'{term_id}' in '{column_name}' is not a child term id of '{all_ancestors}'.")
+                all_ancestors = [ancestor for ancestors in allowed_ancestors.values() for ancestor in ancestors]
+                # print ancestor as string with single-quotes if only 1 entry
+                if len(all_ancestors) == 1:
+                    all_ancestors = f"'{all_ancestors[0]}'"
+                self.errors.append(f"'{term_id}' in '{column_name}' is not a child term id of {all_ancestors}.")
             return False
         return True
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -264,7 +264,7 @@ class TestObs(BaseValidationTest):
             self.validator.errors,
             [
                 "ERROR: 'EFO:0000001' in 'assay_ontology_term_id' is not a "
-                "child term id of '[['EFO:0002772', 'EFO:0010183']]'."
+                "child term id of ['EFO:0002772', 'EFO:0010183']."
             ],
         )
 
@@ -603,7 +603,7 @@ class TestObs(BaseValidationTest):
                 self.validator.errors,
                 [
                     "ERROR: 'UBERON:0001062' in 'tissue_ontology_term_id' is not a child term id of "
-                    "'[['UBERON:0001062']]'. When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' "
+                    "'UBERON:0001062'. When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' "
                     "MUST be a child term id of 'UBERON:0001062' (anatomical entity)."
                 ],
             )
@@ -616,7 +616,7 @@ class TestObs(BaseValidationTest):
                 self.validator.errors,
                 [
                     "ERROR: 'UBERON:0001062' in 'tissue_ontology_term_id' is not a child term id of "
-                    "'[['UBERON:0001062']]'. When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' "
+                    "'UBERON:0001062'. When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' "
                     "MUST be a child term id of 'UBERON:0001062' (anatomical entity)."
                 ],
             )


### PR DESCRIPTION
## Reason for Change

- #514 
- See error message formatting feedback from Jason: https://github.com/chanzuckerberg/single-cell-curation/issues/514#issuecomment-1728200255

## Changes

- If we're only validating an ontology term against 1 allowed ancestor, print the ancestor term we're checking for in the error message as single term with single quotes instead of a list of 1. 
- For scenarios where a list of ancestors is expected, print as a single concatenated list rather than a list of lists

## Testing

- unit tests

## Notes for Reviewer