### PR TITLE
release 5.0.1

### DIFF
--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -14,16 +14,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - name: Build dist
-        run: |
-          pip install wheel
-          make pydist
-      - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: cellxgene_schema_cli/dist/
+#      - name: Build dist
+#        run: |
+#          pip install wheel
+#          make pydist
+#      - name: Publish distribution to Test PyPI
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+#          repository-url: https://test.pypi.org/legacy/
+#          packages-dir: cellxgene_schema_cli/dist/
       - name: Install and Test Package from Test PyPI
         run: |
           pip install -r cellxgene_schema_cli/requirements.txt

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -18,13 +18,13 @@ jobs:
         run: |
           pip install wheel
           pip install --upgrade setuptools
-          make pydist
-      - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: cellxgene_schema_cli/dist/
+#          make pydist
+##      - name: Publish distribution to Test PyPI
+##        uses: pypa/gh-action-pypi-publish@release/v1
+##        with:
+##          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+##          repository-url: https://test.pypi.org/legacy/
+##          packages-dir: cellxgene_schema_cli/dist/
       - name: Install and Test Package from Test PyPI
         run: |
           pip install -r cellxgene_schema_cli/requirements.txt

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build dist
         run: |
           pip install wheel
-          pip install setuptools
+          pip install --upgrade setuptools
           make pydist
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          check-latest: true
 #      - name: Build dist
 #        run: |
 #          pip install wheel

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Build dist
         run: |
           pip install wheel
+          pip install setuptools
           make pydist
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.x"
       - name: Build dist
         run: |
-          pip install wheel
+          pip install wheel==0.40.0
           pip install --upgrade setuptools
 #          make pydist
 ##      - name: Publish distribution to Test PyPI

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -18,13 +18,13 @@ jobs:
         run: |
           pip install wheel==0.40.0
           pip install --upgrade setuptools
-#          make pydist
-##      - name: Publish distribution to Test PyPI
-##        uses: pypa/gh-action-pypi-publish@release/v1
-##        with:
-##          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-##          repository-url: https://test.pypi.org/legacy/
-##          packages-dir: cellxgene_schema_cli/dist/
+          make pydist
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: cellxgene_schema_cli/dist/
       - name: Install and Test Package from Test PyPI
         run: |
           pip install -r cellxgene_schema_cli/requirements.txt

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -13,11 +13,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
       - name: Build dist
         run: |
-          pip install wheel==0.40.0
-          pip install --upgrade setuptools
+          pip install wheel
           make pydist
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           python-version: "3.11"
           check-latest: true
-#      - name: Build dist
-#        run: |
-#          pip install wheel
-#          make pydist
+      - name: Build dist
+        run: |
+          pip install wheel
+          make pydist
 #      - name: Publish distribution to Test PyPI
 #        uses: pypa/gh-action-pypi-publish@release/v1
 #        with:


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- 

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer