### PR TITLE
feat: ignore test files within the scripts package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ target-version = "py38"
 # packages = ["scripts"] instead of modules = ["scripts"] because packages will recursive
 # check subdirectories, while modules does not.
 packages = ["scripts"]
+exclude = ["scripts.compute_mappings.tests"]
 strict = true
 show_error_codes = true
 ignore_missing_imports = true


### PR DESCRIPTION
ignores files within `scripts/compute_mappings/tests`. i ran mypy against dan's branch `dan/555-compute-scripts` and verified the errors on test files were ignored