### PR TITLE
fix: bool check for uns empty keys

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -1,4 +1,5 @@
 import anndata as ad
+import numpy as np
 
 from . import utils
 
@@ -366,7 +367,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # Delete any uns keys with an empty value, logic taken from:
     # https://github.com/chanzuckerberg/single-cell-curation/blob/43f891005fb9439dbbb747fa0df8f0435ebf3f7c/cellxgene_schema_cli/cellxgene_schema/validate.py#L761-L762
     for key, value in list(dataset.uns.items()):
-        if value is not None and type(value) is not bool and len(value) == 0:
+        if value is not None and type(value) is not bool and type(value) is not np.bool_ and len(value) == 0:
             del dataset.uns[key]
 
     if "X_.umap_MinDist_0.2_N_Neighbors_15" in dataset.obsm:

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -367,7 +367,12 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # Delete any uns keys with an empty value, logic taken from:
     # https://github.com/chanzuckerberg/single-cell-curation/blob/43f891005fb9439dbbb747fa0df8f0435ebf3f7c/cellxgene_schema_cli/cellxgene_schema/validate.py#L761-L762
     for key, value in list(dataset.uns.items()):
-        if value is not None and type(value) is not bool and type(value) is not np.bool_ and len(value) == 0:
+        if (
+            value is not None
+            and type(value) is not bool
+            and not (isinstance(value, (np.bool_, np.bool)))
+            and len(value) == 0
+        ):
             del dataset.uns[key]
 
     if "X_.umap_MinDist_0.2_N_Neighbors_15" in dataset.obsm:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -759,7 +759,7 @@ class Validator:
                 category_mapping[column_name] = column.nunique()
 
         for key, value in uns_dict.items():
-            if value is not None and type(value) is not bool and len(value) == 0:
+            if value is not None and type(value) is not bool and type(value) is not np.bool_ and len(value) == 0:
                 self.errors.append(f"uns['{key}'] cannot be an empty value.")
             if key.endswith("_colors"):
                 # 1. Verify that the corresponding categorical field exists in obs

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -759,7 +759,12 @@ class Validator:
                 category_mapping[column_name] = column.nunique()
 
         for key, value in uns_dict.items():
-            if value is not None and type(value) is not bool and not (isinstance(value, np.bool_) or isinstance(value, np.bool)) and len(value) == 0:
+            if (
+                value is not None
+                and type(value) is not bool
+                and not (isinstance(value, (np.bool_, np.bool)))
+                and len(value) == 0
+            ):
                 self.errors.append(f"uns['{key}'] cannot be an empty value.")
             if key.endswith("_colors"):
                 # 1. Verify that the corresponding categorical field exists in obs

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -759,7 +759,7 @@ class Validator:
                 category_mapping[column_name] = column.nunique()
 
         for key, value in uns_dict.items():
-            if value is not None and type(value) is not bool and type(value) is not np.bool_ and len(value) == 0:
+            if value is not None and type(value) is not bool and not (isinstance(value, np.bool_) or isinstance(value, np.bool)) and len(value) == 0:
                 self.errors.append(f"uns['{key}'] cannot be an empty value.")
             if key.endswith("_colors"):
                 # 1. Verify that the corresponding categorical field exists in obs

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1754,8 +1754,13 @@ class TestUns:
         validator.validate_adata()
         assert validator.errors == []
 
-        # Numpy bool value
+        # Numpy bool_ value
         validator.adata.uns["log1p"] = numpy.bool_(True)
+        validator.validate_adata()
+        assert validator.errors == []
+
+        # Numpy bool value
+        validator.adata.uns["log1p"] = numpy.bool(True)
         validator.validate_adata()
         assert validator.errors == []
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1745,6 +1745,19 @@ class TestUns:
         validator.adata.uns["log1p"] = {}
         validator.validate_adata()
         assert validator.errors == ["ERROR: uns['log1p'] cannot be an empty value."]
+    
+    def test_uns_bool_allowed(self, validator_with_adata):
+        validator = validator_with_adata
+        
+        # Regular bool value
+        validator.adata.uns["log1p"] = True
+        validator.validate_adata()
+        assert validator.errors == []
+
+        # Numpy bool value
+        validator.adata.uns["log1p"] = numpy.bool_(True)
+        validator.validate_adata()
+        assert validator.errors == []
 
     def test_colors_happy_path_duplicates(self, validator_with_adata):
         validator = validator_with_adata

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1745,10 +1745,10 @@ class TestUns:
         validator.adata.uns["log1p"] = {}
         validator.validate_adata()
         assert validator.errors == ["ERROR: uns['log1p'] cannot be an empty value."]
-    
+
     def test_uns_bool_allowed(self, validator_with_adata):
         validator = validator_with_adata
-        
+
         # Regular bool value
         validator.adata.uns["log1p"] = True
         validator.validate_adata()


### PR DESCRIPTION
## Reason for Change

we have datasets with `adata.uns["log1p"] = numpy.bool_(True)`, so our check for `type(value) is not bool` doesn't work. for some reason, i can't directly connect this PR to this issue: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/728 but it does patch our previous work on that ticket, in addition to this one: https://github.com/chanzuckerberg/single-cell/issues/684

## Changes

updates to also verify that `type(value)` is not `np.bool_` in both the migrate script and the schema validation

## Testing

added unit test coverage

## Notes for Reviewer