### PR TITLE
chore: update schema requirements for obsm suffix keys

### DIFF
--- a/schema/5.0.0/schema.md
+++ b/schema/5.0.0/schema.md
@@ -1138,7 +1138,7 @@ To display a dataset in CELLxGENE Explorer, Curators MUST annotate **one or more
       <td>X_{suffix} with the following requirements:<br><br>
       <ul>
         <li>{suffix} MUST be at least one character in length.</li>
-        <li>The first character of {suffix} MUST be a letter of the alphabet and the remaining characters MUST be alphanumeric characters. (This is equivalent to the regular expression pattern <code>"^[a-zA-Z][a-zA-Z0-9]*$"</code>.)</li>
+        <li>The first character of {suffix} MUST be a letter of the alphabet and the remaining characters MUST be alphanumeric characters or one of: `_`, `-`, `.` (This is equivalent to the regular expression pattern <code>"^[a-zA-Z][a-zA-Z0-9_.-]*$"</code>.)</li>
       </ul><br>
       {suffix} is presented as text to users in the <b>Embedding Choice</b> selector in CELLxGENE Explorer so it is STRONGLY RECOMMENDED that it be descriptive.<br><br>See also <code>default_embedding</code> in <code>uns</code>.</td>
     </tr>

--- a/schema/5.0.0/schema.md
+++ b/schema/5.0.0/schema.md
@@ -1594,6 +1594,7 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
   * Updated requirements. The data stored as a value for a key in `uns` MUST be `True`, `False`, `None`, or its size MUST NOT be zero.
   * Updated schema_reference to <code>"https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.0.0/schema.md"</code>
   * Updated schema_version to <code>"5.0.0"</code>
+* obsm (Embeddings)
   * Updated requirements for `obsm['X_{suffix}']`
 
 ### schema v4.0.0

--- a/schema/5.0.0/schema.md
+++ b/schema/5.0.0/schema.md
@@ -1594,6 +1594,7 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
   * Updated requirements. The data stored as a value for a key in `uns` MUST be `True`, `False`, `None`, or its size MUST NOT be zero.
   * Updated schema_reference to <code>"https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.0.0/schema.md"</code>
   * Updated schema_version to <code>"5.0.0"</code>
+  * Updated requirements for `obsm['X_{suffix}']`
 
 ### schema v4.0.0
 

--- a/schema/5.0.0/schema.md
+++ b/schema/5.0.0/schema.md
@@ -1138,7 +1138,7 @@ To display a dataset in CELLxGENE Explorer, Curators MUST annotate **one or more
       <td>X_{suffix} with the following requirements:<br><br>
       <ul>
         <li>{suffix} MUST be at least one character in length.</li>
-        <li>The first character of {suffix} MUST be a letter of the alphabet and the remaining characters MUST be alphanumeric characters or one of: `_`, `-`, `.` (This is equivalent to the regular expression pattern <code>"^[a-zA-Z][a-zA-Z0-9_.-]*$"</code>.)</li>
+        <li>The first character of {suffix} MUST be a letter of the alphabet and the remaining characters MUST be alphanumeric characters or one of: <code>_</code>, <code>-</code>, <code>.</code> (This is equivalent to the regular expression pattern <code>"^[a-zA-Z][a-zA-Z0-9_.-]*$"</code>.)</li>
       </ul><br>
       {suffix} is presented as text to users in the <b>Embedding Choice</b> selector in CELLxGENE Explorer so it is STRONGLY RECOMMENDED that it be descriptive.<br><br>See also <code>default_embedding</code> in <code>uns</code>.</td>
     </tr>

--- a/schema/5.1.0/schema.md
+++ b/schema/5.1.0/schema.md
@@ -1221,7 +1221,7 @@ To display a dataset in CELLxGENE Explorer, Curators MUST annotate **one or more
       <td>X_{suffix} with the following requirements:<br><br>
       <ul>
         <li>{suffix} MUST be at least one character in length.</li>
-        <li>The first character of {suffix} MUST be a letter of the alphabet and the remaining characters MUST be alphanumeric characters or one of: `_`, `-`, `.` (This is equivalent to the regular expression pattern <code>"^[a-zA-Z][a-zA-Z0-9_.-]*$"</code>.)</li>
+        <li>The first character of {suffix} MUST be a letter of the alphabet and the remaining characters MUST be alphanumeric characters or one of: <code>_</code>, <code>-</code>, <code>.</code> (This is equivalent to the regular expression pattern <code>"^[a-zA-Z][a-zA-Z0-9_.-]*$"</code>.)</li>
          <li>{suffix} MUST NOT be <code>"spatial"</code>.
       </ul><br>
       {suffix} is presented as text to users in the <b>Embedding Choice</b> selector in CELLxGENE Explorer so it is STRONGLY RECOMMENDED that it be descriptive.<br><br>See also <code>default_embedding</code> in <code>uns</code>.</td>

--- a/schema/5.1.0/schema.md
+++ b/schema/5.1.0/schema.md
@@ -1891,6 +1891,7 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
   * Updated requirements. The data stored as a value for a key in `uns` MUST be `True`, `False`, `None`, or its size MUST NOT be zero.
   * Updated schema_reference to <code>"https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.0.0/schema.md"</code>
   * Updated schema_version to <code>"5.0.0"</code>
+* obsm (Embeddings)
   * Updated requirements for `obsm['X_{suffix}']`
 
 ### schema v4.0.0

--- a/schema/5.1.0/schema.md
+++ b/schema/5.1.0/schema.md
@@ -1221,7 +1221,7 @@ To display a dataset in CELLxGENE Explorer, Curators MUST annotate **one or more
       <td>X_{suffix} with the following requirements:<br><br>
       <ul>
         <li>{suffix} MUST be at least one character in length.</li>
-        <li>The first character of {suffix} MUST be a letter of the alphabet and the remaining characters MUST be alphanumeric characters. (This is equivalent to the regular expression pattern <code>"^[a-zA-Z][a-zA-Z0-9]*$"</code>.)</li>
+        <li>The first character of {suffix} MUST be a letter of the alphabet and the remaining characters MUST be alphanumeric characters or one of: `_`, `-`, `.` (This is equivalent to the regular expression pattern <code>"^[a-zA-Z][a-zA-Z0-9_.-]*$"</code>.)</li>
          <li>{suffix} MUST NOT be <code>"spatial"</code>.
       </ul><br>
       {suffix} is presented as text to users in the <b>Embedding Choice</b> selector in CELLxGENE Explorer so it is STRONGLY RECOMMENDED that it be descriptive.<br><br>See also <code>default_embedding</code> in <code>uns</code>.</td>
@@ -1891,6 +1891,7 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
   * Updated requirements. The data stored as a value for a key in `uns` MUST be `True`, `False`, `None`, or its size MUST NOT be zero.
   * Updated schema_reference to <code>"https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.0.0/schema.md"</code>
   * Updated schema_version to <code>"5.0.0"</code>
+  * Updated requirements for `obsm['X_{suffix}']`
 
 ### schema v4.0.0
 


### PR DESCRIPTION
## Reason for Change

https://github.com/chanzuckerberg/single-cell-curation/issues/797

After [discussion](https://czi-sci.slack.com/archives/C06AVGFV222/p1709754992082549), we agreed that it was best to validate that suffix keys matched the pattern `^[a-zA-Z][a-zA-Z0-9_.-]*$`

## Changes

- Updates the schema requirements to match the new regex pattern

## Testing

n/a

## Notes for Reviewer