### PR TITLE
chore: refactor confusing 'required' attribute in schema_definition.yaml

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -17,7 +17,7 @@ raw:
 components:
     uns:
         type: dict
-        required: null # Means it's required
+        required: True
         reserved_columns:
             - schema_version
             - schema_reference
@@ -36,7 +36,7 @@ components:
         keys:
             title:
                 type: string
-                required: null
+                required: True
             batch_condition:
                 type: list
                 element_type: match_obs_columns
@@ -49,7 +49,7 @@ components:
                     - normal
     var:
         type: dataframe
-        required: null # Means it's required
+        required: True
         warn_if_less_than_rows: 20000
         index:
             unique: true
@@ -77,7 +77,7 @@ components:
         type: annotation_mapping
     obsm:
         type: annotation_mapping
-        required: null # Means it's required
+        required: True
     obsp:
         type: annotation_mapping
     raw.var:
@@ -102,7 +102,7 @@ components:
                     to_column: feature_length
     obs:
         type: dataframe
-        required: null # Means it's required
+        required: True
         index:
             unique: true
         deprecated_columns:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -582,7 +582,7 @@ class Validator:
         for key, value_def in dict_def["keys"].items():
             logger.debug(f"Validating uns dict for key: {key}")
             if key not in dictionary:
-                if "required" in value_def:
+                if value_def.get("required", False):
                     self.errors.append(f"'{key}' in '{dict_name}' is not present.")
                 continue
 
@@ -1289,7 +1289,7 @@ class Validator:
             # Skip if component does not exist: only useful for adata.raw.var
             if component is None:
                 # Check for required components
-                if "required" in component_def:
+                if component_def.get("required", False):
                     pass
                 continue
             elif component_def["type"] == "dataframe":


### PR DESCRIPTION
Changes: 
- Fixed confusing state where marking a component 'required: null' in the schema definition yaml meant that it IS required. Use boolean instead
- Updated checks in validate.py that use this attribute accordingly