### PR TITLE
feat: validate obsm embeddings start with letter

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -921,30 +921,23 @@ class Validator:
         for key, value in self.adata.obsm.items():
             issue_list = self.errors
 
-            if not key[0].isalpha():
-                self.errors.append(f"Embedding key in 'adata.obsm' {key} must start with a letter.")
+            regex_pattern = r'^[a-zA-Z][a-zA-Z0-9]*$'
 
             if key.startswith("X_"):
                 obsm_with_x_prefix += 1
-                if len(key) <= 3:
+                if not re.match(regex_pattern, key[2:]):
                     self.errors.append(
-                        f"Embedding key in 'adata.obsm' {key} must start with X_ and have a suffix at least one character long."
+                        f"Suffix for embedding key in 'adata.obsm' {key} does not match the regex pattern {regex_pattern}."
                     )
-                else:
-                    suffix_first_char = key[2]
-                    if not suffix_first_char.isalpha():
-                        self.errors.append(
-                            f"Embedding key in 'adata.obsm' {key} must have a suffix that starts with a letter."
-                        )
             else:
+                if not re.match(regex_pattern, key):
+                    self.errors.append(
+                        f"Embedding key in 'adata.obsm' {key} does not match the regex pattern {regex_pattern}."
+                    )
                 self.warnings.append(
                     f"Embedding key in 'adata.obsm' {key} does not start with X_ and thus will not be available in Explorer"
                 )
                 issue_list = self.warnings
-
-            # For all subsequent checks, we want to raise an error if it's an X_ embedding key, and a warning otherwise
-            if " " in key:
-                issue_list.append(f"Embedding key {key} has whitespace in it, please remove it.")
 
             if not isinstance(value, np.ndarray):
                 issue_list.append(

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -922,9 +922,7 @@ class Validator:
             issue_list = self.errors
 
             if not key[0].isalpha():
-                self.errors.append(
-                    f"Embedding key in 'adata.obsm' {key} must start with a letter."
-                )
+                self.errors.append(f"Embedding key in 'adata.obsm' {key} must start with a letter.")
 
             if key.startswith("X_"):
                 obsm_with_x_prefix += 1

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -921,7 +921,7 @@ class Validator:
         for key, value in self.adata.obsm.items():
             issue_list = self.errors
 
-            regex_pattern = r'^[a-zA-Z][a-zA-Z0-9]*$'
+            regex_pattern = r"^[a-zA-Z][a-zA-Z0-9]*$"
 
             if key.startswith("X_"):
                 obsm_with_x_prefix += 1

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -920,12 +920,24 @@ class Validator:
         obsm_with_x_prefix = 0
         for key, value in self.adata.obsm.items():
             issue_list = self.errors
+
+            if not key[0].isalpha():
+                self.errors.append(
+                    f"Embedding key in 'adata.obsm' {key} must start with a letter."
+                )
+
             if key.startswith("X_"):
                 obsm_with_x_prefix += 1
                 if len(key) <= 3:
                     self.errors.append(
                         f"Embedding key in 'adata.obsm' {key} must start with X_ and have a suffix at least one character long."
                     )
+                else:
+                    suffix_first_char = key[2]
+                    if not suffix_first_char.isalpha():
+                        self.errors.append(
+                            f"Embedding key in 'adata.obsm' {key} must have a suffix that starts with a letter."
+                        )
             else:
                 self.warnings.append(
                     f"Embedding key in 'adata.obsm' {key} does not start with X_ and thus will not be available in Explorer"

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1781,23 +1781,21 @@ class TestObsm:
             "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
             "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>').",
         ]
-    
+
     def test_obsm_values_suffix_start_with_number(self, validator_with_adata):
         validator = validator_with_adata
         validator.adata.obsm["X_3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: Embedding key in 'adata.obsm' X_3D must have a suffix that starts with a letter.",
-            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class 'pandas.core.frame.DataFrame'>')."
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class 'pandas.core.frame.DataFrame'>').",
         ]
-    
+
     def test_obsm_values_key_start_with_number(self, validator_with_adata):
         validator = validator_with_adata
         validator.adata.obsm["3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
-        assert validator.errors == [
-            "ERROR: Embedding key in 'adata.obsm' 3D must start with a letter."
-        ]
+        assert validator.errors == ["ERROR: Embedding key in 'adata.obsm' 3D must start with a letter."]
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1795,7 +1795,9 @@ class TestObsm:
         validator = validator_with_adata
         validator.adata.obsm["3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
-        assert validator.errors == ["ERROR: Embedding key in 'adata.obsm' 3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$."]
+        assert validator.errors == [
+            "ERROR: Embedding key in 'adata.obsm' 3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$."
+        ]
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1781,6 +1781,29 @@ class TestObsm:
             "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
             "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>').",
         ]
+    
+    def test_obsm_values_suffix_start_with_number(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.obsm["X_3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: Embedding key in 'adata.obsm' X_3D must have a suffix that starts with a letter.",
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class 'pandas.core.frame.DataFrame'>')."
+        ]
+    
+    def test_obsm_values_key_start_with_number(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.obsm["3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: Embedding key in 'adata.obsm' 3D must start with a letter."
+        ]
+        assert validator.warnings == [
+            "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
+            "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",
+            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class 'pandas.core.frame.DataFrame'>').",
+            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
+        ]
 
     def test_obsm_suffix_name_valid(self, validator_with_adata):
         """
@@ -1801,7 +1824,10 @@ class TestObsm:
         obsm = validator.adata.obsm
         obsm["X_ umap"] = obsm["X_umap"]
         validator.validate_adata()
-        assert validator.errors == ["ERROR: Embedding key X_ umap has whitespace in it, please remove it."]
+        assert validator.errors == [
+            "ERROR: Embedding key in 'adata.obsm' X_ umap must have a suffix that starts with a letter.",
+            "ERROR: Embedding key X_ umap has whitespace in it, please remove it.",
+        ]
 
         del obsm["X_ umap"]
         obsm["u m a p"] = obsm["X_umap"]

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1787,7 +1787,7 @@ class TestObsm:
         validator.adata.obsm["X_3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Embedding key in 'adata.obsm' X_3D must have a suffix that starts with a letter.",
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$.",
             "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class 'pandas.core.frame.DataFrame'>').",
         ]
 
@@ -1795,7 +1795,7 @@ class TestObsm:
         validator = validator_with_adata
         validator.adata.obsm["3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
-        assert validator.errors == ["ERROR: Embedding key in 'adata.obsm' 3D must start with a letter."]
+        assert validator.errors == ["ERROR: Embedding key in 'adata.obsm' 3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$."]
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",
@@ -1811,7 +1811,7 @@ class TestObsm:
         validator.adata.obsm["X_"] = validator.adata.obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Embedding key in 'adata.obsm' X_ must start with X_ and have a suffix at least one character long."
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_ does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$."
         ]
 
     def test_obsm_key_name_whitespace(self, validator_with_adata):
@@ -1823,15 +1823,15 @@ class TestObsm:
         obsm["X_ umap"] = obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Embedding key in 'adata.obsm' X_ umap must have a suffix that starts with a letter.",
-            "ERROR: Embedding key X_ umap has whitespace in it, please remove it.",
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_ umap does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$.",
         ]
 
         del obsm["X_ umap"]
         obsm["u m a p"] = obsm["X_umap"]
         validator.validate_adata()
-        assert validator.errors == []
-        assert "WARNING: Embedding key u m a p has whitespace in it, please remove it." in validator.warnings
+        assert validator.errors == [
+            "ERROR: Embedding key in 'adata.obsm' u m a p does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$."
+        ]
 
     def test_obsm_shape_one_column(self, validator_with_adata):
         """


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6340

## Changes

- raises an error if either the obsm embedding key starts with a non-letter, or if it begins with X_ and the suffix starts with a non-letter

## Testing

- added some unit tests to verify that this works as expected

## Notes for Reviewer