### PR TITLE
chore: migrate: change uns default embedding where appropriate

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -387,16 +387,20 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     column_changes = []
     for key in list(dataset.obsm.keys()):
         delete_key = False
-        if " " in key:
-            dataset.obsm[key.replace(" ", "_")] = dataset.obsm[key]
+        new_key = key
+        if " " in new_key:
+            new_key = new_key.replace(" ", "_")
             delete_key = True
-        if key.startswith("_"):
-            dataset.obsm[key.strip("_")] = dataset.obsm[key]
+        if new_key.startswith("_"):
+            new_key = new_key.strip("_")
             delete_key = True
-        if "(" in key or ")" in key:
-            dataset.obsm[key.replace("(", "").replace(")", "")] = dataset.obsm[key]
+        if "(" in new_key or ")" in new_key:
+            new_key = new_key.replace("(", "").replace(")", "")
             delete_key = True
         if delete_key:
+            dataset.obsm[new_key] = dataset.obsm[key]
+            if (default_embedding := dataset.uns.get("default_embedding")) and default_embedding == key:
+                dataset.uns["default_embedding"] = new_key
             column_changes.append(key)
             del dataset.obsm[key]
 


### PR DESCRIPTION
## Reason for Change

- When an `obsm` key is the value for `uns["default_embedding"]`, then we need to update that value if that particular `obsm` key needed to be transformed due to the presence of illegal characters, otherwise validation fails.

## Changes

- 

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer