### PR TITLE
chore: remove mypy

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -18,16 +18,6 @@ jobs:
       - uses: actions/setup-python@v3
       - name: Pre-commit checks
         uses: pre-commit/action@v3.0.0
-      - name: Install dependencies
-        run: |
-          pip install -r ./requirements-dev.txt
-      # We can't have mypy in the pre-commit hook without having it run on all files
-      # in the repo, because (probably) the --all-files argument in pre-commit overrides
-      # the more narrow specifying of files in pyproject.toml
-      # TODO: Remove this if/when all files are mypy-compliant
-      - name: Run mypy
-        run: |
-          mypy --config-file pyproject.toml
 
   unit-tests-cli:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Reason for Change

- We should keep the mypy recipe in the makefile to help people make use of mypy where they wish to. It can be a useful guide. It should not be a check. Or, if it is a check, it should be its own check so its failure does not mask the success/failure of any other checks.

## Changes

- Do not run mypy as a GHA job step.

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer