### PR TITLE
feat: update how we check for existing obs categorical columns

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -689,7 +689,7 @@ class Validator:
 
         for column_name in df.columns:
             column = df[column_name]
-            if column.dtype != "category":
+            if column.dtype.name != "category":
                 # Check for columns with mixed values, which is not supported by anndata 0.8.0
                 # TODO: check if this can be removed after upgading to anndata 0.10.0
                 value_types = {type(x) for x in column.values}
@@ -744,7 +744,7 @@ class Validator:
         # Check for categorical dtypes in the dataframe directly
         for column_name in df.columns:
             column = df[column_name]
-            if column.dtype == "category":
+            if column.dtype.name == "category":
                 category_mapping[column_name] = column.nunique()
 
         for key, value in uns_dict.items():

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -742,6 +742,14 @@ class Validator:
         # Mapping from obs column name to number of unique categorical values
         category_mapping = {}
 
+        # Check for categorical dtypes in the dataframe directly
+        for column_name in df.columns:
+            column = df[column_name]
+            if column.dtype == "category":
+                category_mapping[column_name] = column.nunique()
+
+        # TODO: check to see if we want to include this block of code or not
+        # Check for categorical columns in the dataframe definition
         if "columns" in df_definition:
             for column_name, column_def in df_definition["columns"].items():
                 if column_name not in df.columns:
@@ -749,7 +757,10 @@ class Validator:
                     continue
 
                 if column_def.get("type") == "categorical":
-                    category_mapping[column_name] = df[column_name].nunique()
+                    if category_mapping.get(column_name) is None:
+                        self.errors.append(
+                            f"Column '{column_name}' in dataframe 'obs' must be declared as categorical in the column definition."
+                        )
 
         for key, value in uns_dict.items():
             if key.endswith("_colors"):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -737,7 +737,7 @@ class Validator:
 
     def _validate_colors_in_uns_dict(self, uns_dict: dict) -> None:
         df = getattr_anndata(self.adata, "obs")
-        df_definition = self._get_component_def("obs")
+        self._get_component_def("obs")
 
         # Mapping from obs column name to number of unique categorical values
         category_mapping = {}
@@ -747,20 +747,6 @@ class Validator:
             column = df[column_name]
             if column.dtype == "category":
                 category_mapping[column_name] = column.nunique()
-
-        # TODO: check to see if we want to include this block of code or not
-        # Check for categorical columns in the dataframe definition
-        if "columns" in df_definition:
-            for column_name, column_def in df_definition["columns"].items():
-                if column_name not in df.columns:
-                    # Skip this, dataframe validation should already append an error for this
-                    continue
-
-                if column_def.get("type") == "categorical":
-                    if category_mapping.get(column_name) is None:
-                        self.errors.append(
-                            f"Column '{column_name}' in dataframe 'obs' must be declared as categorical in the column definition."
-                        )
 
         for key, value in uns_dict.items():
             if key.endswith("_colors"):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -737,7 +737,6 @@ class Validator:
 
     def _validate_colors_in_uns_dict(self, uns_dict: dict) -> None:
         df = getattr_anndata(self.adata, "obs")
-        self._get_component_def("obs")
 
         # Mapping from obs column name to number of unique categorical values
         category_mapping = {}

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1568,6 +1568,17 @@ class TestUns:
             "ERROR: The field 'publication_doi' is present in 'uns', but it is deprecated.",
         ]
 
+    def test_colors_happy_path(self, validator_with_adata):
+        """
+        Creates a new column in `obs[test_column]` where the dtype is categorical, but its column definition
+        is not in the schema. Having valid colors in `uns[test_column_colors]` should not raise an error.
+        """
+        validator = validator_with_adata
+        validator.adata.obs["test_column"] = ["one", "two"]
+        validator.adata.obs["test_column"] = validator.adata.obs["test_column"].astype("category")
+        validator.adata.uns["test_column_colors"] = numpy.array(["#000000", "#ffffff"])
+        assert validator.validate_adata()
+
     def test_colors_not_numpy_array(self, validator_with_adata):
         validator = validator_with_adata
         validator.adata.uns["suspension_type_colors"] = ["green", "purple"]
@@ -1580,7 +1591,7 @@ class TestUns:
 
     def test_colors_bool_obs_counterpart(self, validator_with_adata):
         validator = validator_with_adata
-        validator.adata.uns["is_primary_data_colors"] = ["green", "purple"]
+        validator.adata.uns["is_primary_data_colors"] = numpy.array(["green", "purple"])
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: Colors field uns[is_primary_data_colors] does not have a corresponding categorical field in obs"
@@ -1588,7 +1599,7 @@ class TestUns:
 
     def test_colors_without_obs_counterpart(self, validator_with_adata):
         validator = validator_with_adata
-        validator.adata.uns["fake_field_colors"] = ["green", "purple"]
+        validator.adata.uns["fake_field_colors"] = numpy.array(["green", "purple"])
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: Colors field uns[fake_field_colors] does not have a corresponding categorical field in obs"


### PR DESCRIPTION
## Reason for Change

- based on discussion [here](https://github.com/chanzuckerberg/single-cell-curation/issues/513), we should be considering the obs column's dtype directly, instead of what we currently do, which is checking the schema def

## Changes

- check for categorical obs column by looking at the column's dtype instead of the column definition

## Testing

- wrote a test case where we have a new categorical column added to `obs[test_column]` that's not part of the schema def, and has valid colors in `uns[test_column_colors]`. this should pass validation, despite the column not existing in the schema def

## Notes for Reviewer