### PR TITLE
feat: update validator for disease_ontology_term_id

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -147,7 +147,7 @@ components:
                         type: curie
                         to_column: assay
             disease_ontology_term_id:
-                error_message_suffix: "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
+                error_message_suffix: "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
                 type: curie
                 curie_constraints:
                     ontologies:

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -147,7 +147,7 @@ components:
                         type: curie
                         to_column: assay
             disease_ontology_term_id:
-                error_message_suffix: "Only 'PATO:0000461' (normal), children terms of 'MONDO:0000001' (disease), and self or children terms of 'MONDO:0021178' (injury) are allowed"
+                error_message_suffix: "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
                 type: curie
                 curie_constraints:
                     ontologies:

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -147,7 +147,7 @@ components:
                         type: curie
                         to_column: assay
             disease_ontology_term_id:
-                error_message_suffix: "Only 'PATO:0000461' is allowed for 'PATO' term ids."
+                error_message_suffix: "Only 'PATO:0000461' (normal), children terms of 'MONDO:0000001' (disease), and self or children terms of 'MONDO:0021178' (injury) are allowed"
                 type: curie
                 curie_constraints:
                     ontologies:
@@ -158,7 +158,11 @@ components:
                             PATO:
                                 - PATO:0000461
                             MONDO:
-                                - all
+                                - MONDO:0021178
+                        ancestors:
+                            MONDO:
+                                - MONDO:0000001
+                                - MONDO:0021178
                 add_labels:
                     -
                         type: curie

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -507,7 +507,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'disease_ontology_term_id' is not a valid ontology term id of 'MONDO, PATO'. "
-            "Only 'PATO:0000461' (normal), children terms of 'MONDO:0000001' (disease), and self or children terms of 'MONDO:0021178' (injury) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid PATO term id
@@ -516,7 +516,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'PATO:0001894' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), children terms of 'MONDO:0000001' (disease), and self or children terms of 'MONDO:0021178' (injury) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease characteristic
@@ -525,7 +525,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0021125' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), children terms of 'MONDO:0000001' (disease), and self or children terms of 'MONDO:0021178' (injury) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease parent term
@@ -534,7 +534,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0000001' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), children terms of 'MONDO:0000001' (disease), and self or children terms of 'MONDO:0021178' (injury) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Valid PATO term id - healthy

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -507,7 +507,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'disease_ontology_term_id' is not a valid ontology term id of 'MONDO, PATO'. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid PATO term id
@@ -516,7 +516,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'PATO:0001894' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease characteristic
@@ -525,7 +525,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0021125' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease parent term
@@ -534,7 +534,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0000001' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms, or children terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Valid PATO term id - healthy


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/719

## Changes

validates that the `disease_ontology_term_id` is one of:
- PATO:0000461
- child of MONDO:0000001
- self or child of MONDO:0021178

## Testing

added unit tests!

## Notes for Reviewer