### PR TITLE
feat: add note to annotate ontology term id field instead

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -757,6 +757,18 @@ class Validator:
                     error_message = f"Colors field uns[{key}] does not have a corresponding categorical field in obs"
                     if column_name in df.columns:
                         error_message += f". {column_name} is present but is dtype {df[column_name].dtype.name}"
+                    portal_column_names = [
+                        "assay",
+                        "cell_type",
+                        "development_stage",
+                        "disease",
+                        "organism",
+                        "self_reported_ethnicity",
+                        "sex",
+                        "tissue",
+                    ]
+                    if column_name in portal_column_names:
+                        error_message += f". Annotate {column_name}_ontology_term_id_colors instead"
                     self.errors.append(error_message)
                     continue
                 # 2. Verify that the value is a numpy array

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1608,6 +1608,14 @@ class TestUns:
             "ERROR: Colors field uns[is_primary_data_colors] does not have a corresponding categorical field in obs. is_primary_data is present but is dtype bool"
         ]
 
+    def test_colors_portal_obs_counterpart(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.uns["cell_type_colors"] = numpy.array(["green", "purple"])
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: Colors field uns[cell_type_colors] does not have a corresponding categorical field in obs. Annotate cell_type_ontology_term_id_colors instead"
+        ]
+
     def test_colors_without_obs_counterpart(self, validator_with_adata):
         validator = validator_with_adata
         validator.adata.uns["fake_field_colors"] = numpy.array(["green", "purple"])


### PR DESCRIPTION
## Reason for Change

https://github.com/chanzuckerberg/single-cell-curation/issues/513

## Changes

- Currently, if a schema portal field is used in colors: "ERROR: Colors field uns[cell_type_colors] does not have a corresponding categorical field in obs." This PR adds on: "Annotate cell_type_ontology_term_id_colors instead."

## Testing

added a test for above behavior

## Notes for Reviewer