### PR TITLE
fix: use 'descendant' descriptor instead of 'child'

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/convert.py
+++ b/cellxgene_schema_cli/cellxgene_schema/convert.py
@@ -82,7 +82,7 @@ def convert(input_file, output_file):
 
     # Set suspension type
 
-    # mappings of assays (or assays + child term assays) to corresponding suspension_type
+    # mappings of assays (or assays + descendant term assays) to corresponding suspension_type
     # valid assays with multiple possible suspension_types shown but commented out
     match_assays = {
         # 'EFO:0010010': ['cell', 'nucleus'],
@@ -97,7 +97,7 @@ def convert(input_file, output_file):
         "EFO:0030027": "nucleus",
     }
 
-    match_assays_or_children = {
+    match_assays_or_descendants = {
         # 'EFO:0030080': ['cell', 'nucleus'],
         "EFO:0007045": "nucleus",
         "EFO:0009294": "cell",
@@ -113,7 +113,7 @@ def convert(input_file, output_file):
         if item in match_assays:
             return match_assays[item]
         else:
-            for k, v in match_assays_or_children.items():
+            for k, v in match_assays_or_descendants.items():
                 try:
                     if k == item or ontology_checker.is_descendent_of("EFO", item, k):
                         return v

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -8,7 +8,7 @@ max_size_for_seurat: 2147483647  # 2^31 - 1 (max value for 4-byte signed int)
 raw:
     obs:
         assay_ontology_term_id:
-                not_children_of:
+                not_descendants_of:
                     EFO:
                         - EFO:0007045 # ATAC-seq
                         - EFO:0008804 # Methyl-seq
@@ -130,7 +130,7 @@ components:
                         to_column: cell_type
             assay_ontology_term_id:
                 error_message_suffix: >-
-                    Only children terms of either 'EFO:0002772' or 'EFO:0010183' are allowed for assay_ontology_term_id
+                    Only descendant terms of either 'EFO:0002772' or 'EFO:0010183' are allowed for assay_ontology_term_id
                 type: curie
                 curie_constraints:
                     ontologies:
@@ -145,7 +145,7 @@ components:
                         type: curie
                         to_column: assay
             disease_ontology_term_id:
-                error_message_suffix: "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
+                error_message_suffix: "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
                 type: curie
                 curie_constraints:
                     ontologies:
@@ -167,7 +167,7 @@ components:
                         to_column: disease
             organism_ontology_term_id:
                 type: curie
-                error_message_suffix: "Only children term ids of 'NCBITaxon:33208' for metazoan are allowed."
+                error_message_suffix: "Only descendant term ids of 'NCBITaxon:33208' for metazoan are allowed."
                 curie_constraints:
                     ontologies:
                         - NCBITaxon
@@ -201,7 +201,7 @@ components:
                         rule: "tissue_type == 'tissue' | tissue_type == 'organoid'"
                         error_message_suffix: >-
                             When 'tissue_type' is 'tissue' or 'organoid',
-                            'tissue_ontology_term_id' MUST be a child term id of 'UBERON:0001062' (anatomical entity).
+                            'tissue_ontology_term_id' MUST be a descendant term id of 'UBERON:0001062' (anatomical entity).
                         type: curie
                         curie_constraints:
                             ontologies:
@@ -327,7 +327,7 @@ components:
                 # If organism is not humnan nor mouse
                 error_message_suffix: >-
                     When 'organism_ontology_term_id' is not 'NCBITaxon:10090' nor 'NCBITaxon:9606',
-                    'development_stage_ontology_term_id' MUST be a child term id of 'UBERON:0000105'
+                    'development_stage_ontology_term_id' MUST be a descendant term id of 'UBERON:0000105'
                     excluding 'UBERON:0000071', or unknown.
                 curie_constraints:
                     ontologies:
@@ -365,7 +365,7 @@ components:
                     during submission so that the assay(s) can be added to the schema definition document.
                 dependencies:
                     -
-                        # If assay_ontology_term_id is EFO:0030080 or its children, 'suspension_type' MUST be 'cell' or 'nucleus'
+                        # If assay_ontology_term_id is EFO:0030080 or its descendants, 'suspension_type' MUST be 'cell' or 'nucleus'
                         complex_rule:
                             match_ancestors:
                                 column: assay_ontology_term_id
@@ -375,12 +375,12 @@ components:
                                 inclusive: True
                         type: categorical
                         error_message_suffix: >- 
-                            when 'assay_ontology_term_id' is EFO:0030080 or its children
+                            when 'assay_ontology_term_id' is EFO:0030080 or its descendants
                         enum:
                             - "cell"
                             - "nucleus"
                     -
-                        # If assay_ontology_term_id is EFO:0007045 or its children, 'suspension_type' MUST be 'nucleus'
+                        # If assay_ontology_term_id is EFO:0007045 or its descendants, 'suspension_type' MUST be 'nucleus'
                         complex_rule:
                             match_ancestors:
                                 column: assay_ontology_term_id
@@ -390,11 +390,11 @@ components:
                                 inclusive: True
                         type: categorical
                         error_message_suffix: >- 
-                            when 'assay_ontology_term_id' is EFO:0007045 or its children
+                            when 'assay_ontology_term_id' is EFO:0007045 or its descendants
                         enum:
                             - "nucleus"
                     -
-                        # If assay_ontology_term_id is EFO:0009294 or its children, 'suspension_type' MUST be 'cell'
+                        # If assay_ontology_term_id is EFO:0009294 or its descendants, 'suspension_type' MUST be 'cell'
                         complex_rule:
                             match_ancestors:
                                 column: assay_ontology_term_id
@@ -404,11 +404,11 @@ components:
                                 inclusive: True
                         type: categorical
                         error_message_suffix: >- 
-                            when 'assay_ontology_term_id' is EFO:0009294 or its children
+                            when 'assay_ontology_term_id' is EFO:0009294 or its descendants
                         enum:
                             - "cell"
                     -
-                        # If assay_ontology_term_id is EFO:0010184 or its children, 'suspension_type' MUST be 'cell' or 'nucleus'
+                        # If assay_ontology_term_id is EFO:0010184 or its descendants, 'suspension_type' MUST be 'cell' or 'nucleus'
                         complex_rule:
                             match_ancestors:
                                 column: assay_ontology_term_id
@@ -418,12 +418,12 @@ components:
                                 inclusive: True
                         type: categorical
                         error_message_suffix: >- 
-                            when 'assay_ontology_term_id' is EFO:0010184 or its children
+                            when 'assay_ontology_term_id' is EFO:0010184 or its descendants
                         enum:
                             - "cell"
                             - "nucleus"
                     -
-                        # If assay_ontology_term_id is EFO:0009918 or its children, 'suspension_type' MUST be 'na'
+                        # If assay_ontology_term_id is EFO:0009918 or its descendants, 'suspension_type' MUST be 'na'
                         complex_rule:
                             match_ancestors:
                                 column: assay_ontology_term_id
@@ -433,11 +433,11 @@ components:
                                 inclusive: True
                         type: categorical
                         error_message_suffix: >- 
-                            when 'assay_ontology_term_id' is EFO:0009918 or its children
+                            when 'assay_ontology_term_id' is EFO:0009918 or its descendants
                         enum:
                             - "na"
                     -
-                        # If assay_ontology_term_id is EFO:0700000 or its children, 'suspension_type' MUST be 'na'
+                        # If assay_ontology_term_id is EFO:0700000 or its descendants, 'suspension_type' MUST be 'na'
                         complex_rule:
                             match_ancestors:
                                 column: assay_ontology_term_id
@@ -447,11 +447,11 @@ components:
                                 inclusive: True
                         type: categorical
                         error_message_suffix: >- 
-                            when 'assay_ontology_term_id' is EFO:0700000 or its children
+                            when 'assay_ontology_term_id' is EFO:0700000 or its descendants
                         enum:
                             - "na"
                     -
-                        # If assay_ontology_term_id is EFO:0008994 or its children, 'suspension_type' MUST be 'na'
+                        # If assay_ontology_term_id is EFO:0008994 or its descendants, 'suspension_type' MUST be 'na'
                         complex_rule:
                             match_ancestors:
                                 column: assay_ontology_term_id
@@ -461,11 +461,11 @@ components:
                                 inclusive: True
                         type: categorical
                         error_message_suffix: >- 
-                            when 'assay_ontology_term_id' is EFO:0008994 or its children
+                            when 'assay_ontology_term_id' is EFO:0008994 or its descendants
                         enum:
                             - "na"
                     -
-                        # If assay_ontology_term_id is EFO:0008919 or its children, 'suspension_type' MUST be 'cell'
+                        # If assay_ontology_term_id is EFO:0008919 or its descendants, 'suspension_type' MUST be 'cell'
                         complex_rule:
                             match_ancestors:
                                 column: assay_ontology_term_id
@@ -475,7 +475,7 @@ components:
                                 inclusive: True
                         type: categorical
                         error_message_suffix: >- 
-                            when 'assay_ontology_term_id' is EFO:0008919 or its children
+                            when 'assay_ontology_term_id' is EFO:0008919 or its descendants
                         enum:
                             - "cell"
                     -

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -105,7 +105,7 @@ class Validator:
         self, term_id: str, column_name: str, forbidden_def: Dict[str, List[str]]
     ) -> bool:
         """
-        Validate if a single curie term id is a child term of any forbidden ancestors.
+        Validate if a single curie term id is a descendant term of any forbidden ancestors.
         If there is a forbidden ancestor detected, it adds it to self.errors.
 
         :param str term_id: the curie term id to validate
@@ -118,7 +118,7 @@ class Validator:
             for ancestor in forbidden_def[ontology_name]:
                 if ONTOLOGY_CHECKER.is_descendent_of(ontology_name, term_id, ancestor):
                     self.errors.append(
-                        f"'{term_id}' in '{column_name}' is not allowed. Child terms of "
+                        f"'{term_id}' in '{column_name}' is not allowed. Descendant terms of "
                         f"'{ancestor}' are not allowed."
                     )
                     return True
@@ -131,7 +131,7 @@ class Validator:
         inclusive: bool = False,
     ) -> bool:
         """
-        Validate a single curie term id is a valid child of any allowed ancestors
+        Validate a single curie term id is a valid descendant of any allowed ancestors
 
         :param str term_id: the curie term id to validate
         :param dict{str: list[str]} allowed_ancestors: keys must be ontology names and values must lists of
@@ -151,8 +151,8 @@ class Validator:
                 is_valid_term_id = ONTOLOGY_CHECKER.is_valid_term_id(ontology_name, term_id)
                 is_valid_ancestor_id = ONTOLOGY_CHECKER.is_valid_term_id(ontology_name, ancestor)
                 if is_valid_term_id & is_valid_ancestor_id:
-                    is_child = ONTOLOGY_CHECKER.is_descendent_of(ontology_name, term_id, ancestor)
-                    checks.append(is_child)
+                    is_descendant = ONTOLOGY_CHECKER.is_descendent_of(ontology_name, term_id, ancestor)
+                    checks.append(is_descendant)
 
         if True not in checks:
             return False
@@ -516,7 +516,7 @@ class Validator:
     def _generate_match_ancestors_query_fn(self, rule_def: Dict):
         """
         Generates vectorized function and args to query a pandas dataframe. Function will determine whether values from
-        a specified column is a child term to a group of specified ancestors, returning a Bool.
+        a specified column is a descendant term to a group of specified ancestors, returning a Bool.
         :param rule_def: defines arguments to pass into vectorized ancestor match validation function
         :return: Tuple(function, Tuple(str, List[str], List[str]))
         """
@@ -992,10 +992,10 @@ class Validator:
                     f"The size of the ndarray stored for a 'adata.{component_name}['{key}']' MUST NOT be zero."
                 )
 
-    def _are_children_of(self, component: str, column: str, ontology_name: str, ancestors: List[str]) -> bool:
+    def _are_descendants_of(self, component: str, column: str, ontology_name: str, ancestors: List[str]) -> bool:
         """
         Checks if elements in the specified column of the component (e.g. 'assay_ontology_term_id' of 'adata.obs') are
-        children of the given ancestors.
+        descendants of the given ancestors.
 
         Ancestors checks are inclusive, meaning that a value is its own ancestor as well.
 
@@ -1005,7 +1005,7 @@ class Validator:
         :param List[str] ancestors: List of ancestors
 
         :rtype bool
-        :return True if any value in column is children of any ancestor.
+        :return True if any value in column is a descendant of any ancestor.
         """
 
         curies = getattr(getattr(self.adata, component), column)
@@ -1142,9 +1142,9 @@ class Validator:
         for component, component_rules in self.schema_def["raw"].items():
             for column, column_rules in component_rules.items():
                 for rule, rule_def in column_rules.items():
-                    if rule == "not_children_of":
+                    if rule == "not_descendants_of":
                         for ontology_name, ancestors in rule_def.items():
-                            checks.append(not self._are_children_of(component, column, ontology_name, ancestors))
+                            checks.append(not self._are_descendants_of(component, column, ontology_name, ancestors))
                     else:
                         raise ValueError(f"'{rule}' rule in raw definition of the schema is not implemented ")
 

--- a/cellxgene_schema_cli/scripts/ontology_processing.py
+++ b/cellxgene_schema_cli/scripts/ontology_processing.py
@@ -135,7 +135,7 @@ def _parse_owls(
         for onto_class in onto.classes():
             term_id = onto_class.name.replace("_", ":")
 
-            # Skip terms that are not direct children from this ontology
+            # Skip terms that are not direct descendants from this ontology
             if onto.name != term_id.split(":")[0]:
                 continue
 
@@ -172,10 +172,10 @@ def _parse_owls(
             # Gets ancestors
             ancestors = _get_ancestors(onto_class, onto.name)
 
-            # If "children_of" specified in owl info then skip the current term if it is
-            # not a children of those indicated.
-            if (onto.name in owl_info and "children_of" in owl_info[onto.name]) and (
-                not list(set(ancestors) & set(owl_info[onto.name]["children_of"]))
+            # If "descendants_of" specified in owl info then skip the current term if it is
+            # not a descendants of those indicated.
+            if (onto.name in owl_info and "descendants_of" in owl_info[onto.name]) and (
+                not list(set(ancestors) & set(owl_info[onto.name]["descendants_of"]))
             ):
                 onto_dict[onto.name].pop(term_id)
                 continue

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -386,7 +386,7 @@ class TestObs:
     def test_assay_ontology_term_id(self, validator_with_adata, assay_ontology_term_id, error):
         """
         assay_ontology_term_id categorical with str categories.
-        This MUST be an EFO term that is a child of either "EFO:0002772" or "EFO:0010183"
+        This MUST be an EFO term that is a descendant of either "EFO:0002772" or "EFO:0010183"
         """
         validator = validator_with_adata
         validator.adata.obs.loc[validator.adata.obs.index[0], "assay_ontology_term_id"] = assay_ontology_term_id
@@ -462,7 +462,7 @@ class TestObs:
 
     def test_development_stage_ontology_term_id_all_species(self, validator_with_adata):
         """
-        All other it MUST be children of UBERON:0000105 and not UBERON:0000071
+        All other it MUST be descendants of UBERON:0000105 and not UBERON:0000071
         """
         validator = validator_with_adata
         obs = validator.adata.obs
@@ -477,11 +477,11 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'development_stage_ontology_term_id' is "
             "not a valid ontology term id of 'UBERON'. When 'organism_ontology_term_id' is not 'NCBITaxon:10090' "
-            "nor 'NCBITaxon:9606', 'development_stage_ontology_term_id' MUST be a child term id of "
+            "nor 'NCBITaxon:9606', 'development_stage_ontology_term_id' MUST be a descendant term id of "
             "'UBERON:0000105' excluding 'UBERON:0000071', or unknown."
         ]
 
-        # All other it MUST be children of UBERON:0000105 and not UBERON:0000071
+        # All other it MUST be descendants of UBERON:0000105 and not UBERON:0000071
         # Fail case UBERON:0000071
         validator.errors = []
         obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:10114"
@@ -494,7 +494,7 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'UBERON:0000071' in 'development_stage_ontology_term_id' is not allowed. When "
             "'organism_ontology_term_id' is not 'NCBITaxon:10090' "
-            "nor 'NCBITaxon:9606', 'development_stage_ontology_term_id' MUST be a child term id of "
+            "nor 'NCBITaxon:9606', 'development_stage_ontology_term_id' MUST be a descendant term id of "
             "'UBERON:0000105' excluding 'UBERON:0000071', or unknown.",
         ]
 
@@ -502,8 +502,8 @@ class TestObs:
         """
         disease_ontology_term_id categorical with str categories. This MUST be one of:
         - PATO:0000461 for normal or healthy
-        - child of MONDO:0000001 for disease
-        - self or child of MONDO:0021178 for injury
+        - descendant of MONDO:0000001 for disease
+        - self or descendant of MONDO:0021178 for injury
         """
         validator = validator_with_adata
         obs = validator.adata.obs
@@ -513,7 +513,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'disease_ontology_term_id' is not a valid ontology term id of 'MONDO, PATO'. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid PATO term id
@@ -522,7 +522,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'PATO:0001894' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease characteristic
@@ -531,7 +531,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0021125' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease parent term
@@ -540,7 +540,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0000001' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or children terms thereof, or children terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Valid PATO term id - healthy
@@ -549,7 +549,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == []
 
-        # Valid MONDO term id - disease child term
+        # Valid MONDO term id - disease descendant term
         validator.errors = []
         obs.loc[obs.index[0], "disease_ontology_term_id"] = "MONDO:0005491"
         validator.validate_adata()
@@ -561,7 +561,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == []
 
-        # Valid MONDO term id - injury child term
+        # Valid MONDO term id - injury descendant term
         validator.errors = []
         obs.loc[obs.index[0], "disease_ontology_term_id"] = "MONDO:0015796"
         validator.validate_adata()
@@ -618,7 +618,7 @@ class TestObs:
         assert not validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'unknown' in 'tissue_ontology_term_id' is not a valid ontology term id of 'UBERON'. "
-            "When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' MUST be a child "
+            "When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' MUST be a descendant "
             "term id of 'UBERON:0001062' (anatomical entity)."
         ]
 
@@ -690,7 +690,7 @@ class TestObs:
     def test_self_reported_ethnicity_ontology_term_id__forbidden_term_ancestor(self, validator_with_adata):
         """
         Test self_reported_ethnicity_ontology_term error message when passed an ontology term that has
-        both itself and its children forbidden
+        both itself and its descendants forbidden
         """
         validator = validator_with_adata
         error_message_suffix = validator.schema_def["components"]["obs"]["columns"][
@@ -709,10 +709,10 @@ class TestObs:
             )
         ]
 
-    def test_self_reported_ethnicity_ontology_term_id__forbidden_term_child(self, validator_with_adata):
+    def test_self_reported_ethnicity_ontology_term_id__forbidden_term_descendant(self, validator_with_adata):
         """
-        Test self_reported_ethnicity_ontology_term error message when passed the child term of an ontology term that has
-        both itself and its children forbidden
+        Test self_reported_ethnicity_ontology_term error message when passed the descendant term of an ontology term that has
+        both itself and its descendants forbidden
         """
         validator = validator_with_adata
         error_message_suffix = validator.schema_def["components"]["obs"]["columns"][
@@ -727,7 +727,7 @@ class TestObs:
         assert validator.errors == [
             self.get_format_error_message(
                 error_message_suffix,
-                "ERROR: 'HANCESTRO:0306' in 'self_reported_ethnicity_ontology_term_id' is not allowed. Child terms "
+                "ERROR: 'HANCESTRO:0306' in 'self_reported_ethnicity_ontology_term_id' is not allowed. Descendant terms "
                 "of 'HANCESTRO:0304' are not allowed.",
             )
         ]
@@ -902,7 +902,7 @@ class TestObs:
 
     def test_organism_ontology_term_id(self, validator_with_adata):
         """
-        organism_ontology_term_id categorical with str categories. This MUST be a child of NCBITaxon:33208.
+        organism_ontology_term_id categorical with str categories. This MUST be a descendant of NCBITaxon:33208.
         """
         validator = validator_with_adata
         obs = validator.adata.obs
@@ -918,7 +918,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'organism_ontology_term_id' is not a valid "
-            "ontology term id of 'NCBITaxon'. Only children term ids of 'NCBITaxon:33208' for metazoan are allowed."
+            "ontology term id of 'NCBITaxon'. Only descendant term ids of 'NCBITaxon:33208' for metazoan are allowed."
         ]
 
     def test_tissue_ontology_term_id_base(self, validator_with_adata):
@@ -934,7 +934,7 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'tissue_ontology_term_id' is not a valid ontology term id of "
             "'UBERON'. When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' MUST be a "
-            "child term id of 'UBERON:0001062' (anatomical entity)."
+            "descendant term id of 'UBERON:0001062' (anatomical entity)."
         ]
 
     def test_tissue_ontology_term_id_cell_culture__suffix_in_term_id(self, validator_with_adata):
@@ -1011,12 +1011,12 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'UBERON:0000057 (organoid)' in 'tissue_ontology_term_id' is not a valid ontology term id of "
             "'UBERON'. When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' MUST be a "
-            "child term id of 'UBERON:0001062' (anatomical entity)."
+            "descendant term id of 'UBERON:0001062' (anatomical entity)."
         ]
 
-    def test_tissue_ontology_term_id_child_of_anatomical_entity__tissue(self, validator_with_adata):
+    def test_tissue_ontology_term_id_descendant_of_anatomical_entity__tissue(self, validator_with_adata):
         """
-        Tissue ontology term ID must be a CHILD TERM of 'UBERON:0001062' (anatomical entity) if tissue_type is
+        Tissue ontology term ID must be a descendant term of 'UBERON:0001062' (anatomical entity) if tissue_type is
         organoid or tissue.
         """
         validator = validator_with_adata
@@ -1027,12 +1027,12 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'UBERON:0001062' in 'tissue_ontology_term_id' is not an allowed term id. "
             "When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' "
-            "MUST be a child term id of 'UBERON:0001062' (anatomical entity)."
+            "MUST be a descendant term id of 'UBERON:0001062' (anatomical entity)."
         ]
 
-    def test_tissue_ontology_term_id_child_of_anatomical_entity__organoid(self, validator_with_adata):
+    def test_tissue_ontology_term_id_descendant_of_anatomical_entity__organoid(self, validator_with_adata):
         """
-        Tissue ontology term ID must be a CHILD TERM of 'UBERON:0001062' (anatomical entity) if tissue_type is
+        Tissue ontology term ID must be a descendant term of 'UBERON:0001062' (anatomical entity) if tissue_type is
         organoid or tissue.
         """
         validator = validator_with_adata
@@ -1044,7 +1044,7 @@ class TestObs:
         assert validator.errors == [
             "ERROR: 'UBERON:0001062' in 'tissue_ontology_term_id' is not an allowed term id. "
             "When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' "
-            "MUST be a child term id of 'UBERON:0001062' (anatomical entity)."
+            "MUST be a descendant term id of 'UBERON:0001062' (anatomical entity)."
         ]
 
     def test_tissue_type(self, validator_with_adata):
@@ -1064,7 +1064,7 @@ class TestObs:
     def test_sex_ontology_term_id(self, validator_with_adata):
         """
         sex_ontology_term_id categorical with str categories.
-        This MUST be a child of PATOPATO:0001894 for phenotypic sex or "unknown" if unavailable
+        This MUST be a descendant of PATOPATO:0001894 for phenotypic sex or "unknown" if unavailable
         """
         validator = validator_with_adata
         obs = validator.adata.obs
@@ -1192,34 +1192,34 @@ class TestObs:
         assert validator.errors == [
             f"ERROR: Column 'suspension_type' in dataframe 'obs' contains invalid values "
             f"'['{invalid_suspension_type}']'. Values must be one of {suspension_types} when "
-            f"'assay_ontology_term_id' is {assay} or its children"
+            f"'assay_ontology_term_id' is {assay} or its descendants"
         ]
 
-    def test_suspension_type_with_child_term_id_failure(self, validator_with_adata):
+    def test_suspension_type_with_descendant_term_id_failure(self, validator_with_adata):
         """
         suspension_id categorical with str categories. This field MUST be "cell", "nucleus", or "na". The allowed
         values depend on the assay_ontology_term_id. MUST support matching against ancestor term rules if specified.
         """
         validator = validator_with_adata
         obs = validator.adata.obs
-        obs.loc[obs.index[0], "assay_ontology_term_id"] = "EFO:0030008"  # child of EFO:0009294
+        obs.loc[obs.index[0], "assay_ontology_term_id"] = "EFO:0030008"  # descendant of EFO:0009294
         obs.loc[obs.index[0], "suspension_type"] = "nucleus"
 
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: Column 'suspension_type' in dataframe 'obs' contains invalid values "
             "'['nucleus']'. Values must be one of ['cell'] when "
-            "'assay_ontology_term_id' is EFO:0009294 or its children"
+            "'assay_ontology_term_id' is EFO:0009294 or its descendants"
         ]
 
-    def test_suspension_type_with_child_term_id_success(self, validator_with_adata):
+    def test_suspension_type_with_descendant_term_id_success(self, validator_with_adata):
         """
         suspension_id categorical with str categories. This field MUST be "cell", "nucleus", or "na". The allowed
         values depend on the assay_ontology_term_id. MUST support matching against ancestor term rules if specified.
         """
         validator = validator_with_adata
         obs = validator.adata.obs
-        obs.loc[obs.index[0], "assay_ontology_term_id"] = "EFO:0008904"  # child of EFO:0007045
+        obs.loc[obs.index[0], "assay_ontology_term_id"] = "EFO:0008904"  # descendant of EFO:0007045
         obs["suspension_type"][0] = "nucleus"
 
         validator.validate_adata()

--- a/schema/5.1.0/schema.md
+++ b/schema/5.1.0/schema.md
@@ -362,12 +362,12 @@ Curators MUST annotate the following columns in the `obs` dataframe:
       <th>Value</th>
         <td>categorical with <code>str</code> categories. This MUST be an EFO term and either:<br><br>
           <ul><li>
-            the most accurate child of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0002772"><code>"EFO:0002772"</code></a> for <i>assay by molecule</i>
+            the most accurate descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0002772"><code>"EFO:0002772"</code></a> for <i>assay by molecule</i>
           </li>
           <li>
-            the most accurate child of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010183"><code>"EFO:0010183"</code></a>  for <i>single cell library construction</i>
+            the most accurate descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010183"><code>"EFO:0010183"</code></a>  for <i>single cell library construction</i>
           </li></ul>
-        An assay based on 10X Genomics products SHOULD either be <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0008995"><code>"EFO:0008995"</code></a> for <i>10x technology</i> or <b>preferably</b> its most accurate child. An assay based on <i>SMART (Switching Mechanism at the 5' end of the RNA Template) or SMARTer technology</i> SHOULD either be <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010184"><code>"EFO:0010184"</code></a> for <i>Smart-like</i> or preferably its most accurate child.<br><br>
+        An assay based on 10X Genomics products SHOULD either be <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0008995"><code>"EFO:0008995"</code></a> for <i>10x technology</i> or <b>preferably</b> its most accurate descendant. An assay based on <i>SMART (Switching Mechanism at the 5' end of the RNA Template) or SMARTer technology</i> SHOULD either be <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010184"><code>"EFO:0010184"</code></a> for <i>Smart-like</i> or preferably its most accurate descendant.<br><br>
        <br>Recommended values for specific assays:
           <br><br>
           <table>
@@ -499,7 +499,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               <td>A term from the set of <a href="http://www.ontobee.org/search?ontology=MMUSDV&keywords=month-old&submit=Search+terms"> month-old stages</a><br>(e.g. <a href="https://www.ebi.ac.uk/ols4/ontologies/mmusdv/classes?obo_id=MmusDv%3A0000062">MmusDv:0000062)</a></td>
             </tr>
           </tbody></table>
-          <br> Otherwise, for all other organisms this MUST be the most accurate child of <a href="https://www.ebi.ac.uk/ols4/ontologies/uberon/classes?obo_id=UBERON%3A0000105"<code>UBERON:0000105</code></a> for <i>life cycle stage</i>, excluding <a href="https://www.ebi.ac.uk/ols4/ontologies/uberon/classes?obo_id=UBERON%3A0000071"<code>UBERON:0000071</code></a> for <i>death stage</i>.
+          <br> Otherwise, for all other organisms this MUST be the most accurate descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/uberon/classes?obo_id=UBERON%3A0000105"<code>UBERON:0000105</code></a> for <i>life cycle stage</i>, excluding <a href="https://www.ebi.ac.uk/ols4/ontologies/uberon/classes?obo_id=UBERON%3A0000071"<code>UBERON:0000071</code></a> for <i>death stage</i>.
         </td>
     </tr>
 </tbody></table>
@@ -521,8 +521,8 @@ Curators MUST annotate the following columns in the `obs` dataframe:
         <td>categorical with <code>str</code> categories. This MUST be one of:<br><br>
         <ul>
           <li><a href="https://www.ebi.ac.uk/ols4/ontologies/pato/classes?obo_id=PATO%3A0000461"><code>"PATO:0000461"</code></a> for <i>normal</i> or <i>healthy</i>.</li>
-          <li>the most accurate child of <a href="https://www.ebi.ac.uk/ols4/ontologies/mondo/classes?obo_id=MONDO%3A0000001"><code>"MONDO:0000001"</code></a> for <i>disease</i></li>
-          <li><a href="https://www.ebi.ac.uk/ols4/ontologies/mondo/classes?obo_id=MONDO%3A0021178"><code>"MONDO:0021178"</code></a> for <i>injury</i> or <b>preferably</b> its most accurate child</li>
+          <li>the most accurate descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/mondo/classes?obo_id=MONDO%3A0000001"><code>"MONDO:0000001"</code></a> for <i>disease</i></li>
+          <li><a href="https://www.ebi.ac.uk/ols4/ontologies/mondo/classes?obo_id=MONDO%3A0021178"><code>"MONDO:0021178"</code></a> for <i>injury</i> or <b>preferably</b> its most accurate descendant</li>
        </ul>
         </td>
     </tr>
@@ -603,7 +603,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td>categorical with <code>str</code> categories. This MUST be a child of <a href="https://www.ebi.ac.uk/ols4/ontologies/ncbitaxon/classes?obo_id=NCBITaxon%3A33208"<code>NCBITaxon:33208</code></a> for <i>Metazoa</i>.
+        <td>categorical with <code>str</code> categories. This MUST be a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/ncbitaxon/classes?obo_id=NCBITaxon%3A33208"<code>NCBITaxon:33208</code></a> for <i>Metazoa</i>.
         </td>
     </tr>
 </tbody></table>
@@ -635,7 +635,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               href="https://www.ebi.ac.uk/ols4/ontologies/hancestro/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FHANCESTRO_0002?lang=en"
               ><code>"HANCESTRO:0002"</code></a
             >
-            for <i>regions</i> and its children
+            for <i>regions</i> and its descendants
           </li>
           <li>
             <a
@@ -670,7 +670,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               href="https://www.ebi.ac.uk/ols4/ontologies/hancestro/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FHANCESTRO_0304?lang=en"
               ><code>"HANCESTRO:0304"</code></a
             >
-            for <i>ancestry status</i> and its children
+            for <i>ancestry status</i> and its descendants
           </li>
           <li>
             <a
@@ -769,7 +769,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               href="https://www.ebi.ac.uk/ols4/ontologies/hancestro/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FGEO_000000374?lang=en"
               ><code>"GEO:000000374"</code></a
             >
-            for <i>continent</i> and its children:
+            for <i>continent</i> and its descendants:
             <ul>
               <li>
                 <a
@@ -838,7 +838,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
     <tr>
       <th>Value</th>
-        <td>categorical with <code>str</code> categories. This MUST be a child of <a href="https://www.ebi.ac.uk/ols4/ontologies/pato/classes?obo_id=PATO%3A0001894">PATO:0001894</a> for  <i>phenotypic sex</i> or <code>"unknown"</code> if unavailable.
+        <td>categorical with <code>str</code> categories. This MUST be a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/pato/classes?obo_id=PATO%3A0001894">PATO:0001894</a> for  <i>phenotypic sex</i> or <code>"unknown"</code> if unavailable.
         </td>
     </tr>
 </tbody></table>
@@ -870,11 +870,11 @@ Curators MUST annotate the following columns in the `obs` dataframe:
           </thead>
           <tbody>
             <tr>
-              <td><i>10x transcription profiling</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0030080"><code>EFO:0030080</code></a>] and its children</td>
+              <td><i>10x transcription profiling</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0030080"><code>EFO:0030080</code></a>] and its descendants</td>
               <td><code>"cell"</code> or <code>"nucleus"</code></td>
            </tr> 
             <tr>
-              <td><i>ATAC-seq</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0007045"><code>EFO:0007045</code></a>] and its children</td>
+              <td><i>ATAC-seq</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0007045"><code>EFO:0007045</code></a>] and its descendants</td>
               <td><code>"nucleus"</code></td>
            </tr>
             <tr>
@@ -890,7 +890,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               <td><code>"cell"</code> or <code>"nucleus"</code></td>
            </tr>
             <tr>
-              <td><i>CITE-seq</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0009294"><code>EFO:0009294</code></a>] and its children</td>
+              <td><i>CITE-seq</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0009294"><code>EFO:0009294</code></a>] and its descendants</td>
               <td><code>"cell"</code></td>
            </tr>
             <tr>
@@ -930,15 +930,15 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               <td><code>"cell"</code> or <code>"nucleus"</code></td>
            </tr>
             <tr>
-              <td><i>Seq-Well</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0008919"><code>EFO:0008919</code></a>] and its children</td>
+              <td><i>Seq-Well</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0008919"><code>EFO:0008919</code></a>] and its descendants</td>
               <td><code>"cell"</code></td>
            </tr>
             <tr>
-              <td><i>Smart-like</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010184"><code>EFO:0010184</code></a>] and its children</td>
+              <td><i>Smart-like</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010184"><code>EFO:0010184</code></a>] and its descendants</td>
               <td><code>"cell"</code> or <code>"nucleus"</code></td>
            </tr>
             <tr>
-              <td><i>smFISH</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0009918"><code>EFO:0009918</code></a>] and its children</td>
+              <td><i>smFISH</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0009918"><code>EFO:0009918</code></a>] and its descendants</td>
               <td><code>"na"</code></td>
            </tr>   
             <tr>
@@ -950,11 +950,11 @@ Curators MUST annotate the following columns in the `obs` dataframe:
               <td><code>"nucleus"</code></td>
            </tr>
             <tr>
-              <td><i>spatial proteomics</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0700000"><code>EFO:0700000</code></a>] and its children</td>
+              <td><i>spatial proteomics</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0700000"><code>EFO:0700000</code></a>] and its descendants</td>
               <td><code>"na"</code></td>
            </tr>
             <tr>
-              <td><i>spatial transcriptomics</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0008994"><code>EFO:0008994</code></a>] and its children</td>
+              <td><i>spatial transcriptomics</i> [<a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0008994"><code>EFO:0008994</code></a>] and its descendants</td>
               <td><code>"na"</code></td>
            </tr> 
             <tr>
@@ -1007,7 +1007,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
     </tr>
    <tr>
       <th>Value</th>
-        <td>categorical with <code>str</code> categories. If <code>tissue_type</code> is <code>"tissue"</code> or <code>"organoid"</code>, this MUST be the most accurate child of <a href="https://www.ebi.ac.uk/ols4/ontologies/uberon/classes?obo_id=UBERON%3A0001062"><code>UBERON:0001062</code></a> for <i>anatomical entity</i>.<br><br> If <code>tissue_type</code> is <code>"cell culture"</code> this MUST follow the requirements for <code>cell_type_ontology_term_id<code>.</td>
+        <td>categorical with <code>str</code> categories. If <code>tissue_type</code> is <code>"tissue"</code> or <code>"organoid"</code>, this MUST be the most accurate descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/uberon/classes?obo_id=UBERON%3A0001062"><code>UBERON:0001062</code></a> for <i>anatomical entity</i>.<br><br> If <code>tissue_type</code> is <code>"cell culture"</code> this MUST follow the requirements for <code>cell_type_ontology_term_id<code>.</td>
      </tr>
 </tbody></table>
 <br>
@@ -1886,10 +1886,10 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
   * Updated GENCODE (Human) to Human Reference GRCh38.p14 (GENCODE v44/Ensembl 110)
   * Updated GENCODE (Mouse) to Mouse reference GRCm39 (GENCODE vM33/Ensembl 110)
 * obs (Cell metadata)
-  * Updated the requirements for `assay_ontology_term_id` to not allow  the parent terms `EFO:0002772` for _assay by molecule_ and `EFO:0010183` for _single cell library construction_. Their most accurate children are still valid. 
+  * Updated the requirements for `assay_ontology_term_id` to not allow  the parent terms `EFO:0002772` for _assay by molecule_ and `EFO:0010183` for _single cell library construction_. Their most accurate descendants are still valid. 
   * **Breaking change**. Updated the requirements for `cell_type` to annotate `"unknown"` as the label when the `cell_type_ontology_term_id` value is  `"unknown"`. 
   * **Breaking change**. Updated the requirements for `cell_type_ontology_term_id` to replace `"CL:0000003"` for *native cell* with `"unknown"` to indicate that the cell type is unknown. 
-  * Updated the requirements for `disease_ontology_term_id` to restrict MONDO terms to the most accurate child of `"MONDO:0000001"` for _disease_ or `"MONDO:0021178"` for _injury_ or preferably its most accurate child.
+  * Updated the requirements for `disease_ontology_term_id` to restrict MONDO terms to the most accurate descendant of `"MONDO:0000001"` for _disease_ or `"MONDO:0021178"` for _injury_ or preferably its most accurate descendant.
 * obsm (Embeddings)
   * Updated requirements for `X_{suffix}` to change the regular expression pattern from `"^[a-zA-Z][a-zA-Z0-9]*$"` to `"^[a-zA-Z][a-zA-Z0-9_.-]*$"`
 * uns (Dataset metadata)
@@ -1956,8 +1956,8 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
     * Added TruDrop
     * Added GEXSCOPE technology
     * Added SPLiT-seq
-    * Changed spatial transcriptomics by high-throughput sequencing [EFO:0030005] and its children to spatial transcriptomics [EFO:0008994] and its children
-    * Updated Seq-Well [EFO:0008919] to Seq-Well [EFO:0008919] and its children
+    * Changed spatial transcriptomics by high-throughput sequencing [EFO:0030005] and its descendants to spatial transcriptomics [EFO:0008994] and its descendants
+    * Updated Seq-Well [EFO:0008919] to Seq-Well [EFO:0008919] and its descendants
 * uns (Dataset metadata)
   * `schema_version`
     * Must be annotated by CELLxGENE Discover and not the Curator.

--- a/schema/5.1.0/schema.md
+++ b/schema/5.1.0/schema.md
@@ -1853,6 +1853,7 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
 
 ### schema v5.1.0
 
+* All references to "child" and "children" have been changed to "descendant" and "descendants" for accuracy.
 * Required Ontologies
   * PENDING
 * X (Matrix Layers)
@@ -1871,7 +1872,6 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
   * Updated schema_reference to <code>"https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.1.0/schema.md"</code>
   * Updated schema_version to <code>"5.1.0"</code>
   * Added `spatial` for _Visium Spatial Gene Expression_ and _Slide-seqV2_, including scale factors and underlay images for _Visium Spatial Gene Expression_.
-
 
 ### schema v5.0.0
 

--- a/schema/5.1.0/schema.md
+++ b/schema/5.1.0/schema.md
@@ -1886,10 +1886,10 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
   * Updated GENCODE (Human) to Human Reference GRCh38.p14 (GENCODE v44/Ensembl 110)
   * Updated GENCODE (Mouse) to Mouse reference GRCm39 (GENCODE vM33/Ensembl 110)
 * obs (Cell metadata)
-  * Updated the requirements for `assay_ontology_term_id` to not allow  the parent terms `EFO:0002772` for _assay by molecule_ and `EFO:0010183` for _single cell library construction_. Their most accurate descendants are still valid. 
+  * Updated the requirements for `assay_ontology_term_id` to not allow the parent terms `EFO:0002772` for _assay by molecule_ and `EFO:0010183` for _single cell library construction_. Their most accurate children are still valid. 
   * **Breaking change**. Updated the requirements for `cell_type` to annotate `"unknown"` as the label when the `cell_type_ontology_term_id` value is  `"unknown"`. 
   * **Breaking change**. Updated the requirements for `cell_type_ontology_term_id` to replace `"CL:0000003"` for *native cell* with `"unknown"` to indicate that the cell type is unknown. 
-  * Updated the requirements for `disease_ontology_term_id` to restrict MONDO terms to the most accurate descendant of `"MONDO:0000001"` for _disease_ or `"MONDO:0021178"` for _injury_ or preferably its most accurate descendant.
+  * Updated the requirements for `disease_ontology_term_id` to restrict MONDO terms to the most accurate child of `"MONDO:0000001"` for _disease_ or `"MONDO:0021178"` for _injury_ or preferably its most accurate child.
 * obsm (Embeddings)
   * Updated requirements for `X_{suffix}` to change the regular expression pattern from `"^[a-zA-Z][a-zA-Z0-9]*$"` to `"^[a-zA-Z][a-zA-Z0-9_.-]*$"`
 * uns (Dataset metadata)
@@ -1956,8 +1956,8 @@ When a dataset is uploaded, CELLxGENE Discover MUST automatically add the `schem
     * Added TruDrop
     * Added GEXSCOPE technology
     * Added SPLiT-seq
-    * Changed spatial transcriptomics by high-throughput sequencing [EFO:0030005] and its descendants to spatial transcriptomics [EFO:0008994] and its descendants
-    * Updated Seq-Well [EFO:0008919] to Seq-Well [EFO:0008919] and its descendants
+    * Changed spatial transcriptomics by high-throughput sequencing [EFO:0030005] and its children to spatial transcriptomics [EFO:0008994] and its children
+    * Updated Seq-Well [EFO:0008919] to Seq-Well [EFO:0008919] and its children
 * uns (Dataset metadata)
   * `schema_version`
     * Must be annotated by CELLxGENE Discover and not the Curator.


### PR DESCRIPTION
## Reason for Change

- #742

## Changes

In 1) code, and 2) error messages:
- Replace `child` with `descendant` where appropriate
- Replace `children` with `descendants` where appropriate

I do not see any cases of function name changes that would be used via import in other repos (the one function whose name has been changed is prefaced with an underscore)

## Testing

- Unit tests updated accordingly
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer