### PR TITLE
fix: restrict allow categorical types

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -709,10 +709,18 @@ class Validator:
                             )
                 # Check for columns that have none string categories, which is not supported by anndata 0.8.0
                 # TODO: check if this can be removed after upgading to anndata 0.10.0
-                category_types = {type(x) for x in column.dtype.categories.values}
-                if len(category_types) > 1 or str not in category_types:
+                categorical_types = {type(x) for x in column.dtype.categories.values}
+                if len(categorical_types) > 1:
                     self.errors.append(
-                        f"Column '{column_name}' in dataframe '{df_name}' must only contain string categories. Found {category_types}."
+                        f"Column '{column_name}' in dataframe '{df_name}' containes {len(categorical_types)} categorical types. "
+                        f"Only one type is allowed."
+                    )
+                allowed_categorical_types = {str, int, np.int32, np.int64}
+                illegal_categorical_types = categorical_types - allowed_categorical_types
+                if illegal_categorical_types:
+                    self.errors.append(
+                        f"Column '{column_name}' in dataframe '{df_name}' containes {illegal_categorical_types=}. "
+                        f"Categories must only contain {allowed_categorical_types=}."
                     )
 
         # Validate columns

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -707,20 +707,22 @@ class Validator:
                                 f"Column '{column_name}' in dataframe '{df_name}' contains a category '{category}' with "
                                 f"zero observations. These categories will be removed when `--add-labels` flag is present."
                             )
-                # Check for columns that have none string categories, which is not supported by anndata 0.8.0
+                categorical_types = {type(x) for x in column.dtype.categories.values}
+                # Check for columns that have illegal categories, which are not supported by anndata 0.8.0
+                # TODO: check if this can be removed after upgading to anndata 0.10.0
+                blocked_categorical_types = {bool}
+                illegal_categorical_types = categorical_types & blocked_categorical_types
+                if illegal_categorical_types:
+                    self.errors.append(
+                        f"Column '{column_name}' in dataframe '{df_name}' containes {illegal_categorical_types=}."
+                    )
+                # Check for categorical column has mixed types, which is not supported by anndata 0.8.0
                 # TODO: check if this can be removed after upgading to anndata 0.10.0
                 categorical_types = {type(x) for x in column.dtype.categories.values}
                 if len(categorical_types) > 1:
                     self.errors.append(
                         f"Column '{column_name}' in dataframe '{df_name}' containes {len(categorical_types)} categorical types. "
                         f"Only one type is allowed."
-                    )
-                allowed_categorical_types = {str, int, np.int32, np.int64}
-                illegal_categorical_types = categorical_types - allowed_categorical_types
-                if illegal_categorical_types:
-                    self.errors.append(
-                        f"Column '{column_name}' in dataframe '{df_name}' containes {illegal_categorical_types=}. "
-                        f"Categories must only contain {allowed_categorical_types=}."
                     )
 
         # Validate columns

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -714,14 +714,14 @@ class Validator:
                 illegal_categorical_types = categorical_types & blocked_categorical_types
                 if illegal_categorical_types:
                     self.errors.append(
-                        f"Column '{column_name}' in dataframe '{df_name}' containes {illegal_categorical_types=}."
+                        f"Column '{column_name}' in dataframe '{df_name}' contains {illegal_categorical_types=}."
                     )
                 # Check for categorical column has mixed types, which is not supported by anndata 0.8.0
                 # TODO: check if this can be removed after upgading to anndata 0.10.0
                 categorical_types = {type(x) for x in column.dtype.categories.values}
                 if len(categorical_types) > 1:
                     self.errors.append(
-                        f"Column '{column_name}' in dataframe '{df_name}' containes {len(categorical_types)} categorical types. "
+                        f"Column '{column_name}' in dataframe '{df_name}' contains {len(categorical_types)} categorical types. "
                         f"Only one type is allowed."
                     )
 

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -384,7 +384,7 @@ class TestValidatorValidateDataFrame:
         validator._validate_dataframe("obs")
 
         # Assert
-        assert "in dataframe 'obs' containes 2 categorical types. Only one type is allowed." in validator.errors[0]
+        assert "in dataframe 'obs' contains 2 categorical types. Only one type is allowed." in validator.errors[0]
         self._fail_write_h5ad(tmp_path, valid_adata)
 
     def test_fail_categorical_bool(self, tmp_path, valid_adata):
@@ -397,7 +397,7 @@ class TestValidatorValidateDataFrame:
         validator._validate_dataframe("obs")
 
         # Assert
-        assert "in dataframe 'obs' containes illegal_categorical_types={<class 'bool'>}." in validator.errors[0]
+        assert "in dataframe 'obs' contains illegal_categorical_types={<class 'bool'>}." in validator.errors[0]
         self._fail_write_h5ad(tmp_path, valid_adata)
 
     def _add_catagorical_obs(self, adata, categories):


### PR DESCRIPTION

## Reason for Change

- during schema migration 4.0 additional categorical type combinations were found to be invalid. This PR add additional test coverage and check for those error types.
- related to https://github.com/chanzuckerberg/single-cell-curation/issues/405
## Changes

- add check for mixedd categorical types
- add check for illegal categorical types
- Add test to verify categorical types allowed.

## Testing

- unit tests.

## Notes for Reviewer