### PR TITLE
feat(schema 5.1.0): validate uns[spatial]

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1336,7 +1336,7 @@ class Validator:
         is_supported_spatial_assay = self._is_supported_spatial_assay()
         if uns_spatial_specified and not is_supported_spatial_assay:
             self.errors.append(
-                "uns['spatial'] is only allowed for adata.obs['assay_ontology_term_id'] values "
+                "uns['spatial'] is only allowed for obs['assay_ontology_term_id'] values "
                 "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)."
             )
             return
@@ -1348,7 +1348,7 @@ class Validator:
         # spatial is required for supported spatial assays.
         if not uns_spatial_specified:
             self.errors.append(
-                "uns['spatial'] is required for adata.obs['assay_ontology_term_id'] values "
+                "uns['spatial'] is required for obs['assay_ontology_term_id'] values "
                 "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)."
             )
             return
@@ -1380,7 +1380,7 @@ class Validator:
         is_visium_and_uns_is_single = is_visium and uns_is_single
         if len(library_ids) > 0 and not is_visium_and_uns_is_single:
             self.errors.append(
-                "uns['spatial'][library_id] is only allowed for adata.obs['assay_ontology_term_id'] "
+                "uns['spatial'][library_id] is only allowed for obs['assay_ontology_term_id'] "
                 "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             )
             # Exit as library_id is not allowed.
@@ -1393,7 +1393,7 @@ class Validator:
         # library_id is required if assay is Visium and is_single is True.
         if len(library_ids) == 0:
             self.errors.append(
-                "uns['spatial'] must contain the key 'library_id' for adata.obs['assay_ontology_term_id'] "
+                "uns['spatial'] must contain the key 'library_id' for obs['assay_ontology_term_id'] "
                 "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             )
             # Exit as library_id is missing.
@@ -1507,9 +1507,7 @@ class Validator:
         :rtype bool
         """
         assay_ontology_term_id = self.adata.obs.get("assay_ontology_term_id")
-        return (
-            assay_ontology_term_id is not None and (assay_ontology_term_id == ASSAY_VISIUM).any()
-        )
+        return assay_ontology_term_id is not None and (assay_ontology_term_id == ASSAY_VISIUM).any()
 
     def _validate_float(self, name: str, value: float):
         """

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1362,7 +1362,7 @@ class Validator:
 
         # is_single must be a boolean.
         uns_is_single = uns_spatial["is_single"]
-        if not isinstance(uns_is_single, (np.bool_, np.bool)):
+        if not isinstance(uns_is_single, (np.bool_, np.bool, bool)):
             self.errors.append(f"uns['spatial']['is_single'] must be of boolean type, it is {type(uns_is_single)}.")
             # Exit if is_single is not valid as all further checks are dependent on its value.
             return
@@ -1433,7 +1433,13 @@ class Validator:
 
             # fullres is optional.
             uns_fullres = uns_images.get("fullres")
-            if uns_fullres is not None:
+            if uns_fullres is None:
+                # Warn if no fullres is specified as it is strongly recommended.
+                self.warnings.append(
+                    "No uns['spatial'][library_id]['images']['fullres'] was found. "
+                    "It is STRONGLY RECOMMENDED that uns['spatial'][library_id]['images']['fullres'] is provided."
+                )
+            else:
                 self._validate_spatial_image_shape("fullres", uns_fullres)
 
         # scalefactors is required.

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1508,7 +1508,7 @@ class Validator:
         """
         assay_ontology_term_id = self.adata.obs.get("assay_ontology_term_id")
         return (
-            assay_ontology_term_id is not None and (self.adata.obs.get("assay_ontology_term_id") == ASSAY_VISIUM).any()
+            assay_ontology_term_id is not None and (assay_ontology_term_id == ASSAY_VISIUM).any()
         )
 
     def _validate_float(self, name: str, value: float):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -29,9 +29,6 @@ ASSAY_SLIDE_SEQV2 = "EFO:0030062"
 class Validator:
     """Handles validation of AnnData"""
 
-    ASSAY_VISIUM = "EFO:0010961"
-    ASSAY_SLIDE_SEQV2 = "EFO:0030062"
-
     def __init__(self, ignore_labels=False):
         self.schema_def = dict()
         self.schema_version: str = None
@@ -1479,7 +1476,7 @@ class Validator:
         :return True if assay_ontology_term_id is Visium or Slide-seqV2, False otherwise.
         :rtype bool
         """
-        return self.adata.obs.get("assay_ontology_term_id").isin([self.ASSAY_VISIUM, self.ASSAY_SLIDE_SEQV2]).any()
+        return self.adata.obs.get("assay_ontology_term_id").isin([ASSAY_VISIUM, ASSAY_SLIDE_SEQV2]).any()
 
     def _is_valid_visium_image_shape(self, image: np.ndarray) -> bool:
         """
@@ -1502,8 +1499,7 @@ class Validator:
         """
         assay_ontology_term_id = self.adata.obs.get("assay_ontology_term_id")
         return (
-            assay_ontology_term_id is not None
-            and (self.adata.obs.get("assay_ontology_term_id") == self.ASSAY_VISIUM).any()
+            assay_ontology_term_id is not None and (self.adata.obs.get("assay_ontology_term_id") == ASSAY_VISIUM).any()
         )
 
     def _validate_spatial_scalefactor(self, scalefactor_name: str, scalefactor: float):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1362,7 +1362,7 @@ class Validator:
 
         # is_single must be a boolean.
         uns_is_single = uns_spatial["is_single"]
-        if not isinstance(uns_is_single, (np.bool_, np.bool, bool)):
+        if not isinstance(uns_is_single, (np.bool_, np.bool)):
             self.errors.append(f"uns['spatial']['is_single'] must be of boolean type, it is {type(uns_is_single)}.")
             # Exit if is_single is not valid as all further checks are dependent on its value.
             return

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1535,7 +1535,7 @@ class Validator:
 
         :param str image_name: the name of the image, either "hires" or "fullres".
         :param np.ndarray image: the image to validate.
-        :param int max_dimension: the maximum dimension of the image, optional.
+        :param int max_dimension: the largest allowed dimension of the image, optional.
 
         :rtype None
         """
@@ -1555,10 +1555,10 @@ class Validator:
             )
 
         # Confirm max dimension of image, if specified, is valid.
-        if max_dimension is not None and max(image.shape) > max_dimension:
+        if max_dimension is not None and max(image.shape) != max_dimension:
             self.errors.append(
-                f"uns['spatial'][library_id]['images']['{image_name}'] has a max dimension of {max_dimension} pixels, "
-                f"it has max dimension {max(image.shape)} pixels."
+                f"The largest dimension of uns['spatial'][library_id]['images']['{image_name}'] must be "
+                f"{max_dimension} pixels, it has a largest dimension of {max(image.shape)} pixels."
             )
 
     def _deep_check(self):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1496,15 +1496,6 @@ class Validator:
         """
         return set(dictionary.keys()).issubset(allowed_keys)
 
-    def _is_supported_spatial_assay(self):
-        """
-        Determine if the assay_ontology_term_id is either Visium (EFO:0010961) or Slide-seqV2 (EFO:0030062).
-
-        :return True if assay_ontology_term_id is Visium or Slide-seqV2, False otherwise.
-        :rtype bool
-        """
-        return self.adata.obs.get("assay_ontology_term_id").isin([ASSAY_VISIUM, ASSAY_SLIDE_SEQV2]).any()
-
     def _is_valid_visium_image_shape(self, image: np.ndarray) -> bool:
         """
         Determine if the image has shape (,,3); image is expected to be a 3D numpy array

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -323,7 +323,7 @@ good_uns_with_slide_seqV2_spatial = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
-    "spatial": {"is_single": numpy.bool_(True)},
+    "spatial": {"is_single": True},
 }
 
 # ---

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -307,7 +307,7 @@ good_uns_with_visium_spatial = {
         "is_single": numpy.bool_(True),
         visium_library_id: {
             "images": {
-                "hires": numpy.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]),
+                "hires": numpy.zeros((2000, 100, 3)),
                 "fullres": numpy.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]),
             },
             "scalefactors": {

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -125,6 +125,112 @@ obs_expected = pd.DataFrame(
 
 obs_expected["observation_joinid"] = get_hash_digest_column(obs_expected)
 
+# Valid spatial obs per schema
+good_obs_visium = pd.DataFrame(
+    [
+        [
+            "CL:0000066",
+            "EFO:0010961",
+            "MONDO:0100096",
+            "NCBITaxon:9606",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            True,
+            "HANCESTRO:0575",
+            "HsapDv:0000003",
+            "donor_1",
+            "nucleus",
+        ],
+        [
+            "CL:0000192",
+            "EFO:0010961",
+            "PATO:0000461",
+            "NCBITaxon:10090",
+            "unknown",
+            "CL:0000192",
+            "cell culture",
+            False,
+            "na",
+            "MmusDv:0000003",
+            "donor_2",
+            "na",
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "organism_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "tissue_type",
+        "is_primary_data",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+        "donor_id",
+        "suspension_type",
+    ],
+)
+
+good_obs_visium.loc[:, ["donor_id"]] = good_obs_visium.astype("category")
+good_obs_visium.loc[:, ["suspension_type"]] = good_obs_visium.astype("category")
+good_obs_visium.loc[:, ["tissue_type"]] = good_obs_visium.astype("category")
+
+# Valid spatial obs per schema
+good_obs_slide_seqv2 = pd.DataFrame(
+    [
+        [
+            "CL:0000066",
+            "EFO:0030062",
+            "MONDO:0100096",
+            "NCBITaxon:9606",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            True,
+            "HANCESTRO:0575",
+            "HsapDv:0000003",
+            "donor_1",
+            "nucleus",
+        ],
+        [
+            "CL:0000192",
+            "EFO:0030062",
+            "PATO:0000461",
+            "NCBITaxon:10090",
+            "unknown",
+            "CL:0000192",
+            "cell culture",
+            False,
+            "na",
+            "MmusDv:0000003",
+            "donor_2",
+            "na",
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "organism_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "tissue_type",
+        "is_primary_data",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+        "donor_id",
+        "suspension_type",
+    ],
+)
+
+good_obs_slide_seqv2.loc[:, ["donor_id"]] = good_obs_slide_seqv2.astype("category")
+good_obs_slide_seqv2.loc[:, ["suspension_type"]] = good_obs_slide_seqv2.astype("category")
+good_obs_slide_seqv2.loc[:, ["tissue_type"]] = good_obs.astype("category")
+
 # ---
 # 2. Creating individual var components: valid object and valid object and with labels
 
@@ -190,6 +296,36 @@ good_uns_with_colors = {
     "tissue_type_colors": numpy.array(["black", "pink"]),
 }
 
+visium_library_id = "Proj2023_Lung_C001"
+
+good_uns_with_visium_spatial = {
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+    "spatial": {
+        "is_single": numpy.bool_(True),
+        visium_library_id: {
+            "images": {
+                "hires": numpy.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]),
+                "fullres": numpy.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]),
+            },
+            "scalefactors": {
+                "spot_diameter_fullres": 1.0,
+                "tissue_hires_scalef": 1.0,
+            },
+        },
+    },
+}
+
+good_uns_with_slide_seqV2_spatial = {
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+    "spatial": {"is_single": numpy.bool_(True)},
+}
+
 # ---
 # 4. Creating expression matrix,
 # X has integer values and non_raw_X has real values
@@ -247,6 +383,20 @@ adata_with_labels = anndata.AnnData(
 # Expected anndata with colors for categorical obs fields
 adata_with_colors = anndata.AnnData(
     X=sparse.csr_matrix(X), obs=good_obs, uns=good_uns_with_colors, obsm=good_obsm, var=good_var
+)
+
+# Expected anndata with Visium spatial data
+adata_visium = anndata.AnnData(
+    X=sparse.csr_matrix(X), obs=good_obs_visium, uns=good_uns_with_visium_spatial, obsm=good_obsm, var=good_var
+)
+
+# Expected anndata with Slide-seqV2 spatial data
+adata_slide_seqv2 = anndata.AnnData(
+    X=sparse.csr_matrix(X),
+    obs=good_obs_slide_seqv2,
+    uns=good_uns_with_slide_seqV2_spatial,
+    obsm=good_obsm,
+    var=good_var,
 )
 
 # anndata for testing migration

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1976,11 +1976,20 @@ class TestObsm:
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
 
-    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0010961", "EFO:0030062"])
-    def test_obsm_values_no_X_embedding__spatial_dataset(self, validator_with_adata, assay_ontology_term_id):
+    @pytest.mark.parametrize(
+        "assay_ontology_term_id, uns_spatial",
+        [
+            ("EFO:0010961", examples.good_uns_with_visium_spatial["spatial"]),
+            ("EFO:0030062", examples.good_uns_with_slide_seqV2_spatial["spatial"]),
+        ],
+    )
+    def test_obsm_values_no_X_embedding__spatial_dataset(
+        self, validator_with_adata, assay_ontology_term_id, uns_spatial
+    ):
         validator = validator_with_adata
         validator.adata.obsm["harmony"] = validator.adata.obsm["X_umap"]
         validator.adata.uns["default_embedding"] = "harmony"
+        validator.adata.uns["spatial"] = uns_spatial
         del validator.adata.obsm["X_umap"]
         validator.adata.obs["assay_ontology_term_id"] = assay_ontology_term_id
         validator.adata.obs["suspension_type"] = "na"

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -464,7 +464,7 @@ class TestValidate:
         validator._check_spatial()
         assert validator.errors
         assert (
-            "uns['spatial'] must contain at least one key representing the library_id for obs['assay_ontology_term_id'] "
+            "uns['spatial'] must contain at least one key representing the library_id when obs['assay_ontology_term_id'] "
             "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             in validator.errors[0]
         )

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -336,7 +336,7 @@ class TestValidate:
         validator._check_spatial()
         assert len(validator.errors) == 1
         assert (
-            "uns['spatial'] is only allowed for adata.obs['assay_ontology_term_id'] values "
+            "uns['spatial'] is only allowed for obs['assay_ontology_term_id'] values "
             "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)." in validator.errors[0]
         )
 
@@ -350,7 +350,7 @@ class TestValidate:
         validator._check_spatial()
         assert len(validator.errors) == 1
         assert (
-            "uns['spatial'] is required for adata.obs['assay_ontology_term_id'] values "
+            "uns['spatial'] is required for obs['assay_ontology_term_id'] values "
             "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)." in validator.errors[0]
         )
 
@@ -364,7 +364,7 @@ class TestValidate:
         validator._check_spatial()
         assert len(validator.errors) == 1
         assert (
-            "uns['spatial'] is required for adata.obs['assay_ontology_term_id'] values "
+            "uns['spatial'] is required for obs['assay_ontology_term_id'] values "
             "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)." in validator.errors[0]
         )
 
@@ -429,7 +429,7 @@ class TestValidate:
         validator._check_spatial()
         assert len(validator.errors) == 1
         assert (
-            "uns['spatial'][library_id] is only allowed for adata.obs['assay_ontology_term_id'] "
+            "uns['spatial'][library_id] is only allowed for obs['assay_ontology_term_id'] "
             "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             in validator.errors[0]
         )
@@ -446,7 +446,7 @@ class TestValidate:
         validator._check_spatial()
         assert len(validator.errors) == 1
         assert (
-            "uns['spatial'][library_id] is only allowed for adata.obs['assay_ontology_term_id'] "
+            "uns['spatial'][library_id] is only allowed for obs['assay_ontology_term_id'] "
             "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             in validator.errors[0]
         )
@@ -461,7 +461,7 @@ class TestValidate:
         validator._check_spatial()
         assert validator.errors
         assert (
-            "uns['spatial'] must contain the key 'library_id' for adata.obs['assay_ontology_term_id'] "
+            "uns['spatial'] must contain the key 'library_id' for obs['assay_ontology_term_id'] "
             "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             in validator.errors[0]
         )

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -12,18 +12,20 @@ from cellxgene_ontology_guide.entities import Ontology
 from cellxgene_schema.schema import get_schema_definition
 from cellxgene_schema.validate import Validator, validate
 from cellxgene_schema.write_labels import AnnDataLabelAppender
-from fixtures.examples_validate import (
-    adata as adata_valid,
-)
+from fixtures.examples_validate import adata as adata_valid
 from fixtures.examples_validate import (
     adata_minimal,
+    adata_slide_seqv2,
+    adata_visium,
     adata_with_labels,
     good_obs,
     good_obsm,
     good_uns,
+    good_uns_with_visium_spatial,
     good_var,
     h5ad_invalid,
     h5ad_valid,
+    visium_library_id,
 )
 from numpy import ndarray
 from scipy import sparse
@@ -304,6 +306,361 @@ class TestValidate:
         assert errors
         assert is_seurat_convertible
 
+    def test__validate_spatial_visium_ok(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+
+        # Confirm spatial is valid.
+        validator._check_spatial()
+        assert not validator.errors
+
+    def test__validate_spatial_slide_seqV2_ok(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_slide_seqv2.copy()
+
+        # Confirm spatial is valid.
+        validator._check_spatial()
+        assert not validator.errors
+
+    def test__validate_spatial_forbidden_if_10x(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+
+        # Create Visium uns (with spatial) with 10x 3' v2 obs.
+        validator.adata = adata_visium.copy()
+        validator.adata.obs = good_obs.copy()
+
+        # Confirm spatial is not allowed for 10x 3' v2.
+        validator._check_spatial()
+        assert len(validator.errors) == 1
+        assert (
+            "uns['spatial'] is only allowed for adata.obs['assay_ontology_term_id'] values "
+            "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)." in validator.errors[0]
+        )
+
+    def test__validate_spatial_required_if_visium(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns = good_uns.copy()
+
+        # Confirm spatial is required for Visium.
+        validator._check_spatial()
+        assert len(validator.errors) == 1
+        assert (
+            "uns['spatial'] is required for adata.obs['assay_ontology_term_id'] values "
+            "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)." in validator.errors[0]
+        )
+
+    def test__validate_spatial_required_if_slide_seqV2(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_slide_seqv2.copy()
+        validator.adata.uns = good_uns.copy()
+
+        # Confirm spatial is required for Slide-seqV2.
+        validator._check_spatial()
+        assert len(validator.errors) == 1
+        assert (
+            "uns['spatial'] is required for adata.obs['assay_ontology_term_id'] values "
+            "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)." in validator.errors[0]
+        )
+
+    def test__validate_spatial_allowed_keys_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"]["invalid_key"] = True
+
+        # Confirm additional key is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'] must contain only one library_id." in validator.errors[0]
+
+    def test__validate_is_single_required_visium_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"].pop("is_single")
+
+        # Confirm is_single is identified as required.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'] must contain the key 'is_single'." in validator.errors[0]
+
+    def test__validate_is_single_required_slide_seqV2_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+
+        # Remove is_single key to trigger error, but add dummy library_id to pass earlier truthy check
+        # on spatial existing.
+        validator.adata = adata_slide_seqv2.copy()
+        validator.adata.uns["spatial"] = {
+            "library_id": "test_library_id",
+        }
+
+        # Confirm is_single is identified as required.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'] must contain the key 'is_single'." in validator.errors[0]
+
+    def test__validate_is_single_boolean_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"]["is_single"] = "invalid"
+
+        # Confirm is_single is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial']['is_single'] must be of boolean type" in validator.errors[0]
+
+    def test__validate_library_id_forbidden_if_slide_seqV2(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+
+        # Add library_id to Slide-seqV2 uns to trigger error.
+        validator.adata = adata_slide_seqv2.copy()
+        validator.adata.uns = good_uns_with_visium_spatial
+
+        # Confirm library_id is not allowed for Slide-seqV2.
+        validator._check_spatial()
+        assert len(validator.errors) == 1
+        assert (
+            "uns['spatial'][library_id] is only allowed for adata.obs['assay_ontology_term_id'] "
+            "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
+            in validator.errors[0]
+        )
+
+    def test__validate_library_id_forbidden_if_visium_and_is_single_false(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+
+        # Set is_single to False to trigger error.
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"]["is_single"] = np.bool_(False)
+
+        # Confirm library_id is not allowed for Visium if is_single is False.
+        validator._check_spatial()
+        assert len(validator.errors) == 1
+        assert (
+            "uns['spatial'][library_id] is only allowed for adata.obs['assay_ontology_term_id'] "
+            "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
+            in validator.errors[0]
+        )
+
+    def test__validate_library_id_required_if_visium(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"].pop(visium_library_id)
+
+        # Confirm library_id is identified as required.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "uns['spatial'] must contain the key 'library_id' for adata.obs['assay_ontology_term_id'] "
+            "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
+            in validator.errors[0]
+        )
+
+    def test__validate_library_id_allowed_keys_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["invalid_key"] = True
+
+        # Confirm additional key is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "uns['spatial'][library_id] can only contain the keys 'images' and 'scalefactors'." in validator.errors[0]
+        )
+
+    def test__validate_images_required_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id].pop("images")
+
+        # Confirm images is required.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'][library_id] must contain the key 'images'." in validator.errors[0]
+
+    def test__validate_images_allowed_keys_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"]["invalid_key"] = True
+
+        # Confirm additional key is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "uns['spatial'][library_id]['images'] can only contain the keys 'fullres' and 'hires'."
+            in validator.errors[0]
+        )
+
+    def test__validate_images_hires_required_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"].pop("hires")
+
+        # Confirm hires is required.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'][library_id]['images'] must contain the key 'hires'." in validator.errors[0]
+
+    def test__validate_images_fullres_optional(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"].pop("fullres")
+
+        # Confirm fullres is optional.
+        validator._check_spatial()
+        assert not validator.errors
+
+    def test__validate_images_hires_is_ndarray_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = "invalid"
+
+        # Confirm hires is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'][library_id]['images']['hires'] must be of numpy.ndarray type" in validator.errors[0]
+
+    def test__valide_images_hires_is_shape_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((1, 1))
+
+        # Confirm hires is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'][library_id]['images']['hires'] must have shape (,,3)" in validator.errors[0]
+
+    def test__validate_images_hires_max_dimension_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((2001, 2001, 3))
+
+        # Confirm hires is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'][library_id]['images']['hires'] has a max dimension of 2000 pixels" in validator.errors[0]
+
+    def test__validate_images_fullres_is_ndarray_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"]["fullres"] = "invalid"
+
+        # Confirm fullres is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'][library_id]['images']['fullres'] must be of numpy.ndarray type" in validator.errors[0]
+
+    def test__validate_images_fullres_is_shape_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"]["fullres"] = np.zeros((1, 1))
+
+        # Confirm fullres is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'][library_id]['images']['fullres'] must have shape (,,3)" in validator.errors[0]
+
+    def test__validate_scalefactors_required_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id].pop("scalefactors")
+
+        # Confirm scalefactors is required.
+        validator._check_spatial()
+        assert validator.errors
+        assert "uns['spatial'][library_id] must contain the key 'scalefactors'." in validator.errors[0]
+
+    def test__validate_scalefactors_allowed_keys_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["scalefactors"]["invalid_key"] = True
+
+        # Confirm additional key is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "uns['spatial'][library_id]['scalefactors'] can only contain the keys "
+            "'spot_diameter_fullres' and 'tissue_hires_scalef'." in validator.errors[0]
+        )
+
+    def test__validate_scalefactors_spot_diameter_fullres_required_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["scalefactors"].pop("spot_diameter_fullres")
+
+        # Confirm spot_diameter_fullres is required.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "uns['spatial'][library_id]['scalefactors'] must contain the key 'spot_diameter_fullres'."
+            in validator.errors[0]
+        )
+
+    def test__validate_scalefactors_tissue_hires_scalef_required_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["scalefactors"].pop("tissue_hires_scalef")
+
+        # Confirm tissue_hires_scalef is required.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "uns['spatial'][library_id]['scalefactors'] must contain the key 'tissue_hires_scalef'."
+            in validator.errors[0]
+        )
+
+    def test__validate_scalefactors_spot_diameter_fullres_is_float_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["scalefactors"]["spot_diameter_fullres"] = "invalid"
+
+        # Confirm spot_diameter_fullres is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "uns['spatial'][library_id]['scalefactors']['spot_diameter_fullres'] must be of type float"
+            in validator.errors[0]
+        )
+
+    def test__validate_scalefactors_tissue_hires_scalef_is_float_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["scalefactors"]["tissue_hires_scalef"] = "invalid"
+
+        # Confirm tissue_hires_scalef is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "uns['spatial'][library_id]['scalefactors']['tissue_hires_scalef'] must be of type float"
+            in validator.errors[0]
+        )
+
 
 class TestSeuratConvertibility:
     def validation_helper(self, matrix, raw=None):
@@ -356,6 +713,13 @@ class TestSeuratConvertibility:
         assert len(self.validator.errors) == 1
         assert not self.validator.is_seurat_convertible
         assert not self.validator.is_valid
+
+        # Visium datasets are not Seurat-convertible
+        self.validation_helper(sparse_matrix_with_zero)
+        self.validator.adata.obs = adata_visium.obs.copy()
+        self.validator._validate_seurat_convertibility()
+        assert len(self.validator.warnings) == 1
+        assert not self.validator.is_seurat_convertible
 
 
 class TestValidatorValidateDataFrame:

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -527,6 +527,12 @@ class TestValidate:
         # Confirm fullres is optional.
         validator._check_spatial()
         assert not validator.errors
+        assert validator.warnings
+        assert (
+            "No uns['spatial'][library_id]['images']['fullres'] was found. "
+            "It is STRONGLY RECOMMENDED that uns['spatial'][library_id]['images']['fullres'] is provided."
+            in validator.warnings[0]
+        )
 
     def test__validate_images_hires_is_ndarray_error(self):
         validator: Validator = Validator()

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -377,7 +377,10 @@ class TestValidate:
         # Confirm additional key is identified as invalid.
         validator._check_spatial()
         assert validator.errors
-        assert "uns['spatial'] must contain only one library_id." in validator.errors[0]
+        assert (
+            "uns['spatial'] must contain only two top-level keys: 'is_single' and a library_id. "
+            "More than two top-level keys detected:" in validator.errors[0]
+        )
 
     def test__validate_is_single_required_visium_error(self):
         validator: Validator = Validator()
@@ -461,7 +464,7 @@ class TestValidate:
         validator._check_spatial()
         assert validator.errors
         assert (
-            "uns['spatial'] must contain the key 'library_id' for obs['assay_ontology_term_id'] "
+            "uns['spatial'] must contain at least one key representing the library_id for obs['assay_ontology_term_id'] "
             "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             in validator.errors[0]
         )

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -556,16 +556,33 @@ class TestValidate:
         assert validator.errors
         assert "uns['spatial'][library_id]['images']['hires'] must have shape (,,3)" in validator.errors[0]
 
-    def test__validate_images_hires_max_dimension_error(self):
+    def test__validate_images_hires_max_dimension_greater_than_error(self):
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((2001, 2001, 3))
+        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((1, 2001, 3))
 
         # Confirm hires is identified as invalid.
         validator._check_spatial()
         assert validator.errors
-        assert "uns['spatial'][library_id]['images']['hires'] has a max dimension of 2000 pixels" in validator.errors[0]
+        assert (
+            "The largest dimension of uns['spatial'][library_id]['images']['hires'] must be 2000 pixels"
+            in validator.errors[0]
+        )
+
+    def test__validate_images_hires_max_dimension_less_than_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((1, 1999, 3))
+
+        # Confirm hires is identified as invalid.
+        validator._check_spatial()
+        assert validator.errors
+        assert (
+            "The largest dimension of uns['spatial'][library_id]['images']['hires'] must be 2000 pixels"
+            in validator.errors[0]
+        )
 
     def test__validate_images_fullres_is_ndarray_error(self):
         validator: Validator = Validator()


### PR DESCRIPTION
## Reason for Change

- #827 

## Changes

- Added `_check_spatial()` to validate `uns["spatial"]` values.
- Added Seurat conversion warning for Visium datasets.

## Testing

- Added unit tests.
- Tested with 5.1.0 datasets.
