### PR TITLE
fix: whitespace rule with X_{suffix}

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1026,9 +1026,6 @@ class Validator:
 
         obsm_with_x_prefix = 0
         for key, value in self.adata.obsm.items():
-            if " " in key:
-                self.errors.append(f"Embedding key {key} has whitespace in it, please remove it.")
-
             issue_list = self.errors
             if key.startswith("X_"):
                 obsm_with_x_prefix += 1
@@ -1036,6 +1033,8 @@ class Validator:
                     self.errors.append(
                         f"Embedding key in 'adata.obsm' {key} must start with X_ and have a suffix at least one character long."
                     )
+                if " " in key:
+                    self.errors.append(f"Embedding key {key} has whitespace in it, please remove it.")
             else:
                 self.warnings.append(f"Embedding key in 'adata.obsm' {key} does not start with X_")
                 issue_list = self.warnings

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1033,13 +1033,14 @@ class Validator:
                     self.errors.append(
                         f"Embedding key in 'adata.obsm' {key} must start with X_ and have a suffix at least one character long."
                     )
-                if " " in key:
-                    self.errors.append(f"Embedding key {key} has whitespace in it, please remove it.")
             else:
                 self.warnings.append(f"Embedding key in 'adata.obsm' {key} does not start with X_")
                 issue_list = self.warnings
 
             # For all subsequent checks, we want to raise an error if it's an X_ embedding key, and a warning otherwise
+            if " " in key:
+                issue_list.append(f"Embedding key {key} has whitespace in it, please remove it.")
+
             if not isinstance(value, np.ndarray):
                 issue_list.append(
                     f"All embeddings have to be of 'numpy.ndarray' type, " f"'adata.obsm['{key}']' is {type(value)}')."

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1690,15 +1690,20 @@ class TestObsm:
             "ERROR: Embedding key in 'adata.obsm' X_ must start with X_ and have a suffix at least one character long."
         ]
 
-    def test_obsm_key_name_valid(self, validator_with_adata):
+    def test_obsm_key_name_whitespace(self, validator_with_adata):
         """
-        Embedding keys with whitespace are not valid
+        Embedding keys beginning with X_ with whitespace are not valid
         """
         validator = validator_with_adata
         obsm = validator.adata.obsm
         obsm["X_ umap"] = obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == ["ERROR: Embedding key X_ umap has whitespace in it, please remove it."]
+
+        del obsm["X_ umap"]
+        obsm["u m a p"] = obsm["X_umap"]
+        validator.validate_adata()
+        assert validator.errors == []
 
     def test_obsm_shape_one_column(self, validator_with_adata):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1704,6 +1704,7 @@ class TestObsm:
         obsm["u m a p"] = obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == []
+        assert "WARNING: Embedding key u m a p has whitespace in it, please remove it." in validator.warnings
 
     def test_obsm_shape_one_column(self, validator_with_adata):
         """


### PR DESCRIPTION
## Reason for Change

https://github.com/chanzuckerberg/single-cell-curation/issues/590

## Changes

per discussion here: https://github.com/chanzuckerberg/single-cell-curation/pull/654#discussion_r1346503528

updating the whitespace error to only apply to `X_` prefixed embedding keys. raises a warning otherwise

## Testing

updated the `test_obsm_key_name_whitespace` test

## Notes for Reviewer