### PR TITLE
feat: 'citation' is a reserved name & disallow '__' name prefixes

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -24,7 +24,6 @@ components:
         reserved_columns:
             - schema_version
             - schema_reference
-            - citation
         deprecated_columns:
             - X_normalization
             - default_field

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -24,6 +24,7 @@ components:
         reserved_columns:
             - schema_version
             - schema_reference
+            - citation
         deprecated_columns:
             - X_normalization
             - default_field

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1,7 +1,6 @@
 import logging
 import math
 import os
-import re
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
@@ -584,9 +583,6 @@ class Validator:
             if key not in dictionary and "required" in value_def:
                 self.errors.append(f"'{key}' in '{dict_name}' is not present.")
 
-            if re.match(r"__", key):  # re.match matches strictly from beginning of str
-                self.errors.append(f"The key '{key}' in '{dict_name}' is not valid; keys must not have a '__' prefix.")
-
             value = dictionary[key]
 
             if value_def["type"] == "string":
@@ -678,14 +674,6 @@ class Validator:
                     if "warning_message" in column_def:
                         self.warnings.append(column_def["warning_message"])
                     self._validate_column(column, column_name, df_name, column_def)
-
-        # Validate user-provided column names
-        for column in df.columns:
-            if re.match(r"__", column):  # re.match matches strictly from beginning of str
-                self.errors.append(
-                    f"The column '{column}' in dataframe '{df_name}' is not valid; columns must not "
-                    f"have a '__' prefix."
-                )
 
     def _validate_sparsity(self):
         """

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import os
+import re
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
@@ -583,7 +584,9 @@ class Validator:
             if key not in dictionary:
                 if "required" in value_def:
                     self.errors.append(f"'{key}' in '{dict_name}' is not present.")
-                continue
+
+            if re.match(r"__", key):  # re.match matches strictly from beginning of str
+                self.errors.append(f"The key '{key}' in '{dict_name}' is not valid; keys must not have a '__' prefix.")
 
             value = dictionary[key]
 
@@ -676,6 +679,12 @@ class Validator:
                     if "warning_message" in column_def:
                         self.warnings.append(column_def["warning_message"])
                     self._validate_column(column, column_name, df_name, column_def)
+
+        # Validate user-provided column names
+        for column in df.columns:
+            if re.match(r"__", column):  # re.match matches strictly from beginning of str
+                self.errors.append(f"The column '{column}' in dataframe '{df_name}' is not valid; columns must not "
+                                   f"have a '__' prefix.")
 
     def _validate_sparsity(self):
         """

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -581,9 +581,8 @@ class Validator:
 
         for key, value_def in dict_def["keys"].items():
             logger.debug(f"Validating uns dict for key: {key}")
-            if key not in dictionary:
-                if "required" in value_def:
-                    self.errors.append(f"'{key}' in '{dict_name}' is not present.")
+            if key not in dictionary and "required" in value_def:
+                self.errors.append(f"'{key}' in '{dict_name}' is not present.")
 
             if re.match(r"__", key):  # re.match matches strictly from beginning of str
                 self.errors.append(f"The key '{key}' in '{dict_name}' is not valid; keys must not have a '__' prefix.")
@@ -683,8 +682,10 @@ class Validator:
         # Validate user-provided column names
         for column in df.columns:
             if re.match(r"__", column):  # re.match matches strictly from beginning of str
-                self.errors.append(f"The column '{column}' in dataframe '{df_name}' is not valid; columns must not "
-                                   f"have a '__' prefix.")
+                self.errors.append(
+                    f"The column '{column}' in dataframe '{df_name}' is not valid; columns must not "
+                    f"have a '__' prefix."
+                )
 
     def _validate_sparsity(self):
         """


### PR DESCRIPTION
## Reason for Change

- #519

## Changes

- Add 'citation' as a reserved_column for the uns component
- Do not allow columns/keys to be prefaced with '__' for:
  - uns
  - obs
  - obs.var
  - obs.raw.var

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer