### PR TITLE
feat: add more colors validation rules

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -767,21 +767,18 @@ class Validator:
                     )
                     # Skip over all subsequent validations which expect a numpy array
                     continue
-                # 3. Verify that all values are not None or numpy.nan
-                if any((color is None or color == np.nan for color in value)):
-                    self.errors.append(f"Colors in uns[{key}] must be not None or numpy.nan. Found: {value}")
-                    continue
-                # 4. Verify that all values are strings
-                if any((not isinstance(color, str) for color in value)):
+                # 3. Verify that we have strings in the array
+                if not np.issubdtype(value.dtype, np.character):
                     self.errors.append(f"Colors in uns[{key}] must be strings. Found: {value}")
-                # 5. Verify that we have at least as many unique colors as unique values in the corresponding categorical field
+                    continue
+                # 4. Verify that we have at least as many unique colors as unique values in the corresponding categorical field
                 value = np.unique(value)
                 if len(value) < obs_unique_values:
                     self.errors.append(
                         f"Annotated categorical field {key.replace('_colors', '')} must have at least {obs_unique_values} color options "
                         f"in uns[{key}]. Found: {value}"
                     )
-                # 6. Verify that either all colors are hex OR all colors are CSS4 named colors
+                # 5. Verify that either all colors are hex OR all colors are CSS4 named colors strings
                 all_hex_colors = all((self._validate_hex_color(color) for color in value))
                 all_css4_colors = all((self._validate_css4_color(color) for color in value))
                 if not (all_hex_colors or all_css4_colors):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -750,24 +750,37 @@ class Validator:
 
                 if column_def.get("type") == "categorical":
                     category_mapping[column_name] = df[column_name].nunique()
-
-        for column_name, num_unique_vals in category_mapping.items():
-            colors_options = uns_dict.get(f"{column_name}_colors")
-            # If there are no colors specified, that's fine. We only want to validate this field if it's set
-            if colors_options is not None:
-                if len(colors_options) < num_unique_vals:
+        
+        for key, value in uns_dict.items():
+            if key.endswith("_colors"):
+                # 1. Verify that the corresponding categorical field exists in obs
+                obs_unique_values = category_mapping.get(key.replace("_colors", ""))
+                if not obs_unique_values:
                     self.errors.append(
-                        f"Annotated categorical field {column_name} must have at least {num_unique_vals} color options "
-                        f"in uns[{column_name}_colors]. Found: {colors_options}"
+                        f"Colors field uns[{key}] does not have a corresponding categorical field in obs"
                     )
-                for color in colors_options:
-                    if not self._validate_color(color):
-                        self.errors.append(
-                            f"Color {color} in uns[{column_name}_colors] is not valid. Colors must be a valid hex "
-                            f"code (#08c0ff) or a CSS4 named color"
-                        )
+                # 2. Verify that the value is a numpy array
+                if value is None or not isinstance(value, np.ndarray):
+                    self.errors.append(
+                        f"Colors field uns['{key}'] must be of 'numpy.ndarray' type, it is {type(value)}"
+                    )
+                    # Skip over all subsequent validations which expect a numpy array
+                    continue
+                # 3. Verify that we have at least as many colors as unique values in the corresponding categorical field
+                if len(value) < obs_unique_values:
+                    self.errors.append(
+                        f"Annotated categorical field {key.replace('_colors', '')} must have at least {obs_unique_values} color options "
+                        f"in uns[{key}]. Found: {value}"
+                    )
+                # 4. Verify that either all colors are hex OR all colors are CSS4 named colors
+                all_hex_colors = all(map(lambda color: self._validate_hex_color(color), value))
+                all_css4_colors = all(map(lambda color: self._validate_css4_color(color), value))
+                if not (all_hex_colors or all_css4_colors):
+                    self.errors.append(
+                        f"Colors in uns[{key}] must be either all hex colors or all CSS4 named colors. Found: {value}"
+                    )
 
-    def _validate_color(self, color: str) -> bool:
+    def _validate_css4_color(self, color: str) -> bool:
         css4_named_colors = [
             "aliceblue",
             "antiquewhite",
@@ -912,8 +925,9 @@ class Validator:
             "yellow",
             "yellowgreen",
         ]
-        if color in css4_named_colors:
-            return True
+        return color in css4_named_colors
+    
+    def _validate_hex_color(self, color: str) -> bool:
         return re.match(r"^#([0-9a-fA-F]{6})$", color)
 
     def _validate_sparsity(self):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -759,6 +759,7 @@ class Validator:
                     self.errors.append(
                         f"Colors field uns[{key}] does not have a corresponding categorical field in obs"
                     )
+                    continue
                 # 2. Verify that the value is a numpy array
                 if value is None or not isinstance(value, np.ndarray):
                     self.errors.append(

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -166,9 +166,6 @@ good_uns = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
-    "donor_id_colors": ["black", "pink"],
-    "suspension_type_colors": ["red", "#000000"],
-    "tissue_type_colors": ["blue", "#ffffff"],
 }
 
 good_uns_with_labels = {
@@ -181,9 +178,6 @@ good_uns_with_labels = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
-    "donor_id_colors": ["black", "pink"],
-    "suspension_type_colors": ["red", "#000000"],
-    "tissue_type_colors": ["blue", "#ffffff"],
 }
 
 # ---

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1553,45 +1553,74 @@ class TestUns:
         uns["project_name"] = "test_value"
         uns["publication_doi"] = "test_value"
 
-        validator.validate_adata()
-        assert validator.errors == [
-            "ERROR: The field 'X_normalization' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'default_field' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'layer_descriptions' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'tags' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'version' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'contributors' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'preprint_doi' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'project_description' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'project_links' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'project_name' is present in 'uns', but it is deprecated.",
-            "ERROR: The field 'publication_doi' is present in 'uns', but it is deprecated.",
-        ]
+        self.validator.validate_adata()
+        self.assertEqual(
+            self.validator.errors,
+            [
+                "ERROR: The field 'X_normalization' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'default_field' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'layer_descriptions' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'tags' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'version' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'contributors' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'preprint_doi' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'project_description' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'project_links' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'project_name' is present in 'uns', but it is deprecated.",
+                "ERROR: The field 'publication_doi' is present in 'uns', but it is deprecated.",
+            ],
+        )
+    
+    def test_colors_not_numpy_array(self):
+        self.validator.adata.uns["suspension_type_colors"] = ["green", "purple"]
+        self.validator.validate_adata()
+        self.assertEqual(
+            self.validator.errors,
+            [
+                "ERROR: Colors field uns[suspension_type_colors] must be of 'numpy.ndarray' type, it is <class 'list'>"
+            ],
+        )
 
-    def test_no_colors_should_pass(self, validator_with_adata):
-        validator = validator_with_adata
-        del validator.adata.uns["suspension_type_colors"]
-        assert validator.validate_adata()
+    def test_not_enough_color_options(self):
+        self.validator.adata.uns["suspension_type_colors"] = numpy.array(["green"])
+        self.validator.validate_adata()
+        self.assertEqual(
+            self.validator.errors,
+            [
+                "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns[suspension_type_colors]. Found: ['green']"
+            ],
+        )
+    
+    def test_different_color_types(self):
+        self.validator.adata.uns["suspension_type_colors"] = numpy.array(["#000000", "pink"])
+        self.validator.validate_adata()
+        self.assertEqual(
+            self.validator.errors,
+            [
+                "Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['#000000' 'pink']",
+            ],
+        )
+    
+    def test_invalid_hex_color_option(self):
+        self.validator.adata.uns["suspension_type_colors"] = numpy.array(["#000", "#ffffff"])
+        self.validator.validate_adata()
+        self.assertEqual(
+            self.validator.errors,
+            [
+                "Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['#000' '#ffffff']",
+            ],
+        )
 
-    def test_not_enough_color_options(self, validator_with_adata):
-        validator = validator_with_adata
-        validator.adata.uns["suspension_type_colors"] = ["green"]
-        validator.validate_adata()
-        assert validator.errors == [
-            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns["
-            "suspension_type_colors]. Found: ['green']"
-        ]
-
-    def test_invalid_color_options(self, validator_with_adata):
-        validator = validator_with_adata
-        validator.adata.uns["suspension_type_colors"] = ["#000", "pynk"]
-        validator.validate_adata()
-        assert validator.errors == [
-            "ERROR: Color #000 in uns[suspension_type_colors] is not valid. Colors must be a valid hex code ("
-            "#08c0ff) or a CSS4 named color",
-            "ERROR: Color pynk in uns[suspension_type_colors] is not valid. Colors must be a valid hex code ("
-            "#08c0ff) or a CSS4 named color",
-        ]
+    def test_invalid_named_color_option(self):
+        self.validator.adata.uns["suspension_type_colors"] = numpy.array(["green", "pynk"])
+        self.validator.validate_adata()
+        print(self.validator.errors)
+        self.assertEqual(
+            self.validator.errors,
+            [
+                "Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['green' 'pynk']",
+            ],
+        )
 
 
 class TestObsm:

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1599,7 +1599,7 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array([])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns[suspension_type_colors]. Found: []"
+            "ERROR: Colors in uns[suspension_type_colors] must be strings. Found: []"
         ]
 
     def test_not_enough_color_options(self, validator_with_adata):
@@ -1652,10 +1652,10 @@ class TestUns:
 
     def test_invalid_named_color_option_integer(self, validator_with_adata):
         validator = validator_with_adata
-        validator.adata.uns["suspension_type_colors"] = numpy.array(["green", 3])
+        validator.adata.uns["suspension_type_colors"] = numpy.array([3, 4])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['3' 'green']"
+            "ERROR: Colors in uns[suspension_type_colors] must be strings. Found: [3 4]"
         ]
 
     def test_invalid_named_color_option_none(self, validator_with_adata):
@@ -1663,15 +1663,15 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["green", None])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be not None or numpy.nan. Found: ['green' None]"
+            "ERROR: Colors in uns[suspension_type_colors] must be strings. Found: ['green' None]"
         ]
 
     def test_invalid_named_color_option_nan(self, validator_with_adata):
         validator = validator_with_adata
-        validator.adata.uns["suspension_type_colors"] = numpy.array(["green", numpy.nan])
+        validator.adata.uns["suspension_type_colors"] = numpy.array([numpy.nan, numpy.nan])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['green' 'nan']"
+            "ERROR: Colors in uns[suspension_type_colors] must be strings. Found: [nan nan]"
         ]
 
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1662,7 +1662,6 @@ class TestUns:
         validator = validator_with_adata
         validator.adata.uns["suspension_type_colors"] = numpy.array(["green", None])
         validator.validate_adata()
-        print(validator.errors)
         assert validator.errors == [
             "ERROR: Colors in uns[suspension_type_colors] must be not None or numpy.nan. Found: ['green' None]"
         ]
@@ -1671,7 +1670,6 @@ class TestUns:
         validator = validator_with_adata
         validator.adata.uns["suspension_type_colors"] = numpy.array(["green", numpy.nan])
         validator.validate_adata()
-        print(validator.errors)
         assert validator.errors == [
             "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['green' 'nan']"
         ]

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1598,9 +1598,7 @@ class TestUns:
         validator = validator_with_adata
         validator.adata.uns["suspension_type_colors"] = numpy.array([])
         validator.validate_adata()
-        assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be strings. Found: []"
-        ]
+        assert validator.errors == ["ERROR: Colors in uns[suspension_type_colors] must be strings. Found: []"]
 
     def test_not_enough_color_options(self, validator_with_adata):
         validator = validator_with_adata
@@ -1654,9 +1652,7 @@ class TestUns:
         validator = validator_with_adata
         validator.adata.uns["suspension_type_colors"] = numpy.array([3, 4])
         validator.validate_adata()
-        assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be strings. Found: [3 4]"
-        ]
+        assert validator.errors == ["ERROR: Colors in uns[suspension_type_colors] must be strings. Found: [3 4]"]
 
     def test_invalid_named_color_option_none(self, validator_with_adata):
         validator = validator_with_adata
@@ -1670,9 +1666,7 @@ class TestUns:
         validator = validator_with_adata
         validator.adata.uns["suspension_type_colors"] = numpy.array([numpy.nan, numpy.nan])
         validator.validate_adata()
-        assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be strings. Found: [nan nan]"
-        ]
+        assert validator.errors == ["ERROR: Colors in uns[suspension_type_colors] must be strings. Found: [nan nan]"]
 
 
 class TestObsm:


### PR DESCRIPTION
## Reason for Change

- https://github.com/chanzuckerberg/single-cell-curation/issues/513

## Changes

based on QA feedback, added the following changes:
- validates that `{column}_colors` must be a numpy array
- verify that a corresponding categorical column in `obs` must exist
- verifies that none of the colors are non-strings, None, or numpy.nan
- verifies that all colors must be CSS4 colors or they must all be hex colors. no mixing allowed.
- filters out any duplicate colors, and raises an error if there are not enough unique colors to be found

## Testing

- wrote a bunch of tests to verify all of those things ^

## Notes for Reviewer