### PR TITLE
fix: add necessary corpus transformations uncovered by dev migration

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -49,8 +49,6 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     reported_changes = []
 
     dataset = ad.read_h5ad(input_file, backed="r")
-    if dataset.raw is not None and DEPRECATED_FEATURE_IDS:
-        dataset = dataset.to_memory()
 
     # AUTOMATED, DO NOT CHANGE
     for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
@@ -218,6 +216,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
             break
 
     if has_rna_assay:
+        dataset = dataset.to_memory()
         if dataset.raw:
             raw = dataset.raw.X
         else:

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -211,7 +211,9 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     has_rna_assay = False
     for assay in assays:
         term_ancestors = ontology_checker.get_term_ancestors("EFO", assay)
-        if (assay not in accessibility_assays) and bool(accessibility_assays & term_ancestors) is False:
+        term_ancestors.add(assay)
+        # check intersection, if no matches, term is not accessibility assay and therefore we assume its RNA
+        if bool(accessibility_assays & term_ancestors) is False:
             has_rna_assay = True
             break
 


### PR DESCRIPTION
## Changes

- added ontology term replacements corpus-wide for 3 terms we are now denying in schema 4 but are currently found in the corpus, per discussion in single-cell-four with Jason
- added check for datasets with RNA assays to meet new schema requirements--if raw matrix dtype is not np.float32 and the matrix values can be coerced safely into np.float32, do so and report the change as an output of the migration script (the migration SFM uses the output to report to slack in the curator report, mapping to the dataset_id and collection_id)
      - Because the validator already enforces that raw matrix values for RNA assays are positive integers, we don't have to worry about floating point precision being lost. The only concern for safe casting is whether any values are too large to be represented as np.float32; so we check the max value of the matrix against the np.float32 max.

## Testing

-  Local testing against prod datasets that failed in dev migration--validation succeeds after running with this updated script

## Note for Reviewer

- Writing to the raw matrix requires reading the dataset into memory, which we were not doing before. Our machines for the migration should be large enough to handle our worst case, but it is an added risk for this run. Another Dev migration run would catch such issues