### PR TITLE
chore: address race condition with pypi publish in schema migration

### DIFF
--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -18,41 +18,40 @@ jobs:
       - name: Build dist
         id: build
         run: |
-#          pip install wheel
-#          make pydist
+          pip install wheel
+          make pydist
           cd cellxgene_schema_cli
           echo "version=`python setup.py --version`" >> $GITHUB_OUTPUT
-          echo -e "\n djh version is `python setup.py --version`\n"
           cd ..
-#      - name: Publish distribution to Test PyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#          repository-url: https://test.pypi.org/legacy/
-#          packages-dir: cellxgene_schema_cli/dist/
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: cellxgene_schema_cli/dist/
       - name: Confirm publish to Test PyPI
         run: |
           while [ -z "$has_version" ]; do \
-          echo -e "\n\ndjh\n\n"; sleep 2; has_version=`pip index versions --index-url https://test.pypi.org/simple/ cellxgene-schema | grep \
+          sleep 2; has_version=`pip index versions --index-url https://test.pypi.org/simple/ cellxgene-schema | grep \
           Available.*${{ steps.build.outputs.version }}`; done
-#      - name: Install and Test Package from Test PyPI
-#        run: |
-#          pip install -r cellxgene_schema_cli/requirements.txt
-#          pip install --index-url https://test.pypi.org/simple/ cellxgene-schema
-#          cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad
-#      - name: Publish distribution to PyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          password: ${{ secrets.PYPI_API_TOKEN }}
-#          packages-dir: cellxgene_schema_cli/dist/
-#      - name: Confirm publish to PyPI
-#        run: |
-#          while [ -z "$has_version" ]; do \
-#          sleep 2; has_version=`pip index versions cellxgene-schema | grep \
-#          Available.*${{ steps.build.outputs.version }}`; done
-#      - name: Trigger rebuild of Data Portal Processing Image and Schema Migration
-#        run: |
-#          curl -X POST https://api.github.com/repos/chanzuckerberg/single-cell-data-portal/dispatches \
-#          -H 'Accept: application/vnd.github.everest-preview+json' \
-#          --header 'authorization: Bearer ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}' \
-#          --data '{"event_type": "schema-migration"}'
+      - name: Install and Test Package from Test PyPI
+        run: |
+          pip install -r cellxgene_schema_cli/requirements.txt
+          pip install --index-url https://test.pypi.org/simple/ cellxgene-schema
+          cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: cellxgene_schema_cli/dist/
+      - name: Confirm publish to PyPI
+        run: |
+          while [ -z "$has_version" ]; do \
+          sleep 2; has_version=`pip index versions cellxgene-schema | grep \
+          Available.*${{ steps.build.outputs.version }}`; done
+      - name: Trigger rebuild of Data Portal Processing Image and Schema Migration
+        run: |
+          curl -X POST https://api.github.com/repos/chanzuckerberg/single-cell-data-portal/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          --header 'authorization: Bearer ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}' \
+          --data '{"event_type": "schema-migration"}'

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -16,28 +16,43 @@ jobs:
           python-version: "3.11"
           check-latest: true
       - name: Build dist
+        id: build
         run: |
-          pip install wheel
-          make pydist
-      - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: cellxgene_schema_cli/dist/
-      - name: Install and Test Package from Test PyPI
+#          pip install wheel
+#          make pydist
+          cd cellxgene_schema_cli
+          echo "version=`python setup.py --version`" >> $GITHUB_OUTPUT
+          echo -e "\n djh version is `python setup.py --version`\n"
+          cd ..
+#      - name: Publish distribution to Test PyPI
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+#          repository-url: https://test.pypi.org/legacy/
+#          packages-dir: cellxgene_schema_cli/dist/
+      - name: Confirm publish to Test PyPI
         run: |
