### PR TITLE
fix: improve error message when raw.X and raw.var are mismatched

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -766,8 +766,8 @@ class Validator:
 
         if self.adata.raw and self.adata.raw.X.shape[1] != self.adata.raw.var.shape[0]:
             self.errors.append(
-                "This dataset has a mismatch between 1) the number of variables in the raw matrix and 2) the number of "
-                "raw var key-indexed variables. These counts must be identical."
+                "This dataset has a mismatch between 1) the number of features in raw.X and 2) the number of features "
+                "in raw.var. These counts must be identical."
             )
             self.is_seurat_convertible = False
 


### PR DESCRIPTION
## Reason for Change

- #418 

## Changes

- Simple change in the error message that is produced when the # of vars in raw.X does not exactly equal the number of vars in raw.var

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer