### PR TITLE
feat: column names must be unique within 'var' and 'obs' DataFrames

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1200,6 +1200,23 @@ class Validator:
                         f"The field '{column}' in '{component}' is invalid. Fields that start with '__' are reserved."
                     )
 
+    def _check_var_and_obs_column_name_uniqueness(self):
+        """
+        This method checks that all column names in the 'var' and 'obs' DataFrames are unique
+
+        :rtype none
+        """
+        dataframe_components = ["obs", "var"]
+        for df_component in dataframe_components:
+            adata_component = getattr_anndata(self.adata, df_component)
+            component_columns = set()
+            for column in adata_component.columns:
+                if column in component_columns:
+                    self.errors.append(
+                        f"Duplicate column name '{column}' detected in 'adata.{df_component}' DataFrame. All DataFrame column names must be unique."
+                    )
+                component_columns.add(column)
+
     def _check_column_availability(self):
         """
         This method will check for columns that are reserved in components and validate that they are
@@ -1256,6 +1273,9 @@ class Validator:
 
         # Checks for invalid columns
         self._check_invalid_columns()
+
+        # Checks DataFrame column name uniqueness
+        self._check_var_and_obs_column_name_uniqueness()
 
         # Checks that reserved columns are not used
         self._check_column_availability()

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1212,7 +1212,7 @@ class Validator:
             component_columns = set()
             for column in adata_component.columns:
                 if column in component_columns:
-                    self.errors.append(
+                    raise ValueError(
                         f"Duplicate column name '{column}' detected in 'adata.{df_component}' DataFrame. All DataFrame column names must be unique."
                     )
                 component_columns.add(column)
@@ -1267,15 +1267,14 @@ class Validator:
 
         :rtype None
         """
+        # Checks DataFrame column name uniqueness
+        self._check_var_and_obs_column_name_uniqueness()
 
         # Checks for deprecated columns
         self._check_deprecated_columns()
 
         # Checks for invalid columns
         self._check_invalid_columns()
-
-        # Checks DataFrame column name uniqueness
-        self._check_var_and_obs_column_name_uniqueness()
 
         # Checks that reserved columns are not used
         self._check_column_availability()

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1224,6 +1224,13 @@ class TestObs:
             "ERROR: The field '__test_field' in 'obs' is invalid. Fields that start with '__' are reserved.",
         ]
 
+    def test_obs_column_name_uniqueness(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.obs = pd.concat([validator.adata.obs, validator.adata.obs["suspension_type"]], axis=1)
+
+        with pytest.raises(ValueError):
+            validator.validate_adata()
+
     def test_nan_values_must_be_rejected(self, validator_with_adata):
         """
         NaN values should not be allowed in dataframes
@@ -1428,6 +1435,13 @@ class TestVar:
             f"ERROR: Add labels error: Column '{column}' is a reserved column name "
             f"of '{df}'. Remove it from h5ad and try again."
         ]
+
+    def test_var_column_name_uniqueness(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.var = pd.concat([validator.adata.var, validator.adata.var["feature_is_filtered"]], axis=1)
+
+        with pytest.raises(ValueError):
+            validator.validate_adata()
 
 
 class TestUns:


### PR DESCRIPTION
## Reason for Change

- #729 

## Changes

- Raise `ValueError` if any duplicate column names appear in `var` or `obs` 
  - Must `raise` rather than including in errors list because otherwise subsequent steps choke on `dtype` vs `dtypes` (originally [noted](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/627) by @Jchaffer787) 
  - This pattern for such cases follows convention already loosely established in the validator code

## Testing

- Unit tested
- Specific error message tested & confirmed via manual install 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer