### PR TITLE
chore: remove version bump from generate conversion script

### DIFF
--- a/.github/workflows/generate-conversion-script.yml
+++ b/.github/workflows/generate-conversion-script.yml
@@ -49,12 +49,6 @@ jobs:
       - name: remove diff files
         run: |
           git rm --ignore-unmatch ./cellxgene_schema_cli/cellxgene_schema/ontology_files/*_diff.txt
-      - name: Bump RC to Major Version
-        run: |
-          pip install bumpversion
-          pip install wheel
-          bumpversion --config-file .bumpversion.cfg prerel --allow-dirty --tag
-          echo "new_version=$(make show-current-version)" >> $GITHUB_ENV
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-data-portal/6863

## Changes

- removes the version bump from the generate conversion script workflow

## Testing

n/a

## Notes for Reviewer