### PR TITLE
fix(schema 5.1.0): throw error if obsm is not type np.ndarray

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1043,7 +1043,7 @@ class Validator:
 
                 if unknown_key and value.shape[1] < 1:
                     self.errors.append(
-                        f"All other embeddings must have at least one column. 'adata.obsm['{key}']' has columns='{value.shape[1]}'."
+                        f"All unspecified embeddings must have at least one column. 'adata.obsm['{key}']' has columns='{value.shape[1]}'."
                     )
 
                 if not unknown_key and value.shape[1] < 2:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -999,7 +999,7 @@ class Validator:
                 continue
 
             if len(value.shape) < 2 or value.shape[0] != self.adata.n_obs or value.shape[1] < 2:
-                issue_list.append(
+                self.errors.append(
                     f"All embeddings must have as many rows as cells, and at least two columns."
                     f" 'adata.obsm['{key}']' has shape of '{value.shape}'."
                 )

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -983,7 +983,7 @@ class Validator:
                 issue_list = self.warnings
 
             if not isinstance(value, np.ndarray):
-                issue_list.append(
+                self.errors.append(
                     f"All embeddings have to be of 'numpy.ndarray' type, " f"'adata.obsm['{key}']' is {type(value)}')."
                 )
                 # Skip over the subsequent checks that require the value to be an array

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1301,8 +1301,7 @@ class Validator:
             for column in adata_component.columns:
                 if column in component_columns:
                     raise ValueError(
-                        f"Duplicate column name '{column}' detected in 'adata.{df_component}' DataFrame. All "
-                        f"DataFrame column names must be unique."
+                        f"Duplicate column name '{column}' detected in 'adata.{df_component}' DataFrame. All DataFrame column names must be unique."
                     )
                 component_columns.add(column)
 
@@ -1433,8 +1432,7 @@ class Validator:
         # library_id is required if assay is Visium and is_single is True.
         if len(library_ids) == 0:
             self.errors.append(
-                "uns['spatial'] must contain at least one key representing the library_id when obs["
-                "'assay_ontology_term_id'] "
+                "uns['spatial'] must contain at least one key representing the library_id when obs['assay_ontology_term_id'] "
                 "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             )
             # Exit as library_id is missing.
@@ -1504,10 +1502,8 @@ class Validator:
                 spot_diameter_fullres = uns_scalefactors["spot_diameter_fullres"]
                 if not isinstance(spot_diameter_fullres, float):
                     self.errors.append(
-                        "uns['spatial'][library_id]['scalefactors']['spot_diameter_fullres'] must be of type float, "
-                        "it is "
-                        f"{type(spot_diameter_fullres)}. This must be the value of the spot_diameter_fullres field "
-                        f"from scalefactors_json.json"
+                        "uns['spatial'][library_id]['scalefactors']['spot_diameter_fullres'] must be of type float, it is "
+                        f"{type(spot_diameter_fullres)}. This must be the value of the spot_diameter_fullres field from scalefactors_json.json"
                     )
 
             # tissue_hires_scalef is required.
@@ -1520,10 +1516,8 @@ class Validator:
                 tissue_hires_scalef = uns_scalefactors["tissue_hires_scalef"]
                 if not isinstance(tissue_hires_scalef, float):
                     self.errors.append(
-                        "uns['spatial'][library_id]['scalefactors']['tissue_hires_scalef'] must be of type float, "
-                        "it is "
-                        f"{type(tissue_hires_scalef)}. This must be the value of the tissue_hires_scalef field from "
-                        f"scalefactors_json.json"
+                        "uns['spatial'][library_id]['scalefactors']['tissue_hires_scalef'] must be of type float, it is "
+                        f"{type(tissue_hires_scalef)}. This must be the value of the tissue_hires_scalef field from scalefactors_json.json"
                     )
 
     def _has_no_extra_keys(self, dictionary: dict, allowed_keys: List[str]) -> bool:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -968,6 +968,9 @@ class Validator:
 
         obsm_with_x_prefix = 0
         for key, value in self.adata.obsm.items():
+            if not isinstance(key, str):
+                # no validation on none string OBSM key types.
+                continue
             issue_list = self.errors
 
             regex_pattern = r"^[a-zA-Z][a-zA-Z0-9_.-]*$"
@@ -1007,17 +1010,17 @@ class Validator:
             else:
                 if value.shape[0] != self.adata.n_obs:
                     self.errors.append(
-                        f"All embeddings must have as many rows as cells. 'adata.obsm['{key}']' has shape of '{value.shape[0]}'."
+                        f"All embeddings must have as many rows as cells. 'adata.obsm['{key}']' has rows='{value.shape[0]}'."
                     )
 
                 if unknown_key and value.shape[1] < 1:
                     self.errors.append(
-                        f"All other embeddings must have at least one column. 'adata.obsm['{key}']' has shape of '{value.shape[1]}'."
+                        f"All other embeddings must have at least one column. 'adata.obsm['{key}']' has columns='{value.shape[1]}'."
                     )
 
                 if not unknown_key and value.shape[1] < 2:
                     self.errors.append(
-                        f"All 'X_' and 'spatial' embeddings must have at least two columns. 'adata.obsm['{key}']' has shape of '{value.shape[1]}'."
+                        f"All 'X_' and 'spatial' embeddings must have at least two columns. 'adata.obsm['{key}']' has columns='{value.shape[1]}'."
                     )
 
             if not (np.issubdtype(value.dtype, np.integer) or np.issubdtype(value.dtype, np.floating)):
@@ -1298,7 +1301,8 @@ class Validator:
             for column in adata_component.columns:
                 if column in component_columns:
                     raise ValueError(
-                        f"Duplicate column name '{column}' detected in 'adata.{df_component}' DataFrame. All DataFrame column names must be unique."
+                        f"Duplicate column name '{column}' detected in 'adata.{df_component}' DataFrame. All "
+                        f"DataFrame column names must be unique."
                     )
                 component_columns.add(column)
 
@@ -1429,7 +1433,8 @@ class Validator:
         # library_id is required if assay is Visium and is_single is True.
         if len(library_ids) == 0:
             self.errors.append(
-                "uns['spatial'] must contain at least one key representing the library_id when obs['assay_ontology_term_id'] "
+                "uns['spatial'] must contain at least one key representing the library_id when obs["
+                "'assay_ontology_term_id'] "
                 "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             )
             # Exit as library_id is missing.
@@ -1499,8 +1504,10 @@ class Validator:
                 spot_diameter_fullres = uns_scalefactors["spot_diameter_fullres"]
                 if not isinstance(spot_diameter_fullres, float):
                     self.errors.append(
-                        "uns['spatial'][library_id]['scalefactors']['spot_diameter_fullres'] must be of type float, it is "
-                        f"{type(spot_diameter_fullres)}. This must be the value of the spot_diameter_fullres field from scalefactors_json.json"
+                        "uns['spatial'][library_id]['scalefactors']['spot_diameter_fullres'] must be of type float, "
+                        "it is "
+                        f"{type(spot_diameter_fullres)}. This must be the value of the spot_diameter_fullres field "
+                        f"from scalefactors_json.json"
                     )
 
             # tissue_hires_scalef is required.
@@ -1513,8 +1520,10 @@ class Validator:
                 tissue_hires_scalef = uns_scalefactors["tissue_hires_scalef"]
                 if not isinstance(tissue_hires_scalef, float):
                     self.errors.append(
-                        "uns['spatial'][library_id]['scalefactors']['tissue_hires_scalef'] must be of type float, it is "
-                        f"{type(tissue_hires_scalef)}. This must be the value of the tissue_hires_scalef field from scalefactors_json.json"
+                        "uns['spatial'][library_id]['scalefactors']['tissue_hires_scalef'] must be of type float, "
+                        "it is "
+                        f"{type(tissue_hires_scalef)}. This must be the value of the tissue_hires_scalef field from "
+                        f"scalefactors_json.json"
                     )
 
     def _has_no_extra_keys(self, dictionary: dict, allowed_keys: List[str]) -> bool:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -999,9 +999,6 @@ class Validator:
 
         obsm_with_x_prefix = 0
         for key, value in self.adata.obsm.items():
-            if not isinstance(key, str):
-                # no validation on none string OBSM key types.
-                continue
             issue_list = self.errors
 
             regex_pattern = r"^[a-zA-Z][a-zA-Z0-9_.-]*$"

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2022,10 +2022,10 @@ class TestObsm:
         validator.validate_adata()
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in "
-            "Explorer",
-            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current "
-            "errors.",
+            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and "
+            "thus will not be available in Explorer",
+            "WARNING: Validation of raw layer was not performed due to current errors, "
+            "try again after fixing current errors.",
         ]
         assert validator.errors == [
             "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class "
@@ -2060,10 +2060,10 @@ class TestObsm:
         ]
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered " "from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in "
-            "Explorer",
-            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current "
-            "errors.",
+            "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and "
+            "thus will not be available in Explorer",
+            "WARNING: Validation of raw layer was not performed due to current errors, "
+            "try again after fixing current errors.",
         ]
 
     def test_obsm_suffix_name_valid(self, validator_with_adata):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2006,14 +2006,11 @@ class TestObsm:
         validator.validate_adata()
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and "
-            "thus will not be available in Explorer",
-            "WARNING: Validation of raw layer was not performed due to current errors, "
-            "try again after fixing current errors.",
+            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
+            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
         assert validator.errors == [
-            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class "
-            "'pandas.core.frame.DataFrame'>')."
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>')."
         ]
 
     def test_obsm_values_suffix_is_forbidden(self, validator_with_adata):
@@ -2027,10 +2024,8 @@ class TestObsm:
         validator.adata.obsm["X_3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_3D does not match the regex pattern ^[a-zA-Z]["
-            "a-zA-Z0-9_.-]*$.",
-            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class "
-            "'pandas.core.frame.DataFrame'>').",
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$.",
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class 'pandas.core.frame.DataFrame'>').",
         ]
 
     def test_obsm_values_key_start_with_number(self, validator_with_adata):
@@ -2043,11 +2038,9 @@ class TestObsm:
             "'pandas.core.frame.DataFrame'>').",
         ]
         assert validator.warnings == [
-            "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered " "from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and "
-            "thus will not be available in Explorer",
-            "WARNING: Validation of raw layer was not performed due to current errors, "
-            "try again after fixing current errors.",
+            "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
+            "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",
+            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
 
     def test_obsm_suffix_name_valid(self, validator_with_adata):
@@ -2058,8 +2051,7 @@ class TestObsm:
         validator.adata.obsm["X_"] = validator.adata.obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_ does not match the regex pattern ^[a-zA-Z]["
-            "a-zA-Z0-9_.-]*$."
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_ does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$."
         ]
 
     def test_obsm_key_name_whitespace(self, validator_with_adata):
@@ -2071,8 +2063,7 @@ class TestObsm:
         obsm["X_ umap"] = obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_ umap does not match the regex pattern ^[a-zA-Z]["
-            "a-zA-Z0-9_.-]*$.",
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_ umap does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$.",
         ]
 
         del obsm["X_ umap"]

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1996,7 +1996,9 @@ class TestObsm:
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
-            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>').",
+        ]
+        assert validator.errors == [
+            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>')."
         ]
 
     def test_obsm_values_suffix_is_forbidden(self, validator_with_adata):
@@ -2024,8 +2026,10 @@ class TestObsm:
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",
-            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class 'pandas.core.frame.DataFrame'>').",
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
+        ]
+        assert validator.errors == [
+            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class 'pandas.core.frame.DataFrame'>')."
         ]
 
     def test_obsm_suffix_name_valid(self, validator_with_adata):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2155,7 +2155,8 @@ class TestObsm:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: The size of the ndarray stored for a 'adata.obsm['unknown']' MUST NOT " "be zero.",
-            "ERROR: All other embeddings must have at least one column. " "'adata.obsm['unknown']' has columns='0'.",
+            "ERROR: All unspecified embeddings must have at least one column. "
+            "'adata.obsm['unknown']' has columns='0'.",
         ]
 
     def test_obsm_shape_same_rows_and_columns(self, validator_with_adata):
@@ -2184,7 +2185,8 @@ class TestObsm:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: The size of the ndarray stored for a 'adata.obsm['badsize']' MUST NOT " "be zero.",
-            "ERROR: All other embeddings must have at least one column. " "'adata.obsm['badsize']' has columns='0'.",
+            "ERROR: All unspecified embeddings must have at least one column. "
+            "'adata.obsm['badsize']' has columns='0'.",
         ]
 
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -379,8 +379,7 @@ class TestObs:
             ("EFO:0010183", "ERROR: 'EFO:0010183' in 'assay_ontology_term_id' is not an allowed term id."),
             (
                 "EFO:0010183 (sci-plex)",
-                "ERROR: 'EFO:0010183 (sci-plex)' in 'assay_ontology_term_id' is not a valid ontology term id of "
-                "'EFO'.",
+                "ERROR: 'EFO:0010183 (sci-plex)' in 'assay_ontology_term_id' is not a valid ontology term id of 'EFO'.",
             ),
         ],
     )
@@ -514,8 +513,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'disease_ontology_term_id' is not a valid ontology term id of 'MONDO, PATO'. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms "
-            "of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid PATO term id
@@ -524,8 +522,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'PATO:0001894' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms "
-            "of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease characteristic
@@ -534,8 +531,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0021125' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms "
-            "of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease parent term
@@ -544,8 +540,7 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0000001' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms "
-            "of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Valid PATO term id - healthy
@@ -716,8 +711,7 @@ class TestObs:
 
     def test_self_reported_ethnicity_ontology_term_id__forbidden_term_descendant(self, validator_with_adata):
         """
-        Test self_reported_ethnicity_ontology_term error message when passed the descendant term of an ontology term
-        that has
+        Test self_reported_ethnicity_ontology_term error message when passed the descendant term of an ontology term that has
         both itself and its descendants forbidden
         """
         validator = validator_with_adata
@@ -733,8 +727,7 @@ class TestObs:
         assert validator.errors == [
             self.get_format_error_message(
                 error_message_suffix,
-                "ERROR: 'HANCESTRO:0306' in 'self_reported_ethnicity_ontology_term_id' is not allowed. Descendant "
-                "terms "
+                "ERROR: 'HANCESTRO:0306' in 'self_reported_ethnicity_ontology_term_id' is not allowed. Descendant terms "
                 "of 'HANCESTRO:0304' are not allowed.",
             )
         ]
@@ -999,8 +992,7 @@ class TestObs:
             "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "and 'CL:0000548' (animal cell)) or 'unknown'."
         ] or validator.errors == [
-            f"ERROR: '{term}' in 'tissue_ontology_term_id' is a deprecated term id of 'CL'. When 'tissue_type' "
-            f"is "
+            f"ERROR: '{term}' in 'tissue_ontology_term_id' is a deprecated term id of 'CL'. When 'tissue_type' is "
             f"'cell culture', 'tissue_ontology_term_id' MUST be either a CL term "
             "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "and 'CL:0000548' (animal cell)) or 'unknown'."
@@ -1815,8 +1807,7 @@ class TestUns:
         validator.adata.uns["is_primary_data_colors"] = numpy.array(["green", "purple"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors field uns[is_primary_data_colors] does not have a corresponding categorical field in obs. "
-            "is_primary_data is present but is dtype bool"
+            "ERROR: Colors field uns[is_primary_data_colors] does not have a corresponding categorical field in obs. is_primary_data is present but is dtype bool"
         ]
 
     def test_colors_portal_obs_counterpart(self, validator_with_adata):
@@ -1824,8 +1815,7 @@ class TestUns:
         validator.adata.uns["cell_type_colors"] = numpy.array(["green", "purple"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors field uns[cell_type_colors] does not have a corresponding categorical field in obs. "
-            "Annotate cell_type_ontology_term_id_colors instead"
+            "ERROR: Colors field uns[cell_type_colors] does not have a corresponding categorical field in obs. Annotate cell_type_ontology_term_id_colors instead"
         ]
 
     def test_colors_without_obs_counterpart(self, validator_with_adata):
@@ -1842,8 +1832,7 @@ class TestUns:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: uns['suspension_type_colors'] cannot be an empty value.",
-            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns["
-            "suspension_type_colors]. Found: []",
+            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns[suspension_type_colors]. Found: []",
         ]
 
     def test_not_enough_color_options(self, validator_with_adata):
@@ -1851,8 +1840,7 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["green"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns["
-            "suspension_type_colors]. Found: ['green']"
+            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns[suspension_type_colors]. Found: ['green']"
         ]
 
     def test_different_color_types(self, validator_with_adata):
@@ -1860,8 +1848,7 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["#000000", "pink"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
-            "Found: ['#000000' 'pink']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['#000000' 'pink']"
         ]
 
     def test_invalid_hex_color_option(sel, validator_with_adata):
@@ -1869,8 +1856,7 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["#000", "#ffffff"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
-            "Found: ['#000' '#ffffff']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['#000' '#ffffff']"
         ]
 
     def test_invalid_named_color_option(self, validator_with_adata):
@@ -1878,8 +1864,7 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["green", "pynk"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
-            "Found: ['green' 'pynk']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['green' 'pynk']"
         ]
 
     def test_invalid_named_color_option_empty_strings(self, validator_with_adata):
@@ -1887,8 +1872,7 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["", "green"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
-            "Found: ['' 'green']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['' 'green']"
         ]
 
     def test_invalid_named_color_option_integer(self, validator_with_adata):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -379,7 +379,8 @@ class TestObs:
             ("EFO:0010183", "ERROR: 'EFO:0010183' in 'assay_ontology_term_id' is not an allowed term id."),
             (
                 "EFO:0010183 (sci-plex)",
-                "ERROR: 'EFO:0010183 (sci-plex)' in 'assay_ontology_term_id' is not a valid ontology term id of 'EFO'.",
+                "ERROR: 'EFO:0010183 (sci-plex)' in 'assay_ontology_term_id' is not a valid ontology term id of "
+                "'EFO'.",
             ),
         ],
     )
@@ -513,7 +514,8 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'disease_ontology_term_id' is not a valid ontology term id of 'MONDO, PATO'. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms "
+            "of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid PATO term id
@@ -522,7 +524,8 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'PATO:0001894' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms "
+            "of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease characteristic
@@ -531,7 +534,8 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0021125' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms "
+            "of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Invalid MONDO term id - disease parent term
@@ -540,7 +544,8 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'MONDO:0000001' in 'disease_ontology_term_id' is not an allowed term id. "
-            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
+            "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms "
+            "of 'MONDO:0000001' (disease) are allowed"
         ]
 
         # Valid PATO term id - healthy
@@ -711,7 +716,8 @@ class TestObs:
 
     def test_self_reported_ethnicity_ontology_term_id__forbidden_term_descendant(self, validator_with_adata):
         """
-        Test self_reported_ethnicity_ontology_term error message when passed the descendant term of an ontology term that has
+        Test self_reported_ethnicity_ontology_term error message when passed the descendant term of an ontology term
+        that has
         both itself and its descendants forbidden
         """
         validator = validator_with_adata
@@ -727,7 +733,8 @@ class TestObs:
         assert validator.errors == [
             self.get_format_error_message(
                 error_message_suffix,
-                "ERROR: 'HANCESTRO:0306' in 'self_reported_ethnicity_ontology_term_id' is not allowed. Descendant terms "
+                "ERROR: 'HANCESTRO:0306' in 'self_reported_ethnicity_ontology_term_id' is not allowed. Descendant "
+                "terms "
                 "of 'HANCESTRO:0304' are not allowed.",
             )
         ]
@@ -992,7 +999,8 @@ class TestObs:
             "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "and 'CL:0000548' (animal cell)) or 'unknown'."
         ] or validator.errors == [
-            f"ERROR: '{term}' in 'tissue_ontology_term_id' is a deprecated term id of 'CL'. When 'tissue_type' is "
+            f"ERROR: '{term}' in 'tissue_ontology_term_id' is a deprecated term id of 'CL'. When 'tissue_type' "
+            f"is "
             f"'cell culture', 'tissue_ontology_term_id' MUST be either a CL term "
             "(excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell), "
             "and 'CL:0000548' (animal cell)) or 'unknown'."
@@ -1807,7 +1815,8 @@ class TestUns:
         validator.adata.uns["is_primary_data_colors"] = numpy.array(["green", "purple"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors field uns[is_primary_data_colors] does not have a corresponding categorical field in obs. is_primary_data is present but is dtype bool"
+            "ERROR: Colors field uns[is_primary_data_colors] does not have a corresponding categorical field in obs. "
+            "is_primary_data is present but is dtype bool"
         ]
 
     def test_colors_portal_obs_counterpart(self, validator_with_adata):
@@ -1815,7 +1824,8 @@ class TestUns:
         validator.adata.uns["cell_type_colors"] = numpy.array(["green", "purple"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors field uns[cell_type_colors] does not have a corresponding categorical field in obs. Annotate cell_type_ontology_term_id_colors instead"
+            "ERROR: Colors field uns[cell_type_colors] does not have a corresponding categorical field in obs. "
+            "Annotate cell_type_ontology_term_id_colors instead"
         ]
 
     def test_colors_without_obs_counterpart(self, validator_with_adata):
@@ -1832,7 +1842,8 @@ class TestUns:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: uns['suspension_type_colors'] cannot be an empty value.",
-            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns[suspension_type_colors]. Found: []",
+            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns["
+            "suspension_type_colors]. Found: []",
         ]
 
     def test_not_enough_color_options(self, validator_with_adata):
@@ -1840,7 +1851,8 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["green"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns[suspension_type_colors]. Found: ['green']"
+            "ERROR: Annotated categorical field suspension_type must have at least 2 color options in uns["
+            "suspension_type_colors]. Found: ['green']"
         ]
 
     def test_different_color_types(self, validator_with_adata):
@@ -1848,7 +1860,8 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["#000000", "pink"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['#000000' 'pink']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
+            "Found: ['#000000' 'pink']"
         ]
 
     def test_invalid_hex_color_option(sel, validator_with_adata):
@@ -1856,7 +1869,8 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["#000", "#ffffff"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['#000' '#ffffff']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
+            "Found: ['#000' '#ffffff']"
         ]
 
     def test_invalid_named_color_option(self, validator_with_adata):
@@ -1864,7 +1878,8 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["green", "pynk"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['green' 'pynk']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
+            "Found: ['green' 'pynk']"
         ]
 
     def test_invalid_named_color_option_empty_strings(self, validator_with_adata):
@@ -1872,7 +1887,8 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["", "green"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['' 'green']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
+            "Found: ['' 'green']"
         ]
 
     def test_invalid_named_color_option_integer(self, validator_with_adata):
@@ -1972,8 +1988,10 @@ class TestObsm:
         assert validator.is_spatial is False
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
-            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
+            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in "
+            "Explorer",
+            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current "
+            "errors.",
         ]
 
     @pytest.mark.parametrize(
@@ -2003,6 +2021,7 @@ class TestObsm:
         validator.adata.obsm["harmony"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.warnings == [
+            "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
@@ -2021,8 +2040,10 @@ class TestObsm:
         validator.adata.obsm["X_3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$.",
-            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class 'pandas.core.frame.DataFrame'>').",
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_3D does not match the regex pattern ^[a-zA-Z]["
+            "a-zA-Z0-9_.-]*$.",
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['X_3D']' is <class "
+            "'pandas.core.frame.DataFrame'>').",
         ]
 
     def test_obsm_values_key_start_with_number(self, validator_with_adata):
@@ -2031,9 +2052,11 @@ class TestObsm:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: Embedding key in 'adata.obsm' 3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$.",
-            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class 'pandas.core.frame.DataFrame'>').",
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class "
+            "'pandas.core.frame.DataFrame'>').",
         ]
         assert validator.warnings == [
+            "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered " "from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
@@ -2046,7 +2069,8 @@ class TestObsm:
         validator.adata.obsm["X_"] = validator.adata.obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_ does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$."
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_ does not match the regex pattern ^[a-zA-Z]["
+            "a-zA-Z0-9_.-]*$."
         ]
 
     def test_obsm_key_name_whitespace(self, validator_with_adata):
@@ -2058,7 +2082,8 @@ class TestObsm:
         obsm["X_ umap"] = obsm["X_umap"]
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Suffix for embedding key in 'adata.obsm' X_ umap does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$.",
+            "ERROR: Suffix for embedding key in 'adata.obsm' X_ umap does not match the regex pattern ^[a-zA-Z]["
+            "a-zA-Z0-9_.-]*$.",
         ]
 
         del obsm["X_ umap"]

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2054,7 +2054,7 @@ class TestObsm:
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' harmony is not 'spatial' nor does it start with 'X_'. "
             "Thus, it will not be available in Explorer",
-            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>').",
+            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
         assert validator.errors == [
             "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>')."
@@ -2088,7 +2088,6 @@ class TestObsm:
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' 3D is not 'spatial' nor does it start with 'X_'. "
             "Thus, it will not be available in Explorer",
-            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class 'pandas.core.frame.DataFrame'>').",
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1994,11 +1994,11 @@ class TestObsm:
         validator.adata.obsm["harmony"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.warnings == [
-            "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
+            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
         assert validator.errors == [
-            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>')."
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>')."
         ]
 
     def test_obsm_values_suffix_is_forbidden(self, validator_with_adata):
@@ -2021,15 +2021,12 @@ class TestObsm:
         validator.adata.obsm["3D"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Embedding key in 'adata.obsm' 3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$."
+            "ERROR: Embedding key in 'adata.obsm' 3D does not match the regex pattern ^[a-zA-Z][a-zA-Z0-9_.-]*$.",
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class 'pandas.core.frame.DataFrame'>').",
         ]
         assert validator.warnings == [
-            "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
             "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
-        ]
-        assert validator.errors == [
-            "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class 'pandas.core.frame.DataFrame'>')."
         ]
 
     def test_obsm_suffix_name_valid(self, validator_with_adata):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2137,9 +2137,22 @@ class TestObsm:
         validator.adata.obsm[key] = numpy.delete(validator.adata.obsm[key], 0, 1)
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: All embeddings must have as many rows as cells, and "
-            f"at least two columns. 'adata.obsm['{key}']' has shape "
-            "of '(2, 1)'."
+            "ERROR: All 'X_' and 'spatial' embeddings must have at least two columns. "
+            f"'adata.obsm['{key}']' has columns='1'."
+        ]
+
+    def test_obsm_shape_zero_column_with_unknown_key(self, validator_with_adata):
+        """
+        embeddings that are not 'X_' or 'spatial' that are ndarrays must have at least one column
+        """
+        # Makes 0 column array
+        validator = validator_with_adata
+        n_obs = validator_with_adata.adata.n_obs
+        validator.adata.obsm["unknown"] = numpy.zeros((n_obs, 0))
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: The size of the ndarray stored for a 'adata.obsm['unknown']' MUST NOT " "be zero.",
+            "ERROR: All other embeddings must have at least one column. " "'adata.obsm['unknown']' has columns='0'.",
         ]
 
     def test_obsm_shape_same_rows_and_columns(self, validator_with_adata):
@@ -2167,7 +2180,8 @@ class TestObsm:
         validator.adata = save_and_read_adata(adata)
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: The size of the ndarray stored for a 'adata.obsm['badsize']' MUST NOT be zero.",
+            "ERROR: The size of the ndarray stored for a 'adata.obsm['badsize']' MUST NOT " "be zero.",
+            "ERROR: All other embeddings must have at least one column. " "'adata.obsm['badsize']' has columns='0'.",
         ]
 
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2022,11 +2022,14 @@ class TestObsm:
         validator.validate_adata()
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
-            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
+            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in "
+            "Explorer",
+            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current "
+            "errors.",
         ]
         assert validator.errors == [
-            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>')."
+            "ERROR: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class "
+            "'pandas.core.frame.DataFrame'>')."
         ]
 
     def test_obsm_values_suffix_is_forbidden(self, validator_with_adata):
@@ -2057,8 +2060,10 @@ class TestObsm:
         ]
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered " "from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",
-            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
+            "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in "
+            "Explorer",
+            "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current "
+            "errors.",
         ]
 
     def test_obsm_suffix_name_valid(self, validator_with_adata):


### PR DESCRIPTION
## Reason for Change

- #853
- https://github.com/chanzuckerberg/single-cell-curation/pull/860
## Changes

- change warning to an error when obsm field is not type numpy.ndarray.
- validating that obsm ndarray that don't match spatial or X_ must have a column length of at least 1.
- split out the checks in `_validate_obsm` to make it clear why an error occured.

## Testing

- Update the unit tests to match expect behavior
- Added a test for unknown obsm keys