-          pip install -r cellxgene_schema_cli/requirements.txt
-          pip install --index-url https://test.pypi.org/simple/ cellxgene-schema
-          cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: cellxgene_schema_cli/dist/
-      - name: Trigger rebuild of Data Portal Processing Image and Schema Migration
-        run: |
-          curl -X POST https://api.github.com/repos/chanzuckerberg/single-cell-data-portal/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          --header 'authorization: Bearer ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}' \
-          --data '{"event_type": "schema-migration"}'
+          while [ -z "$has_version" ]; do \
+          echo -e "\n\ndjh\n\n"; sleep 2; has_version=`pip index versions --index-url https://test.pypi.org/simple/ cellxgene-schema | grep \
+          Available.*${{ steps.build.outputs.version }}`; done
+#      - name: Install and Test Package from Test PyPI
+#        run: |
+#          pip install -r cellxgene_schema_cli/requirements.txt
+#          pip install --index-url https://test.pypi.org/simple/ cellxgene-schema
+#          cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad
+#      - name: Publish distribution to PyPI
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          password: ${{ secrets.PYPI_API_TOKEN }}
+#          packages-dir: cellxgene_schema_cli/dist/
+#      - name: Confirm publish to PyPI
+#        run: |
+#          while [ -z "$has_version" ]; do \
+#          sleep 2; has_version=`pip index versions cellxgene-schema | grep \
+#          Available.*${{ steps.build.outputs.version }}`; done
+#      - name: Trigger rebuild of Data Portal Processing Image and Schema Migration
+#        run: |
+#          curl -X POST https://api.github.com/repos/chanzuckerberg/single-cell-data-portal/dispatches \
+#          -H 'Accept: application/vnd.github.everest-preview+json' \
+#          --header 'authorization: Bearer ${{ secrets.CZIBUILDBOT_GITHUB_TOKEN }}' \
+#          --data '{"event_type": "schema-migration"}'

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Build dist
         id: build
         run: |
+#          pip install wheel
+#          make pydist
           cd cellxgene_schema_cli
           echo "version=`python setup.py --version`" >> $GITHUB_OUTPUT
           echo -e "\n djh version is `python setup.py --version`\n"

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -18,8 +18,6 @@ jobs:
       - name: Build dist
         id: build
         run: |
-#          pip install wheel
-#          make pydist
           cd cellxgene_schema_cli
           echo "version=`python setup.py --version`" >> $GITHUB_OUTPUT
           echo -e "\n djh version is `python setup.py --version`\n"

--- a/.github/workflows/trigger-schema-migration.yml
+++ b/.github/workflows/trigger-schema-migration.yml
@@ -30,10 +30,12 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: cellxgene_schema_cli/dist/
       - name: Confirm publish to Test PyPI
-        run: |
-          while [ -z "$has_version" ]; do \
-          sleep 2; has_version=`pip index versions --index-url https://test.pypi.org/simple/ cellxgene-schema | grep \
-          Available.*${{ steps.build.outputs.version }}`; done
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 15
+          timeout_seconds: 30
+          polling_interval_seconds: 5
+          command: pip index versions --index-url https://test.pypi.org/simple/ cellxgene-schema | grep Available.*${{ steps.build.outputs.version }}
       - name: Install and Test Package from Test PyPI
         run: |
           pip install -r cellxgene_schema_cli/requirements.txt
@@ -44,11 +46,13 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: cellxgene_schema_cli/dist/
-      - name: Confirm publish to PyPI
-        run: |
-          while [ -z "$has_version" ]; do \
-          sleep 2; has_version=`pip index versions cellxgene-schema | grep \
-          Available.*${{ steps.build.outputs.version }}`; done
+      - name: Confirm publish to Test PyPI
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 15
+          timeout_seconds: 30
+          polling_interval_seconds: 5
+          command: pip index versions cellxgene-schema | grep Available.*${{ steps.build.outputs.version }}
       - name: Trigger rebuild of Data Portal Processing Image and Schema Migration
         run: |
           curl -X POST https://api.github.com/repos/chanzuckerberg/single-cell-data-portal/dispatches \


### PR DESCRIPTION
## Reason for Change

- [single-cell 547](https://github.com/chanzuckerberg/single-cell/issues/547)

## Changes

- extract package version from setup
- for both Test PyPI and PyPI, add loops that wait until the just-published version is available

## Testing

- [Tested on a modified workflow run](https://github.com/chanzuckerberg/single-cell-curation/actions/runs/8623232599) which printed the version and successfully passed through the `while` loop checking for the version via `pip index versions` call
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer