### PR TITLE
feat: validate raw matrix values

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1056,7 +1056,7 @@ class Validator:
 
         return False
 
-    def _get_raw_x(self) -> Union[np.ndarray, sparse.csc_matrix, sparse.csr_matrix, pd.DataFrame]:
+    def _get_raw_x(self) -> Union[np.ndarray, sparse.csc_matrix, sparse.csr_matrix]:
         """
         gets raw x (best guess, i.e. not guarantee it's actually raw)
         """
@@ -1274,7 +1274,7 @@ class Validator:
     def _validate_dense_raw_matrix_values(self) -> None:
         raw_matrix = self._get_raw_x()
         for row_index in range(0, self.adata.n_obs):
-            row = raw_matrix[row_index] if isinstance(raw_matrix, np.ndarray) else raw_matrix.iloc[row_index]
+            row = raw_matrix[row_index]
             whole_row_is_zeros = True
             for col_index, val in enumerate(row):
                 if val:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1319,7 +1319,7 @@ class Validator:
         matrix_format = get_matrix_format()
         if matrix_format in ("csr", "csc", "coo"):  # full set of sparse matrix types
             self._validate_sparse_raw_matrix_values()
-        else:  # "dense" or "unknown"
+        elif matrix_format == "dense":
             self._validate_dense_raw_matrix_values()
 
     def _deep_check(self):


### PR DESCRIPTION
Excepting the raw matrices of Accessibility assays:
- Each row must have at least one nonzero value
- All values must be of type numpy.float32

## Reason for Change

- #614 

## Changes

- Update return type on `Validator._get_raw_x` to include Pandas.DataFrame (see [related discussion](https://czi-sci.slack.com/archives/C03PXFMM7ST/p1695967976272789))
- Add validation for matrices:
  - sparse: 3 scipy.sparse.spmatrix variants -- csr, coo, csc
  - dense: "dense" (numpy.ndarray) and "unknown" (Pandas.DataFrame)

## This code still needs tests to be updated / added!

```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer