### PR TITLE
fix: pin HsapDv and MmusDv

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/ontology_files/owl_info.yml
+++ b/cellxgene_schema_cli/cellxgene_schema/ontology_files/owl_info.yml
@@ -13,7 +13,7 @@ HANCESTRO:
 HsapDv:
   latest: 2020-03-10
   urls:
-    2020-03-10: http://purl.obolibrary.org/obo/hsapdv.owl
+    2020-03-10: http://aber-owl.net/media/ontologies/HSAPDV/11/hsapdv.owl
 MONDO:
   latest: 2023-08-02
   urls:
@@ -21,7 +21,7 @@ MONDO:
 MmusDv:
   latest: 2020-03-10
   urls:
-    2020-03-10: http://purl.obolibrary.org/obo/mmusdv.owl
+    2020-03-10: http://aber-owl.net/media/ontologies/MMUSDV/9/mmusdv.owl
 NCBITaxon:
   latest: 2023-06-20
   urls:

--- a/cellxgene_schema_cli/tests/fixtures/examples_ontology_test.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_ontology_test.py
@@ -37,7 +37,7 @@ valid_terms = {
     },
     "MONDO": {"MONDO:0100096": "COVID-19"},
     "MmusDv": {
-        "MmusDv:0000062": "2 month-old stage",
+        "MmusDv:0000062": "2-month-old stage",
         "MmusDv:0000003": "Theiler stage 01",
     },
     "NCBITaxon": {


### PR DESCRIPTION
Introduced pinned links for these two ontologies. Additionally, fix a unit test that began failing after previous ontology update by updating a hard-coded value in the test fixtures.

## Reason for Change

- #616 

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer