### PR TITLE
chore: create standalone GHAs for running dry run reports for bumped schema ref files

### DIFF
--- a/.github/workflows/gencode-bump-dry-run.yml
+++ b/.github/workflows/gencode-bump-dry-run.yml
@@ -1,0 +1,49 @@
+name: Run GENCODE Bump Dry Run
+
+on:
+  workflow_dispatch
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  gencode-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+      - name: Python cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          pip install -r scripts/schema_bump_dry_run_genes/requirements.txt
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
+          role-duration-seconds: 2700
+      - name: Pull AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids:
+            AUTH0_SECRETS, corpora/backend/prod/auth0-secret
+      - name: Run Dry-Run Script
+        run: python3 -m scripts.schema_bump_dry_run_genes.gene_bump_dry_run
+        env:
+          corpus_env: "prod"
+      - name: upload to slack
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          curl -F file=@genes-curator-report.txt -F "initial_comment=Gene Dry Run Report" -F channels=${{secrets
+          .SLACK_CURATOR_REPORTING_CHANNEL}} -H "Authorization: Bearer ${{secrets.SLACK_CURATOR_REPORTING_APP_AUTH}}" https://slack.com/api/files.upload

--- a/.github/workflows/ontology-bump-dry-run.yml
+++ b/.github/workflows/ontology-bump-dry-run.yml
@@ -1,0 +1,52 @@
+name: Run Ontology Bump Dry Run
+
+on:
+  workflow_dispatch
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  ontology-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Python cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          pip install -r scripts/schema_bump_dry_run_ontologies/requirements.txt
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
+          role-duration-seconds: 2700
+      - name: Pull AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids:
+            AUTH0_SECRETS, corpora/backend/prod/auth0-secret
+      - name: Run Dry-Run Script
+        run: python3 -m scripts.schema_bump_dry_run_ontologies.ontology_bump_dry_run
+        env:
+          corpus_env: "prod"
+      - name: Store JSON with Replaced By Ontology Term Mappings
+        uses: actions/cache/save@v3
+        with:
+          path: "./replaced-by.json"
+          key: replaced-by-map
+      - name: upload dry run to slack
+        run: |
+          curl -F file=@ontologies-curator-report.txt -F "initial_comment=Ontology Dry Run Report" -F channels=${{secrets.SLACK_CURATOR_REPORTING_CHANNEL}} -H "Authorization: Bearer ${{secrets.SLACK_CURATOR_REPORTING_APP_AUTH}}" https://slack.com/api/files.upload


### PR DESCRIPTION
## Reason for Change

- https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6394

## Changes

- Create 1 standalone GHA job each for running ontology and gencode bump dry run reports, for flexibility in discovery phases of migration bumps (can see impact of file bumps in branches before merging in changes)

## Testing

- Run dry run GHAs after merge

## Notes for Reviewer