### PR TITLE
fix: only validate colors if the key is specified

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -695,9 +695,9 @@ class Validator:
                     category_mapping[column_name] = df[column_name].nunique()
 
         for column_name, num_unique_vals in category_mapping.items():
-            colors_options = uns_dict.get(f"{column_name}_colors", [])
+            colors_options = uns_dict.get(f"{column_name}_colors")
             # If there are no colors specified, that's fine. We only want to validate this field if it's set
-            if len(colors_options) > 0:
+            if colors_options is not None:
                 if len(colors_options) < num_unique_vals:
                     self.errors.append(
                         f"Annotated categorical field {column_name} must have at least {num_unique_vals} color options "

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -696,17 +696,19 @@ class Validator:
 
         for column_name, num_unique_vals in category_mapping.items():
             colors_options = uns_dict.get(f"{column_name}_colors", [])
-            if len(colors_options) < num_unique_vals:
-                self.errors.append(
-                    f"Annotated categorical field {column_name} must have at least {num_unique_vals} color options "
-                    f"in uns[{column_name}_colors]. Found: {colors_options}"
-                )
-            for color in colors_options:
-                if not self._validate_color(color):
+            # If there are no colors specified, that's fine. We only want to validate this field if it's set
+            if len(colors_options) > 0:
+                if len(colors_options) < num_unique_vals:
                     self.errors.append(
-                        f"Color {color} in uns[{column_name}_colors] is not valid. Colors must be a valid hex "
-                        f"code (#08c0ff) or a CSS4 named color"
+                        f"Annotated categorical field {column_name} must have at least {num_unique_vals} color options "
+                        f"in uns[{column_name}_colors]. Found: {colors_options}"
                     )
+                for color in colors_options:
+                    if not self._validate_color(color):
+                        self.errors.append(
+                            f"Color {color} in uns[{column_name}_colors] is not valid. Colors must be a valid hex "
+                            f"code (#08c0ff) or a CSS4 named color"
+                        )
 
     def _validate_color(self, color: str) -> bool:
         css4_named_colors = [

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1359,7 +1359,7 @@ class TestUns(BaseValidationTest):
                 "ERROR: The field 'publication_doi' is present in 'uns', but it is deprecated.",
             ],
         )
-    
+
     def test_no_colors_should_pass(self):
         del self.validator.adata.uns["suspension_type_colors"]
         self.assertTrue(self.validator.validate_adata())

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1359,6 +1359,10 @@ class TestUns(BaseValidationTest):
                 "ERROR: The field 'publication_doi' is present in 'uns', but it is deprecated.",
             ],
         )
+    
+    def test_no_colors_should_pass(self):
+        del self.validator.adata.uns["suspension_type_colors"]
+        self.assertTrue(self.validator.validate_adata())
 
     def test_not_enough_color_options(self):
         self.validator.adata.uns["suspension_type_colors"] = ["green"]


### PR DESCRIPTION
## Reason for Change

- based on feedback [here](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/513) and [here](https://github.com/chanzuckerberg/single-cell-curation/pull/625#discussion_r1337632953), it looks like we should only do validation on these fields if the key is specified in `uns`

## Changes

- updating the validation to only run the validation on the colors fields if the key is set and the value is not an empty array

## Testing

- added a test to verify that if `uns["suspension_colors"]` is removed, we'll still pass validation

## Notes for Reviewer