### PR TITLE
chore: create standalone gha for updating ontology mappings powering dp fe filters

### DIFF
--- a/.github/workflows/update-ontology-mappings.yml
+++ b/.github/workflows/update-ontology-mappings.yml
@@ -1,0 +1,55 @@
+name: Run Scripts and Update FE Filter Ontology Mappings
+
+# on: workflow_dispatch
+on:
+  push:
+    branches: nayib/standalone-fe-filter-script-gha  # TODO: remove
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-ontology-mappings:
+    runs-on: macos-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1800
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.11
+      - name: Python cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: install homebrew requirements
+        run: brew install graphviz
+      - name: install requirements
+        run: |
+          pip install -r scripts/compute_mappings/requirements.txt
+      - name: Generate Ontology Scripts
+        run: |
+          ./scripts/compute_mappings/compute_tissue_and_cell_type_mappings.py
+          ./scripts/compute_mappings/compute_ancestor_mapping.py
+      - name: Push Updated Ontology Mappings to S3
+        run: |
+          aws s3 sync --exclude="*" --include="*ontology_mapping.json" scripts/compute_mappings s3://cellxgene-schema-ref-files-prod/ontology-mappings/backend
+          aws s3 sync --exclude="*" --include="*descendants.json" scripts/compute_mappings s3://cellxgene-schema-ref-files-prod/ontology-mappings/frontend
+          aws s3 sync --exclude="*" --include="*.gz" cellxgene_schema_cli/cellxgene_schema/ontology_files s3://cellxgene-schema-ref-files-prod/ontology-mappings/gzips
+      - name: Trigger Data Portal to pull latest ontology mappings
+        run: |
+          curl -X POST https://api.github.com/repos/chanzuckerberg/single-cell-data-portal/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          --header 'authorization: Bearer ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}' \
+          --data '{"event_type": "pull-ontology-mappings"}'

--- a/.github/workflows/update-ontology-mappings.yml
+++ b/.github/workflows/update-ontology-mappings.yml
@@ -1,9 +1,7 @@
 name: Run Scripts and Update FE Filter Ontology Mappings
 
-# on: workflow_dispatch
-on:
-  push:
-    branches: nayib/standalone-fe-filter-script-gha  # TODO: remove
+on: 
+  workflow_dispatch
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Reason for Change

- Part of https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/616

## Changes

- Extracted update ontology mappings job into its own standalone GHA that can be triggered manually, so it can be run outside of migration in case the scripts need to be updated + run + deployed outside a migration cycle

## Testing

- Ran a test from this branch, the GHA ran as expected and kicked off a PR in the data-portal repo with the changes as expected.

## Notes for Reviewer