### PR TITLE
feat: Validate that uns array values are all > 0 in length

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -746,7 +746,7 @@ class Validator:
                         self.warnings.append(column_def["warning_message"])
                     self._validate_column(column, column_name, df_name, column_def)
 
-    def _validate_colors_in_uns_dict(self, uns_dict: dict) -> None:
+    def _validate_uns_dict(self, uns_dict: dict) -> None:
         df = getattr_anndata(self.adata, "obs")
 
         # Mapping from obs column name to number of unique categorical values
@@ -759,6 +759,8 @@ class Validator:
                 category_mapping[column_name] = column.nunique()
 
         for key, value in uns_dict.items():
+            if len(value) == 0:
+                self.errors.append(f"uns['{key}'] cannot be an empty value.")
             if key.endswith("_colors"):
                 # 1. Verify that the corresponding categorical field exists in obs
                 column_name = key.replace("_colors", "")
@@ -1284,7 +1286,7 @@ class Validator:
             elif component_def["type"] == "dict":
                 self._validate_dict(component, component_name, component_def)
                 if component_name == "uns":
-                    self._validate_colors_in_uns_dict(component)
+                    self._validate_uns_dict(component)
             elif component_def["type"] == "annotation_mapping":
                 self._validate_annotation_mapping(component_name, component)
                 if component_name == "obsm":

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1632,6 +1632,30 @@ class TestUns:
         validator.adata.uns["test_column_colors"] = numpy.array(["#000000", "#ffffff"])
         assert validator.validate_adata()
 
+    def test_uns_empty_numpy_array(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.uns["log1p"] = numpy.array([])
+        validator.validate_adata()
+        assert validator.errors == ["ERROR: uns['log1p'] cannot be an empty value."]
+
+    def test_uns_empty_python_array(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.uns["log1p"] = []
+        validator.validate_adata()
+        assert validator.errors == ["ERROR: uns['log1p'] cannot be an empty value."]
+
+    def test_uns_empty_string(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.uns["log1p"] = ""
+        validator.validate_adata()
+        assert validator.errors == ["ERROR: uns['log1p'] cannot be an empty value."]
+
+    def test_uns_empty_dictionary(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.uns["log1p"] = {}
+        validator.validate_adata()
+        assert validator.errors == ["ERROR: uns['log1p'] cannot be an empty value."]
+
     def test_colors_happy_path_duplicates(self, validator_with_adata):
         validator = validator_with_adata
         validator.adata.uns["suspension_type_colors"] = numpy.array(["lightgrey", "lightgrey"])
@@ -1676,7 +1700,8 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array([])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns[suspension_type_colors]. Found: []"
+            "ERROR: uns['suspension_type_colors'] cannot be an empty value.",
+            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns[suspension_type_colors]. Found: []",
         ]
 
     def test_not_enough_color_options(self, validator_with_adata):


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/728

## Changes

- Validates that uns values cannot be empty arrays, dictionaries, or strings

## Testing

- Wrote unit tests to make sure error is raised for various types of zero-length values

## Notes for Reviewer