### PR TITLE
fix: test fixtures involving new gene info

### DIFF
--- a/cellxgene_schema_cli/tests/fixtures/examples_ontology_test.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_ontology_test.py
@@ -4,22 +4,21 @@ from cellxgene_schema import ontology
 invalid_species = ["Caenorhabditis elegans"]
 
 valid_genes = {
-    ontology.SupportedOrganisms.HOMO_SAPIENS: {"ENSG00000141510": ("TP53", 5676)},
+    ontology.SupportedOrganisms.HOMO_SAPIENS: {"ENSG00000141510": ("TP53", 6836)},
     ontology.SupportedOrganisms.MUS_MUSCULUS: {"ENSMUSG00000059552": ("Trp53", 4045)},
 }
 
 valid_genes_same_name_diff_species = {
-    ontology.SupportedOrganisms.HOMO_SAPIENS: {"ENSG00000277925": ("Telomerase-vert_ENSG00000277925", 438)},
+    ontology.SupportedOrganisms.HOMO_SAPIENS: {"ENSG00000166278": ("C2_ENSG00000166278", 7151)},
     ontology.SupportedOrganisms.MUS_MUSCULUS: {
-        "ENSMUSG00002075569": ("Telomerase-vert_ENSMUSG00002075569", 423),
-        "ENSMUSG00002076068": ("Telomerase-vert_ENSMUSG00002076068", 412),
+        "ENSMUSG00000024371": ("C2_ENSMUSG00000024371", 3872),
     },
 }
 
 valid_genes_same_name_and_species = {
     ontology.SupportedOrganisms.MUS_MUSCULUS: {
-        "ENSMUSG00002075311": ("U6_ENSMUSG00002075311", 110),
-        "ENSMUSG00002075357": ("U6_ENSMUSG00002075357", 110),
+        "ENSMUSG00000091071": ("1700030C10Rik_ENSMUSG00000091071", 126),
+        "ENSMUSG00000099759": ("1700030C10Rik_ENSMUSG00000099759", 1735),
     },
 }
 

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -145,7 +145,7 @@ good_var = pd.DataFrame(
 var_expected = pd.DataFrame(
     [
         ["spike-in", False, "ERCC-00002 (spike-in control)", "NCBITaxon:32630", 0],
-        ["gene", False, "MACF1", "NCBITaxon:9606", 42738],
+        ["gene", False, "MACF1", "NCBITaxon:9606", 70573],
         ["gene", False, "Trp53", "NCBITaxon:10090", 4045],
         ["gene", False, "S", "NCBITaxon:2697049", 3822],
     ],

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -417,7 +417,10 @@ class TestObs:
         validator = validator_with_adata
         validator.adata.obs.loc[validator.adata.obs.index[0], "cell_type_ontology_term_id"] = term
         validator.validate_adata()
-        assert validator.errors == [f"ERROR: '{term}' in 'cell_type_ontology_term_id' is not allowed."]
+        # Forbidden columns may be marked as either "not allowed" or "deprecated"
+        assert validator.errors == [
+            f"ERROR: '{term}' in 'cell_type_ontology_term_id' is not allowed."
+        ] or validator.errors == [f"ERROR: '{term}' in 'cell_type_ontology_term_id' is a deprecated term id of 'CL'."]
 
     def test_development_stage_ontology_term_id_human(self, validator_with_adata):
         """
@@ -980,8 +983,15 @@ class TestObs:
         obs.loc[obs.index[0], "tissue_type"] = "cell culture"
         obs.loc[obs.index[0], "tissue_ontology_term_id"] = term
         validator.validate_adata()
+
+        # Forbidden columns may be marked as either "not allowed" or "deprecated"
         assert validator.errors == [
             f"ERROR: '{term}' in 'tissue_ontology_term_id' is not allowed. When 'tissue_type' is "
+            f"'cell culture', 'tissue_ontology_term_id' MUST be either a CL term "
+            "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
+            "and 'CL:0000548' (animal cell)) or 'unknown'."
+        ] or validator.errors == [
+            f"ERROR: '{term}' in 'tissue_ontology_term_id' is a deprecated term id of 'CL'. When 'tissue_type' is "
             f"'cell culture', 'tissue_ontology_term_id' MUST be either a CL term "
             "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "and 'CL:0000548' (animal cell)) or 'unknown'."

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -173,7 +173,7 @@ class TestAddLabelFunctions:
         # values derived from csv
         gene_lengths = [
             0,  # non-gene feature, so set to 0 regardless of csv value
-            42738,
+            70573,
             4045,
             3822,
         ]


### PR DESCRIPTION
## Reason for Change

addresses https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/739

## Changes

fixes any tests that were broken with the gencode version bump. it looks like some genes were renamed, so we had to update some of our test fixtures.

## Testing

for the ontology tests involving deduplicated genes, these had to be rewritten because it seems like a lot of the deduplicated names were changed with the gencode bump. i identified deduplicated genes by adding this ✨ print statement ✨ to `process_gene_infos` in `gene_processing.py`:
```
    def process_gene_infos(self, gene_infos: dict) -> None:
        for gene_info_key in gene_infos:
            # Add to self.gene_labels and self.gene_ids_by_description
            self.process_individual_gene_info(gene_infos[gene_info_key])

        # Deduplicate gene names across all gene_metadata
        print("Deduplicating gene names...")
        gene_names = set()
        duplicated_gene_names = set()
        for gene_metadata in self.gene_metadata.values():
            gene_name = gene_metadata.gene_name
            if gene_name in gene_names:
                duplicated_gene_names.add(gene_name)
            else:
                gene_names.add(gene_name)
        for gene_id, gene_metadata in self.gene_metadata.items():
            gene_name = gene_metadata.gene_name
            if gene_name in duplicated_gene_names:
                ✨ print("Deduplicating gene name", gene_name, "for gene id", gene_id, "length", gene_metadata.gene_length) ✨
                self.gene_metadata[gene_id].gene_name = gene_name + "_" + gene_id
```
then, copying and pasting the output, and pasting it into the "feb 2024" sheet here: https://docs.google.com/spreadsheets/d/1jg5vWYFZloHPy91oZOyS0P0Nhct3rufTDrykGPnO7cQ/edit#gid=1872292825

and then manually scanning the page to find a gene name that is deduplicated across just one species and a gene name that is deduplicated across two species.

for all additional tests, these involved changes to gene length. i trusted that the new gencode files have the correct gene length and did not independently verify this.