### PR TITLE
feat: deprecate CL:0000003 'native cell' and replace with "unknown"

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -215,12 +215,14 @@ components:
                         rule: "tissue_type == 'cell culture'"
                         error_message_suffix: >-
                             When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term
-                            and it can not be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell),
+                            and it cannot be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell),
                             nor 'CL:0000548' (animal cell).
                         type: curie
                         curie_constraints:
                             ontologies:
                                 - CL
+                            exceptions:
+                                - unknown
                             forbidden:
                                 terms:
                                     - CL:0000255

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -117,6 +117,8 @@ components:
                 curie_constraints:
                     ontologies:
                         - CL
+                    exceptions:
+                        - unknown
                     forbidden:
                         terms:
                             - CL:0000255

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -215,8 +215,8 @@ components:
                         rule: "tissue_type == 'cell culture'"
                         error_message_suffix: >-
                             When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term
-                            and it cannot be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell),
-                            nor 'CL:0000548' (animal cell).
+                            (excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell),
+                            and 'CL:0000548' (animal cell)) or 'unknown'.
                         type: curie
                         curie_constraints:
                             ontologies:

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -214,7 +214,7 @@ components:
                         # If tissue_type is cell culture
                         rule: "tissue_type == 'cell culture'"
                         error_message_suffix: >-
-                            When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term
+                            When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be either a CL term
                             (excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell),
                             and 'CL:0000548' (animal cell)) or 'unknown'.
                         type: curie

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -464,7 +464,7 @@ class Validator:
         self, df: pd.DataFrame, df_name: str, column_name: str, dependencies: List[dict]
     ) -> pd.Series:
         """
-        Validates subset of columns based on dependecies, for instance development_stage_ontology_term_id has
+        Validates subset of columns based on dependencies, for instance development_stage_ontology_term_id has
         dependencies with organism_ontology_term_id -- the allowed values depend on whether organism is human, mouse
         or something else.
 
@@ -474,7 +474,7 @@ class Validator:
         :param pd.DataFrame df: pandas dataframe containing the column to be validated
         :param str df_name: the name of dataframe in the adata object, e.g. "obs"
         :param str column_name: the name of the column to be validated
-        :param list dependencies: a list of dependecy definitions, which is a list of column definitions with a "rule"
+        :param list dependencies: a list of dependency definitions, which is a list of column definitions with a "rule"
         """
 
         all_rules = []

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1255,9 +1255,9 @@ class Validator:
 
             # Do it for columns that map to other columns, for post-upload annotation
             if "columns" in component_def:
-                for _column, columns_def in component_def["columns"].items():
-                    if "add_labels" in columns_def:
-                        self._check_single_column_availability(component, columns_def["add_labels"])
+                for column_def in component_def["columns"].values():
+                    if "add_labels" in column_def:
+                        self._check_single_column_availability(component, column_def["add_labels"])
 
             # Do it for index that map to columns
             if "index" in component_def:

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -250,7 +250,7 @@ adata_with_colors = anndata.AnnData(
 )
 
 # anndata for testing migration
-umigrated_obs = pd.DataFrame(
+unmigrated_obs = pd.DataFrame(
     [
         [
             "cell_type:1",
@@ -297,12 +297,12 @@ var_unmigrated = pd.DataFrame(
     ],
 )
 
-unmigrated_X = numpy.zeros([good_obs.shape[0], var_unmigrated.shape[0]], dtype=numpy.float32)
-adata_with_lables_unmigrated = anndata.AnnData(
+unmigrated_X = numpy.zeros([unmigrated_obs.shape[0], var_unmigrated.shape[0]], dtype=numpy.float32)
+adata_with_labels_unmigrated = anndata.AnnData(
     X=sparse.csr_matrix(unmigrated_X),
-    obs=umigrated_obs,
+    obs=unmigrated_obs,
     uns=good_uns_with_labels,
     var=var_unmigrated,
     obsm={"X_umap": numpy.zeros([unmigrated_X.shape[0], 2])},
 )
-adata_with_lables_unmigrated.raw = adata_with_lables_unmigrated.copy()
+adata_with_labels_unmigrated.raw = adata_with_labels_unmigrated.copy()

--- a/cellxgene_schema_cli/tests/test_migrate.py
+++ b/cellxgene_schema_cli/tests/test_migrate.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import anndata
 from cellxgene_schema.migrate import migrate
-from fixtures.examples_validate import adata_with_lables_unmigrated
+from fixtures.examples_validate import adata_with_labels_unmigrated
 
 
 class TestMigrate:
@@ -36,7 +36,7 @@ class TestMigrate:
             result_h5ad = tmp + "result.h5ad"
             test_h5ad = tmp + "test.h5ad"
 
-            adata_with_lables_unmigrated.copy().write_h5ad(test_h5ad, compression="gzip")
+            adata_with_labels_unmigrated.copy().write_h5ad(test_h5ad, compression="gzip")
             migrate(
                 input_file=test_h5ad,
                 output_file=result_h5ad,

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -576,6 +576,19 @@ class TestObs:
         assert validator.validate_adata()
         assert validator.errors == []
 
+    def test_cell_type_ontology_term_id__unknown(self, validator_with_adata):
+        """
+        Test 'unknown' cell_type_ontology_term_id is valid
+        """
+        validator = validator_with_adata
+        obs = validator.adata.obs
+        obs.loc[
+            obs.index[0],
+            "cell_type_ontology_term_id",
+        ] = "unknown"
+        assert validator.validate_adata()
+        assert validator.errors == []
+
     def test_self_reported_ethnicity_ontology_term_id__unknown_in_multi_term(self, validator_with_adata):
         """
         Test 'unknown' self_reported_ethnicity_ontology_term is invalid when used in multi-term comma-delimited str
@@ -900,7 +913,6 @@ class TestObs:
         obs.loc[obs.index[0], "tissue_type"] = "cell culture"
         obs.loc[obs.index[0], "tissue_ontology_term_id"] = "CL:0000057 (cell culture)"
         validator.validate_adata()
-        print(validator.errors)
         assert validator.errors == [
             "ERROR: 'CL:0000057 (cell culture)' in 'tissue_ontology_term_id' is not a valid ontology term id "
             "of 'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term "

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2110,6 +2110,17 @@ class TestAddingLabels:
         for i, j in zip(expected_column.tolist(), obtained_column.tolist()):
             assert i == j
 
+    def test_obs_added_cell_type_label__unknown(self, validator_with_adata):
+        obs = validator_with_adata.adata.obs
+
+        # Arrange
+        obs.at["Y", "tissue_type"] = "cell culture"  # Already set in example data, just setting explicitly here
+        obs.at["Y", "tissue_ontology_term_id"] = "unknown"  # Testing this term case
+        validator_with_adata.validate_adata()  # Validate
+        AnnDataLabelAppender(validator_with_adata)._add_labels()  # Annotate
+
+        assert obs.at["Y", "tissue"] == "unknown"
+
     def test_remove_unused_categories(self, label_writer, adata_with_labels):
         modified_donor_id = label_writer.adata.obs["donor_id"].cat.add_categories("donor_3")
         label_writer.adata.obs["donor_id"] = modified_donor_id

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -602,7 +602,7 @@ class TestObs:
 
     def test_tissue_ontology_term_id__unknown_invalid(self, validator_with_adata):
         """
-        Test 'unknown' tissue_ontology_term_id is valid if tissue_type is 'cell culture'
+        Test 'unknown' tissue_ontology_term_id is invalid if tissue_type is NOT 'cell culture'
         """
         validator = validator_with_adata
         obs = validator.adata.obs

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -599,6 +599,24 @@ class TestObs:
         assert validator.validate_adata()
         assert validator.errors == []
 
+    def test_tissue_ontology_term_id__unknown_invalid(self, validator_with_adata):
+        """
+        Test 'unknown' tissue_ontology_term_id is valid if tissue_type is 'cell culture'
+        """
+        validator = validator_with_adata
+        obs = validator.adata.obs
+
+        # Arrange -- 'tissue_ontology_term_id' cannot be "unknown" when 'tissue_type is "tissue"
+        obs.at["Y", "tissue_type"] = "tissue"
+        obs.at["Y", "tissue_ontology_term_id"] = "unknown"
+
+        assert not validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: 'unknown' in 'tissue_ontology_term_id' is not a valid ontology term id of 'UBERON'. "
+            "When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' MUST be a child "
+            "term id of 'UBERON:0001062' (anatomical entity)."
+        ]
+
     def test_self_reported_ethnicity_ontology_term_id__unknown_in_multi_term(self, validator_with_adata):
         """
         Test 'unknown' self_reported_ethnicity_ontology_term is invalid when used in multi-term comma-delimited str

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -593,7 +593,8 @@ class TestObs:
         validator = validator_with_adata
         obs = validator.adata.obs
 
-        # Arrange -- relies on "tissue_type" value for index "Y" already being "cell culture"
+        # Arrange -- relies on "tissue_type" value for index "Y" being "cell culture", set explicitly
+        obs.at["Y", "tissue_type"] = "cell culture"
         obs.at["Y", "tissue_ontology_term_id"] = "unknown"
 
         assert validator.validate_adata()

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -893,18 +893,18 @@ class TestObs:
 
     def test_tissue_ontology_term_id_cell_culture__suffix_in_term_id(self, validator_with_adata):
         """
-        Cell Culture - Can NOT include
-        suffixes.
+        Cell Culture - Cannot include suffixes.
         """
         validator = validator_with_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "tissue_type"] = "cell culture"
         obs.loc[obs.index[0], "tissue_ontology_term_id"] = "CL:0000057 (cell culture)"
         validator.validate_adata()
+        print(validator.errors)
         assert validator.errors == [
             "ERROR: 'CL:0000057 (cell culture)' in 'tissue_ontology_term_id' is not a valid ontology term id "
             "of 'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
-            "and it can not be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
+            "and it cannot be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "nor 'CL:0000548' (animal cell)."
         ]
 
@@ -920,7 +920,7 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'tissue_ontology_term_id' is not a valid ontology term id of "
             "'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
-            "and it can not be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
+            "and it cannot be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "nor 'CL:0000548' (animal cell)."
         ]
 
@@ -942,7 +942,7 @@ class TestObs:
         assert validator.errors == [
             f"ERROR: '{term}' in 'tissue_ontology_term_id' is not allowed. When 'tissue_type' is "
             f"'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
-            "and it can not be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
+            "and it cannot be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "nor 'CL:0000548' (animal cell)."
         ]
 
@@ -2062,7 +2062,7 @@ class TestAddingLabels:
             - assay. categorical with str categories. This MUST be the human-readable name assigned to the value
             of assay_ontology_term_id.
             - cell_type. categorical with str categories. This MUST be the human-readable name assigned to the value
-            of cell_type_ontology_term_id.
+            of cell_type_ontology_term_id or "unknown" if set in cell_type_ontology_term_id.
             - development_stage. categorical with str categories. This MUST be "unknown" if set in
             development_stage_ontology_term_id; otherwise, this MUST be the human-readable name assigned to
             the value of development_stage_ontology_term_id.

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -582,10 +582,7 @@ class TestObs:
         """
         validator = validator_with_adata
         obs = validator.adata.obs
-        obs.loc[
-            obs.index[0],
-            "cell_type_ontology_term_id",
-        ] = "unknown"
+        obs.at["Y", "cell_type_ontology_term_id"] = "unknown"
         assert validator.validate_adata()
         assert validator.errors == []
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -589,6 +589,23 @@ class TestObs:
         assert validator.validate_adata()
         assert validator.errors == []
 
+    # def test_tissue_ontology_term_id__unknown(self, validator_with_adata):
+    #     """
+    #     Test 'unknown' tissue_ontology_term_id is valid if tissue_type is 'cell culture'
+    #     """
+    #     validator = validator_with_adata
+    #     obs = validator.adata.obs
+    #
+    #     # Arrange
+    #     copy_of_first_row = obs.iloc[0].copy()
+    #     copy_of_first_row["tissue"] = "unknown"
+    #     copy_of_first_row["tissue_ontology_term_id"] = "unknown"
+    #     validator.adata.obs = pd.concat([obs.iloc[:-1], copy_of_first_row])
+    #     print(obs.obs_names)
+    #
+    #     assert validator.validate_adata()
+    #     assert validator.errors == []
+
     def test_self_reported_ethnicity_ontology_term_id__unknown_in_multi_term(self, validator_with_adata):
         """
         Test 'unknown' self_reported_ethnicity_ontology_term is invalid when used in multi-term comma-delimited str
@@ -915,7 +932,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'CL:0000057 (cell culture)' in 'tissue_ontology_term_id' is not a valid ontology term id "
-            "of 'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
+            "of 'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be either a CL term "
             "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "and 'CL:0000548' (animal cell)) or 'unknown'."
         ]
@@ -931,7 +948,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'tissue_ontology_term_id' is not a valid ontology term id of "
-            "'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
+            "'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be either a CL term "
             "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "and 'CL:0000548' (animal cell)) or 'unknown'."
         ]
@@ -953,7 +970,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             f"ERROR: '{term}' in 'tissue_ontology_term_id' is not allowed. When 'tissue_type' is "
-            f"'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
+            f"'cell culture', 'tissue_ontology_term_id' MUST be either a CL term "
             "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "and 'CL:0000548' (animal cell)) or 'unknown'."
         ]

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2110,7 +2110,7 @@ class TestAddingLabels:
         for i, j in zip(expected_column.tolist(), obtained_column.tolist()):
             assert i == j
 
-    def test_obs_added_cell_type_label__unknown(self, validator_with_adata):
+    def test_obs_added_tissue_type_label__unknown(self, validator_with_adata):
         obs = validator_with_adata.adata.obs
 
         # Arrange
@@ -2120,6 +2120,16 @@ class TestAddingLabels:
         AnnDataLabelAppender(validator_with_adata)._add_labels()  # Annotate
 
         assert obs.at["Y", "tissue"] == "unknown"
+
+    def test_obs_added_cell_type_label__unknown(self, validator_with_adata):
+        obs = validator_with_adata.adata.obs
+
+        # Arrange
+        obs.at["Y", "cell_type_ontology_term_id"] = "unknown"  # Testing this term case
+        validator_with_adata.validate_adata()  # Validate
+        AnnDataLabelAppender(validator_with_adata)._add_labels()  # Annotate
+
+        assert obs.at["Y", "cell_type"] == "unknown"
 
     def test_remove_unused_categories(self, label_writer, adata_with_labels):
         modified_donor_id = label_writer.adata.obs["donor_id"].cat.add_categories("donor_3")

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -904,8 +904,8 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'CL:0000057 (cell culture)' in 'tissue_ontology_term_id' is not a valid ontology term id "
             "of 'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
-            "and it cannot be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
-            "nor 'CL:0000548' (animal cell)."
+            "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
+            "and 'CL:0000548' (animal cell)) or 'unknown'."
         ]
 
     def test_tissue_ontology_term_id_cell_culture__not_a_CL_term(self, validator_with_adata):
@@ -920,8 +920,8 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'tissue_ontology_term_id' is not a valid ontology term id of "
             "'CL'. When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
-            "and it cannot be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
-            "nor 'CL:0000548' (animal cell)."
+            "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
+            "and 'CL:0000548' (animal cell)) or 'unknown'."
         ]
 
     @pytest.mark.parametrize(
@@ -942,8 +942,8 @@ class TestObs:
         assert validator.errors == [
             f"ERROR: '{term}' in 'tissue_ontology_term_id' is not allowed. When 'tissue_type' is "
             f"'cell culture', 'tissue_ontology_term_id' MUST be a CL term "
-            "and it cannot be 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
-            "nor 'CL:0000548' (animal cell)."
+            "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
+            "and 'CL:0000548' (animal cell)) or 'unknown'."
         ]
 
     def test_tissue_ontology_term_id_organoid(self, validator_with_adata):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -589,22 +589,18 @@ class TestObs:
         assert validator.validate_adata()
         assert validator.errors == []
 
-    # def test_tissue_ontology_term_id__unknown(self, validator_with_adata):
-    #     """
-    #     Test 'unknown' tissue_ontology_term_id is valid if tissue_type is 'cell culture'
-    #     """
-    #     validator = validator_with_adata
-    #     obs = validator.adata.obs
-    #
-    #     # Arrange
-    #     copy_of_first_row = obs.iloc[0].copy()
-    #     copy_of_first_row["tissue"] = "unknown"
-    #     copy_of_first_row["tissue_ontology_term_id"] = "unknown"
-    #     validator.adata.obs = pd.concat([obs.iloc[:-1], copy_of_first_row])
-    #     print(obs.obs_names)
-    #
-    #     assert validator.validate_adata()
-    #     assert validator.errors == []
+    def test_tissue_ontology_term_id__unknown(self, validator_with_adata):
+        """
+        Test 'unknown' tissue_ontology_term_id is valid if tissue_type is 'cell culture'
+        """
+        validator = validator_with_adata
+        obs = validator.adata.obs
+
+        # Arrange -- relies on "tissue_type" value for index "Y" already being "cell culture"
+        obs.at["Y", "tissue_ontology_term_id"] = "unknown"
+
+        assert validator.validate_adata()
+        assert validator.errors == []
 
     def test_self_reported_ethnicity_ontology_term_id__unknown_in_multi_term(self, validator_with_adata):
         """

--- a/schema/4.1.0/schema.md
+++ b/schema/4.1.0/schema.md
@@ -494,7 +494,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
     <tr>
       <th>Annotator</th>
-      <td>CCurator MUST annotate.</td>
+      <td>Curator MUST annotate.</td>
     </tr>
     <tr>
       <th>Value</th>

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -114,7 +114,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
 def test_generate_script__with_automated_replaced_by_map(template, tmpdir):  # type: ignore
     ontology_term_map = {
         "assay": {"EFO:0000002": "EFO:0000001"},
-        "cell_type": {"CL:0000002": "CL:0000001", "CL:0000004": "CL:0000003"},
+        "cell_type": {"CL:0000002": "CL:0000001", "CL:0000004": "unknown"},
         "development_stage": {},
         "disease": {},
         "organism": {},
@@ -149,7 +149,7 @@ ONTOLOGY_TERM_MAPS = {
     },
     "cell_type": {
         "CL:0000002": "CL:0000001", # AUTOMATED
-        "CL:0000004": "CL:0000003", # AUTOMATED
+        "CL:0000004": "unknown", # AUTOMATED
     },
     "development_stage": {
     },


### PR DESCRIPTION
- add exception for "unknown" to schema def yml
- update test_convert_template.py
- migrate script should get auto-updated during migration workflow

## Reason for Change

- #735 

## Changes

- Permit `"unknown"` for `cell_type_ontology_term_id`
  - Annotate `cell_type` as `"unknown"`
- Permit `"unknown"` for `tissue_ontology_term_id` when `tissue_type` is `"cell culture"`
  - Annotate `tissue` as `"unknown"`
- Various unrelated typo fixes
- Fix test `unmigrated_X` in `examples_validate.py` to reference correct obs df shape as source of row count when instantiating

## Testing

- unit tests added to test against scenarios where the ontology term for cell type or tissue is `"unknown"`
- test label writes
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer