### PR TITLE
fix(ontology dry run): account for self-reported ethinicity listing comma-delimited ontology terms in one entry

### DIFF
--- a/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
@@ -59,44 +59,45 @@ def map_deprecated_terms(
     for ontology_type in ONTOLOGY_TYPES:
         if ontology_type in dataset:
             for ontology_term in dataset[ontology_type]:
-                ontology_term_id = ontology_term["ontology_term_id"]
-                if ontology_term_id in non_deprecated_term_cache:
-                    continue
-                else:
-                    # all_ontologies is indexed by ontology prefix and term ID without suffixes,
-                    # so we must parse + build the search term
-                    ontology_id_parts = ontology_term_id.split(" ")[0].split(":")
-                    term_prefix = ontology_id_parts[0]
-                    ontology_index_id = f"{term_prefix}:{ontology_id_parts[1]}"
-                    ontology = onto_map[term_prefix][ontology_index_id]
-
-                if ontology["deprecated"]:
-                    if ontology_term_id in curator_report_entry_map[collection_id]:
-                        curator_report_entry_map[collection_id][ontology_term_id]["dataset_ct"] += 1
+                ontology_term_ids = ontology_term["ontology_term_id"].split(",")
+                for ontology_term_id in ontology_term_ids:
+                    if ontology_term_id in non_deprecated_term_cache:
+                        continue
                     else:
-                        entry = dict()
-                        entry["needs_alert"] = False
-                        entry["dataset_ct"] = 1  # type: ignore
-                        if "term_tracker" in ontology:
-                            entry["term_tracker"] = ontology["term_tracker"]
-                        if "comments" in ontology:
-                            entry["comments"] = ontology["comments"]
-                        if "replaced_by" in ontology:
-                            entry["replaced_by"] = ontology["replaced_by"]
-                            replacement_term_ontology = ontology["replaced_by"].split(":")[0]
-                            if replacement_term_ontology != term_prefix:
-                                entry["needs_alert"] = True
-                            else:
-                                if ontology_index_id not in replaced_by_map[ontology_type]:
-                                    replaced_by_map[ontology_type][ontology_index_id] = ontology["replaced_by"]
-                        else:
-                            entry["needs_alert"] = True
-                            if "consider" in ontology:
-                                entry["consider"] = ontology["consider"]
+                        # all_ontologies is indexed by ontology prefix and term ID without suffixes,
+                        # so we must parse + build the search term
+                        ontology_id_parts = ontology_term_id.split(" ")[0].split(":")
+                        term_prefix = ontology_id_parts[0]
+                        ontology_index_id = f"{term_prefix}:{ontology_id_parts[1]}"
+                        ontology = onto_map[term_prefix][ontology_index_id]
 
-                        curator_report_entry_map[collection_id][ontology_term_id] = entry
-                else:
-                    non_deprecated_term_cache.add(ontology_term_id)
+                    if ontology["deprecated"]:
+                        if ontology_term_id in curator_report_entry_map[collection_id]:
+                            curator_report_entry_map[collection_id][ontology_term_id]["dataset_ct"] += 1
+                        else:
+                            entry = dict()
+                            entry["needs_alert"] = False
+                            entry["dataset_ct"] = 1  # type: ignore
+                            if "term_tracker" in ontology:
+                                entry["term_tracker"] = ontology["term_tracker"]
+                            if "comments" in ontology:
+                                entry["comments"] = ontology["comments"]
+                            if "replaced_by" in ontology:
+                                entry["replaced_by"] = ontology["replaced_by"]
+                                replacement_term_ontology = ontology["replaced_by"].split(":")[0]
+                                if replacement_term_ontology != term_prefix:
+                                    entry["needs_alert"] = True
+                                else:
+                                    if ontology_index_id not in replaced_by_map[ontology_type]:
+                                        replaced_by_map[ontology_type][ontology_index_id] = ontology["replaced_by"]
+                            else:
+                                entry["needs_alert"] = True
+                                if "consider" in ontology:
+                                    entry["consider"] = ontology["consider"]
+
+                            curator_report_entry_map[collection_id][ontology_term_id] = entry
+                    else:
+                        non_deprecated_term_cache.add(ontology_term_id)
 
 
 def write_to_curator_report(output_file: str, curator_report_entry_map: dict, revision_map: dict = None) -> None:  # type: ignore

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_comma_delimited_onto_id_list_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_comma_delimited_onto_id_list_expected
@@ -1,0 +1,10 @@
+Deprecated Terms in Public Datasets:
+
+Collection ID: public_coll_0
+# of Affected Datasets: 1
+Deprecated Term: HANCESTRO:0000002
+Replaced By: HANCESTRO:0000003
+
+
+Deprecated Terms in Private Datasets:
+

--- a/scripts/schema_bump_dry_run_ontologies/tests/test_ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/tests/test_ontology_bump_dry_run.py
@@ -63,6 +63,17 @@ def setup():  # type: ignore
                 "consider": ["EFO:0000090"],
                 "term_tracker": "www.fake-github-link.com/repo/example-2",
             },
+        },
+        "HANCESTRO": {
+            "HANCESTRO:0000001": {
+                "label": "non-deprecated term",
+                "deprecated": False,
+            },
+            "HANCESTRO:0000002": {
+                "label": "obsolete term with replacement",
+                "deprecated": True,
+                "replaced_by": "HANCESTRO:0000003",
+            },
         }
     }
     public_datasets = [
@@ -145,6 +156,18 @@ class TestOntologyBumpDryRun:
         _, _, expected_replaced_by_map = setup
         with NamedTemporaryFile() as tmp, NamedTemporaryFile() as tmp_json, open(
             f"{FIXTURES_ROOT}/no_deprecated_terms_with_open_revisions", "rb"
+        ) as expected:
+            ontology_bump_dry_run.dry_run(tmp.name, tmp_json.name)
+            assert list(expected) == list(tmp)
+            assert expected_replaced_by_map == json.load(tmp_json)
+
+    def test_with_comma_delimited_onto_id_list(self, setup):  # type: ignore
+        public_datasets, private_collections, expected_replaced_by_map = setup
+        private_collections.pop()
+        public_datasets[0]["self_reported_ethnicity"] = [{"ontology_term_id": "HANCESTRO:0000001,HANCESTRO:0000002"}]
+        expected_replaced_by_map["self_reported_ethnicity"]["HANCESTRO:0000002"] = "HANCESTRO:0000003"
+        with NamedTemporaryFile() as tmp, NamedTemporaryFile() as tmp_json, open(
+            f"{FIXTURES_ROOT}/with_comma_delimited_onto_id_list_expected", "rb"
         ) as expected:
             ontology_bump_dry_run.dry_run(tmp.name, tmp_json.name)
             assert list(expected) == list(tmp)

--- a/scripts/schema_bump_dry_run_ontologies/tests/test_ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/tests/test_ontology_bump_dry_run.py
@@ -74,7 +74,7 @@ def setup():  # type: ignore
                 "deprecated": True,
                 "replaced_by": "HANCESTRO:0000003",
             },
-        }
+        },
     }
     public_datasets = [
         {


### PR DESCRIPTION
## Reason for Change

- Self-reported ethnicity ontology terms can now be made up of multiple, comma-delimited terms in a single ontology term entry. We need to account for this format while parsing ontology terms for the ontology report dry run (bug discovered after triggering dry run [reports](https://github.com/chanzuckerberg/single-cell-curation/actions/runs/7387333028/job/20095967802) in advance of bumping GENCODE for schema 4.1)

## Changes

- Parse for comma-delimited lists of terms when processing ontology term entries, and perform deprecated term reporting for each term in list. Only applies to self-reported ethnicity, but done generally in case we adopt this format for other ontology types in the future (for now, we expect every other ontology type will yield lists of 1 when split by ",")

## Testing

- get a successful ontology dry run in branch + unit tests

## Notes for Reviewer