### PR TITLE
fix(raw matrix validation): compare number of nonzero rows in matrix chunk against matrix chunk size, not full matrix size

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1137,7 +1137,7 @@ class Validator:
 
         if self._raw_layer_exists is None:
             # Get potential raw_X
-            x = self.adata.raw.X if self._get_raw_x_loc() == "raw.X" else self.adata.X
+            x = self._get_raw_x()
             if x.dtype != np.float32:
                 self._raw_layer_exists = False
                 self.errors.append("Raw matrix values must have type numpy.float32.")
@@ -1153,7 +1153,7 @@ class Validator:
                 if not has_row_of_zeros:
                     if is_sparse_matrix:
                         row_indices, _ = matrix_chunk.nonzero()
-                        if len(set(row_indices)) != self.adata.n_obs:
+                        if len(set(row_indices)) != matrix_chunk.shape[0]:
                             has_row_of_zeros = True
                     # else, must be dense matrix, confirm that all rows have at least 1 nonzero value
                     elif not all(np.apply_along_axis(np.any, axis=1, arr=matrix_chunk)):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -231,7 +231,7 @@ class TestExpressionMatrix:
         """
         Test adata is validated correctly when matrix is larger than the chunk size
         """
-        with unittest.mock.patch.object(validator_with_adata._chunk_matrix, '__defaults__', (1,)):
+        with unittest.mock.patch.object(validator_with_adata._chunk_matrix, "__defaults__", (1,)):
             validator = validator_with_adata
             validator.validate_adata()
             assert validator.errors == []

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -227,6 +227,15 @@ class TestExpressionMatrix:
         validator.validate_adata()
         assert validator.errors == []
 
+    def test_raw_values__matrix_chunks(self, validator_with_adata):
+        """
+        Test adata is validated correctly when matrix is larger than the chunk size
+        """
+        with unittest.mock.patch.object(validator_with_adata._chunk_matrix, '__defaults__', (1,)):
+            validator = validator_with_adata
+            validator.validate_adata()
+            assert validator.errors == []
+
     def test_missing_raw_matrix(self, validator_with_adata_missing_raw):
         """
         Test error message appears if dataset with RNA assay is missing raw matrix


### PR DESCRIPTION
## Reason for Change

- #614 
- Fix bug introduced in previous PR for this issue

## Changes

- check that number of nonzero rows in a matrix chunk equals matrix chunk size rather than full matrix size
- small fix to DRY up code when fetching raw matrix in has_valid_raw
- added test

## Testing

- unit tests

## Notes for Reviewer