### PR TITLE
feat: update regex pattern and add valid test

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -923,7 +923,7 @@ class Validator:
         for key, value in self.adata.obsm.items():
             issue_list = self.errors
 
-            regex_pattern = r"^[a-zA-Z][a-zA-Z0-9]*$"
+            regex_pattern = r"^[a-zA-Z][a-zA-Z0-9_.-]*$"
 
             if key.startswith("X_"):
                 obsm_with_x_prefix += 1

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1949,7 +1949,7 @@ class TestObsm:
         validator.adata.obsm["X_3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$.",
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$.",
             "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class 'pandas.core.frame.DataFrame'>').",
         ]
 
@@ -1958,7 +1958,7 @@ class TestObsm:
         validator.adata.obsm["3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Embedding key in 'adata.obsm' 3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$."
+            "ERROR: Embedding key in 'adata.obsm' 3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$."
         ]
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
@@ -1975,7 +1975,7 @@ class TestObsm:
         validator.adata.obsm["X_"] = validator.adata.obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_ does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$."
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_ does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$."
         ]
 
     def test_obsm_key_name_whitespace(self, validator_with_adata):
@@ -1987,15 +1987,21 @@ class TestObsm:
         obsm["X_ umap"] = obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_ umap does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$.",
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_ umap does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$.",
         ]
 
         del obsm["X_ umap"]
         obsm["u m a p"] = obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Embedding key in 'adata.obsm' u m a p does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9]*$."
+            "ERROR: Embedding key in 'adata.obsm' u m a p does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$."
         ]
+    
+    def test_obsm_suffix_has_special_characters_valid(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.obsm["X_umap_MinDist_0.2_N_Neighbors-15"] = validator.adata.obsm["X_umap"]
+        validator.validate_adata()
+        assert validator.errors == []
 
     def test_obsm_shape_one_column(self, validator_with_adata):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1996,7 +1996,7 @@ class TestObsm:
         assert validator.errors == [
             "ERROR: Embedding key in 'adata.obsm' u m a p does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$."
         ]
-    
+
     def test_obsm_suffix_has_special_characters_valid(self, validator_with_adata):
         validator = validator_with_adata
         validator.adata.obsm["X_umap_MinDist_0.2_N_Neighbors-15"] = validator.adata.obsm["X_umap"]


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell/685

## Changes

updates regex pattern from `r"^[a-zA-Z][a-zA-Z0-9]*$"` to `r"^[a-zA-Z][a-zA-Z0-9_.-]*$"` which in english means:
- first character must be alphabetic
- subsequent characters must be alphanumeric or one of `_`, `-`, `.` 

## Testing

i wrote this script locally to figure out the list of all obsm keys that failed validation on the recent dev run:
```
import json
import re

def main():
    with open("validation_errors.json", "r") as file:
        json_data = json.load(file)
        all_errors = []

        for _, datasets in json_data.items():
            for _, errors in datasets.items():
                all_errors.extend(errors)

        for error in all_errors:
            prefix = "ERROR: Suffix for embedding key in 'adata.obsm' "
            if error.startswith(prefix):
                rest_of_error = error[len(prefix):].strip()
                embedding_key = rest_of_error.split(" ")[0]
                regex_pattern = r"^[a-zA-Z][a-zA-Z0-9]*$"
                if not re.match(regex_pattern, embedding_key[2:]):
                    print(embedding_key)

main()
```

then, i re-ran the script using `r"^[a-zA-Z][a-zA-Z0-9_.-]*$"` instead of `r"^[a-zA-Z][a-zA-Z0-9]*$"`, since eyeballing the failed keys seemed to indicate that `_`, `-` and `.` were allowable characters. this did result in one key failing the new validation rule: `X_.umap_MinDist_0.2_N_Neighbors_15`. however, as discussed, we'll just be migrating this key: https://github.com/chanzuckerberg/single-cell-curation/pull/798/files

this will allow us to describe the validation rule more clearly: suffix must start with alphabetic character, and subsequent allowable characters are alphanumeric or one of `_`, `-` or `.`.

if we don't migrate `X_.umap_MinDist_0.2_N_Neighbors_15` and allow that, then we'd need to describe the validation rule more confusingly as: suffix must start with an alphabetic character or one of `_`, `-`, `.` but cannot start with a numeric character, and subsequent allowable characters are alphanumeric or one of `_`, `-` or `.`.

additionally, i added a unit test to verify that an obsm embedding key with `_`, `-` and `.` in it will pass validation.

## Notes for Reviewer