### PR TITLE
fix: pin python in schema migration workflow

### DIFF
--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
+          check-latest: true
       - name: Build dist
         run: |
           pip install wheel


### PR DESCRIPTION
## Reason for Change

- [single-cell-data-portal #6886](https://github.com/chanzuckerberg/single-cell-data-portal/issues/6886)

## Changes

- pin trigger-schema-migration workflow python version to 3.11

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer