### PR TITLE
chore: remove '.' from third position in obsm key

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -369,6 +369,11 @@ def migrate(input_file, output_file, collection_id, dataset_id):
         if value is not None and type(value) is not bool and len(value) == 0:
             del dataset.uns[key]
 
+    if "X_.umap_MinDist_0.2_N_Neighbors_15" in dataset.obsm:
+        # Applies to dataset ids 63bb6359-3945-4658-92eb-3072419953e4 and 9b188f26-c8e1-4a78-af15-622a35a371fc
+        dataset.obsm["X_umap_MinDist_0.2_N_Neighbors_15"] = dataset.obsm["X_.umap_MinDist_0.2_N_Neighbors_15"]
+        del dataset.obsm["X_.umap_MinDist_0.2_N_Neighbors_15"]
+
     if collection_id == "91c8e321-566f-4f9d-b89e-3a164be654d5":
         utils.map_ontology_term(
             dataset.obs,


### PR DESCRIPTION
## Reason for Change

- Addresses part of #797

## Changes

- Update migrate script to change the offending `obsm` key that includes a `.` in the 2 str index position.

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer