### PR TITLE
feat(schema 5.1.0): validate obs[array_col], obs[array_row] and obs[in_tissue]

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1378,7 +1378,7 @@ class Validator:
 
         # is_single must be a boolean.
         uns_is_single = uns_spatial["is_single"]
-        if not isinstance(uns_is_single, (np.bool_, np.bool, bool)):
+        if not isinstance(uns_is_single, (np.bool_, np.bool)):
             self.errors.append(f"uns['spatial']['is_single'] must be of boolean type, it is {type(uns_is_single)}.")
             # Exit if is_single is not valid as all further checks are dependent on its value.
             return

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1378,7 +1378,7 @@ class Validator:
 
         # is_single must be a boolean.
         uns_is_single = uns_spatial["is_single"]
-        if not isinstance(uns_is_single, (np.bool_, np.bool)):
+        if not isinstance(uns_is_single, (np.bool_, np.bool, bool)):
             self.errors.append(f"uns['spatial']['is_single'] must be of boolean type, it is {type(uns_is_single)}.")
             # Exit if is_single is not valid as all further checks are dependent on its value.
             return

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -103,7 +103,7 @@ class Validator:
         :rtype bool
         """
         if self.is_visium_and_is_single_true is None:
-            self.is_visium_and_is_single_true = self._is_visium() and (self._is_single() or False)
+            self.is_visium_and_is_single_true = bool(self._is_visium() and self._is_single())
         return self.is_visium_and_is_single_true
 
     def _validate_encoding_version(self):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -29,9 +29,6 @@ ASSAY_SLIDE_SEQV2 = "EFO:0030062"
 class Validator:
     """Handles validation of AnnData"""
 
-    ASSAY_VISIUM = "EFO:0010961"
-    ASSAY_SLIDE_SEQV2 = "EFO:0030062"
-
     def __init__(self, ignore_labels=False):
         self.schema_def = dict()
         self.schema_version: str = None

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -29,6 +29,9 @@ ASSAY_SLIDE_SEQV2 = "EFO:0030062"
 class Validator:
     """Handles validation of AnnData"""
 
+    ASSAY_VISIUM = "EFO:0010961"
+    ASSAY_SLIDE_SEQV2 = "EFO:0030062"
+
     def __init__(self, ignore_labels=False):
         self.schema_def = dict()
         self.schema_version: str = None
@@ -949,6 +952,13 @@ class Validator:
             self.errors.append(
                 "This dataset has a mismatch between 1) the number of features in raw.X and 2) the number of features "
                 "in raw.var. These counts must be identical."
+            )
+            self.is_seurat_convertible = False
+
+        # Seurat conversion is not supported for Visium datasets.
+        if self._is_visium():
+            self.warnings.append(
+                "Datasets with assay_ontology_term_id 'EFO:0010961' (Visium Spatial Gene Expression) are not compatible with Seurat."
             )
             self.is_seurat_convertible = False
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1404,7 +1404,7 @@ class Validator:
         if not self._is_visium_and_is_single_true():
             return
 
-        # Check if tissue position is required. At this point, is_single is True and:
+        # At this point, is_single is True and:
         # - there's at least one row with Visum, tissue position column is required
         # - for any Visium row, tissue position is required.
         if (

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1389,7 +1389,7 @@ class Validator:
         if obs_tissue_position is None:
             self.errors.append(
                 f"obs['{tissue_position_name}'] is required for obs['assay_ontology_term_id'] "
-                "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] True."
+                "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             )
             return
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1389,23 +1389,36 @@ class Validator:
 
         :rtype none
         """
-        # Tissue position is foribidden if assay is not Visium or is_single is False.
-        is_visium_and_uns_is_single = self._is_visium_and_is_single_true()
-        obs_tissue_position = self.adata.obs.get(tissue_position_name)
-        if obs_tissue_position is not None and not is_visium_and_uns_is_single:
+        # Tissue position is foribidden if assay is not Visium and is_single is True.
+        if (
+            tissue_position_name in self.adata.obs
+            and (
+                ~((self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM) & (self.adata.uns["spatial"]["is_single"]))
+                & (self.adata.obs[tissue_position_name].notnull())
+            ).any()
+        ):
             self.errors.append(f"obs['{tissue_position_name}'] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_FORBIDDEN}")
             return
 
         # Exit if we're not dealing with Visium and _is_single True as no further checks are necessary.
-        if not is_visium_and_uns_is_single:
+        if not self._is_visium_and_is_single_true():
             return
 
-        # Tissue position is required.
-        if obs_tissue_position is None:
+        # Check if tissue position is required. At this point, is_single is True and:
+        # - there's at least one row with Visum, tissue position column is required
+        # - for any Visium row, tissue position is required.
+        if (
+            tissue_position_name not in self.adata.obs
+            or (
+                (self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM)
+                & (self.adata.obs[tissue_position_name].isnull())
+            ).any()
+        ):
             self.errors.append(f"obs['{tissue_position_name}'] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_REQUIRED}")
             return
 
         # Tissue position must be an int.
+        obs_tissue_position = self.adata.obs.get(tissue_position_name)
         if not np.issubdtype(obs_tissue_position.dtype, np.integer):
             self.errors.append(f"obs['{tissue_position_name}'] must be of int type, it is {obs_tissue_position.dtype}.")
             return

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -952,13 +952,6 @@ class Validator:
             )
             self.is_seurat_convertible = False
 
-        # Seurat conversion is not supported for Visium datasets.
-        if self._is_visium():
-            self.warnings.append(
-                "Datasets with assay_ontology_term_id 'EFO:0010961' (Visium Spatial Gene Expression) are not compatible with Seurat."
-            )
-            self.is_seurat_convertible = False
-
     def _validate_obsm(self):
         """
         Validates the embedding dictionary -- it checks that all values of adata.obsm are numpy arrays with the correct

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -65,6 +65,19 @@ class Validator:
         self.reset()
         self._adata = adata
 
+    def _is_single(self) -> bool | None:
+        """
+        Determine value of uns.spatial.is_single. None if non-spatial.
+
+        :return Value of uns.spatial.is_single if specified, None otherwise.
+        :rtype bool | None
+        """
+        return (
+            self.adata.uns["spatial"]["is_single"]
+            if hasattr(self.adata, "uns") and "spatial" in self.adata.uns and "is_single" in self.adata.uns["spatial"]
+            else None
+        )
+
     def _is_supported_spatial_assay(self) -> bool:
         """
         Determine if the assay_ontology_term_id is either Visium (EFO:0010961) or Slide-seqV2 (EFO:0030062).
@@ -90,10 +103,7 @@ class Validator:
         :rtype bool
         """
         if self.is_visium_and_is_single_true is None:
-            try:
-                self.is_visium_and_is_single_true = self._is_visium() and self.adata.uns["spatial"]["is_single"]
-            except AttributeError:
-                self.is_visium_and_is_single_true = False
+            self.is_visium_and_is_single_true = self._is_visium() and (self._is_single() or False)
         return self.is_visium_and_is_single_true
 
     def _validate_encoding_version(self):
@@ -1038,11 +1048,7 @@ class Validator:
         if self._is_supported_spatial_assay() is False and obsm_with_x_prefix == 0:
             self.errors.append("At least one embedding in 'obsm' has to have a key with an 'X_' prefix.")
 
-        is_single = (
-            self.adata.uns["spatial"]["is_single"]
-            if "spatial" in self.adata.uns and "is_single" in self.adata.uns["spatial"]
-            else None
-        )
+        is_single = self._is_single()
         has_spatial_embedding = "spatial" in self.adata.obsm
         if is_single and not has_spatial_embedding:
             self.errors.append(
@@ -1371,12 +1377,6 @@ class Validator:
         if obs_component is None:
             return
 
-        # obs spatial validation is dependent on uns.spatial.is_single; exit if not specified. Errors are
-        # reported downstream.
-        uns_component = getattr_anndata(self.adata, "uns")
-        if uns_component is None or "spatial" not in uns_component or "is_single" not in uns_component["spatial"]:
-            return
-
         # Validate tissue positions.
         self._validate_spatial_tissue_position("array_col", 0, 127)
         self._validate_spatial_tissue_position("array_row", 0, 77)
@@ -1390,10 +1390,10 @@ class Validator:
         :rtype none
         """
         # Tissue position is foribidden if assay is not Visium and is_single is True.
-        if (
-            tissue_position_name in self.adata.obs
-            and (
-                ~((self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM) & (self.adata.uns["spatial"]["is_single"]))
+        if tissue_position_name in self.adata.obs and (
+            not self._is_supported_spatial_assay
+            or (
+                ~((self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM) & ((self._is_single() or False)))
                 & (self.adata.obs[tissue_position_name].notnull())
             ).any()
         ):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1391,9 +1391,9 @@ class Validator:
         """
         # Tissue position is foribidden if assay is not Visium and is_single is True.
         if tissue_position_name in self.adata.obs and (
-            not self._is_supported_spatial_assay
+            not self._is_visium_and_is_single_true()
             or (
-                ~((self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM) & ((self._is_single() or False)))
+                ~(self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM)
                 & (self.adata.obs[tissue_position_name].notnull())
             ).any()
         ):

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -129,6 +129,8 @@ obs_expected["observation_joinid"] = get_hash_digest_column(obs_expected)
 good_obs_visium = pd.DataFrame(
     [
         [
+            1,
+            1,
             "CL:0000066",
             "EFO:0010961",
             "MONDO:0100096",
@@ -141,8 +143,11 @@ good_obs_visium = pd.DataFrame(
             "HsapDv:0000003",
             "donor_1",
             "na",
+            0,
         ],
         [
+            2,
+            2,
             "CL:0000192",
             "EFO:0010961",
             "PATO:0000461",
@@ -155,10 +160,13 @@ good_obs_visium = pd.DataFrame(
             "MmusDv:0000003",
             "donor_2",
             "na",
+            1,
         ],
     ],
     index=["X", "Y"],
     columns=[
+        "array_col",
+        "array_row",
         "cell_type_ontology_term_id",
         "assay_ontology_term_id",
         "disease_ontology_term_id",
@@ -171,6 +179,7 @@ good_obs_visium = pd.DataFrame(
         "development_stage_ontology_term_id",
         "donor_id",
         "suspension_type",
+        "in_tissue",
     ],
 )
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2029,12 +2029,20 @@ class TestObsm:
         validator = validator_with_visium_assay
         validator.adata.uns["spatial"] = {"is_single": False}
         del validator.adata.obsm["spatial"]
+        # Format adata.obs into valid shape for Visium and is_single False.
+        validator.adata.obs.pop("array_col")
+        validator.adata.obs.pop("array_row")
+        validator.adata.obs.pop("in_tissue")
         validator.validate_adata()
         assert validator.errors == []
 
     def test_obsm_values_spatial_embedding_present__is_single_false(self, validator_with_visium_assay):
         validator = validator_with_visium_assay
         validator.adata.uns["spatial"] = {"is_single": False}
+        # Format adata.obs into valid shape for Visium and is_single False.
+        validator.adata.obs.pop("array_col")
+        validator.adata.obs.pop("array_row")
+        validator.adata.obs.pop("in_tissue")
         validator.validate_adata()
         assert validator.errors == []
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1994,21 +1994,22 @@ class TestObsm:
         ]
 
     @pytest.mark.parametrize(
-        "assay_ontology_term_id, uns_spatial",
+        "assay_ontology_term_id, adata_spatial",
         [
-            ("EFO:0010961", examples.good_uns_with_visium_spatial["spatial"]),
-            ("EFO:0030062", examples.good_uns_with_slide_seqV2_spatial["spatial"]),
+            ("EFO:0010961", examples.adata_visium),
+            ("EFO:0030062", examples.adata_slide_seqv2),
         ],
     )
     def test_obsm_values_no_X_embedding__spatial_dataset(
-        self, validator_with_adata, assay_ontology_term_id, uns_spatial
+        self, validator_with_adata, assay_ontology_term_id, adata_spatial
     ):
         validator = validator_with_adata
         validator.adata.obsm["harmony"] = validator.adata.obsm["X_umap"]
+        validator.adata.uns = adata_spatial.uns
         validator.adata.uns["default_embedding"] = "harmony"
-        validator.adata.uns["spatial"] = uns_spatial
         validator.adata.obsm["spatial"] = validator.adata.obsm["X_umap"]
         del validator.adata.obsm["X_umap"]
+        validator.adata.obs = adata_spatial.obs
         validator.adata.obs["assay_ontology_term_id"] = assay_ontology_term_id
         validator.adata.obs["suspension_type"] = "na"
         validator.adata.obs.loc[:, ["suspension_type"]] = validator.adata.obs.astype("category")

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -439,7 +439,7 @@ class TestCheckSpatial:
             in validator.errors[0]
         )
 
-    def test__validate_library_id_forbidden_if_visium_or_is_single_false(self):
+    def test__validate_library_id_forbidden_if_visium_and_is_single_false(self):
         validator: Validator = Validator()
         validator._set_schema_def()
 

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -689,8 +689,8 @@ class TestCheckSpatial:
     @pytest.mark.parametrize(
         "assay_ontology_term_id, is_single",
         [
-            (["EFO:0010961", "EFO:0030062"], [True, True]),
-            (["EFO:0010961", "EFO:0030062"], [False, True]),
+            (["EFO:0010961", "EFO:0030062"], True),
+            (["EFO:0010961", "EFO:0030062"], False),
             ("EFO:0010961", False),
             ("EFO:0030062", True),
             ("EFO:0030062", False),

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -689,32 +689,15 @@ class TestCheckSpatial:
             in validator.errors[0]
         )
 
-    def test__validate_tissue_position_forbidden_if_not_visium(self):
+    @pytest.mark.parametrize("assay_ontology_term_id, is_single", [("EFO:0030062", False), ("EFO:0010961", False)])
+    def test__validate_tissue_position_forbidden(self, assay_ontology_term_id, is_single):
         validator: Validator = Validator()
         validator._set_schema_def()
 
-        # Create Visium adata (with spatial) with 10x 3' v2 obs.
+        # Create Visium adata with tissue positions, update assay_ontology_term_id and is_single to trigger error.
         validator.adata = adata_visium.copy()
-        validator.adata.obs.assay_ontology_term_id = "EFO:0009899"
-
-        # Confirm tissue positions are not allowed for 10x 3' v2.
-        validator._check_spatial_obs()
-        assert len(validator.errors) == 3
-        tissue_position_names = ["array_col", "array_row", "in_tissue"]
-        for i, tissue_position_name in enumerate(tissue_position_names):
-            assert (
-                f"obs['{tissue_position_name}'] is only allowed for obs['assay_ontology_term_id'] "
-                "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
-                in validator.errors[i]
-            )
-
-    def test__validate_tissue_position_forbidden_if_not_visium_and_is_single_false(self):
-        validator: Validator = Validator()
-        validator._set_schema_def()
-
-        # Create Visium adata (with spatial) with is_single false.
-        validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"]["is_single"] = False
+        validator.adata.obs.assay_ontology_term_id = assay_ontology_term_id
+        validator.adata.uns["spatial"]["is_single"] = is_single
 
         # Confirm tissue positions are not allowed.
         validator._check_spatial_obs()

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -694,6 +694,9 @@ class TestCheckSpatial:
             ("EFO:0010961", False),
             ("EFO:0030062", True),
             ("EFO:0030062", False),
+            ("EFO:0030062", False),
+            ("EFO:0009899", True),  # Non-spatial
+            ("EFO:0009899", False),  #  Non-spatial
         ],
     )
     def test__validate_tissue_position_forbidden(self, assay_ontology_term_id, is_single):

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -464,11 +464,7 @@ class TestValidate:
         validator._check_spatial()
         assert validator.errors
         assert (
-<<<<<<< HEAD
             "uns['spatial'] must contain at least one key representing the library_id when obs['assay_ontology_term_id'] "
-=======
-            "uns['spatial'] must contain the key 'library_id' for obs['assay_ontology_term_id'] "
->>>>>>> 76c80db (Updated error messages)
             "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             in validator.errors[0]
         )

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -10,7 +10,13 @@ import pandas as pd
 import pytest
 from cellxgene_ontology_guide.entities import Ontology
 from cellxgene_schema.schema import get_schema_definition
-from cellxgene_schema.validate import Validator, validate
+from cellxgene_schema.validate import (
+    ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE,
+    ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_FORBIDDEN,
+    ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_REQUIRED,
+    Validator,
+    validate,
+)
 from cellxgene_schema.write_labels import AnnDataLabelAppender
 from fixtures.examples_validate import adata as adata_valid
 from fixtures.examples_validate import (
@@ -433,11 +439,7 @@ class TestCheckSpatial:
         # Confirm library_id is not allowed for Slide-seqV2.
         validator._check_spatial_uns()
         assert len(validator.errors) == 1
-        assert (
-            "uns['spatial'][library_id] is only allowed for obs['assay_ontology_term_id'] "
-            "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
-            in validator.errors[0]
-        )
+        assert f"uns['spatial'][library_id] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_FORBIDDEN}" in validator.errors[0]
 
     def test__validate_library_id_forbidden_if_visium_and_is_single_false(self):
         validator: Validator = Validator()
@@ -450,11 +452,7 @@ class TestCheckSpatial:
         # Confirm library_id is not allowed for Visium if is_single is False.
         validator._check_spatial_uns()
         assert len(validator.errors) == 1
-        assert (
-            "uns['spatial'][library_id] is only allowed for obs['assay_ontology_term_id'] "
-            "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
-            in validator.errors[0]
-        )
+        assert f"uns['spatial'][library_id] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_FORBIDDEN}" in validator.errors[0]
 
     def test__validate_library_id_required_if_visium(self):
         validator: Validator = Validator()
@@ -466,8 +464,7 @@ class TestCheckSpatial:
         validator._check_spatial_uns()
         assert validator.errors
         assert (
-            "uns['spatial'] must contain at least one key representing the library_id when obs['assay_ontology_term_id'] "
-            "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
+            f"uns['spatial'] must contain at least one key representing the library_id when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}"
             in validator.errors[0]
         )
 
@@ -707,8 +704,7 @@ class TestCheckSpatial:
         tissue_position_names = ["array_col", "array_row", "in_tissue"]
         for i, tissue_position_name in enumerate(tissue_position_names):
             assert (
-                f"obs['{tissue_position_name}'] is only allowed for obs['assay_ontology_term_id'] "
-                "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
+                f"obs['{tissue_position_name}'] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_FORBIDDEN}"
                 in validator.errors[i]
             )
 
@@ -721,10 +717,7 @@ class TestCheckSpatial:
 
         validator._check_spatial_obs()
         assert validator.errors
-        assert (
-            f"obs['{tissue_position_name}'] is required for obs['assay_ontology_term_id'] 'EFO:0010961' "
-            "(Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True." in validator.errors[0]
-        )
+        assert f"obs['{tissue_position_name}'] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_REQUIRED}" in validator.errors[0]
 
     @pytest.mark.parametrize("tissue_position_name", ["array_col", "array_row", "in_tissue"])
     def test__validate_tissue_position_int_error(self, tissue_position_name):

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -689,7 +689,9 @@ class TestCheckSpatial:
             in validator.errors[0]
         )
 
-    @pytest.mark.parametrize("assay_ontology_term_id, is_single", [("EFO:0030062", False), ("EFO:0010961", False)])
+    @pytest.mark.parametrize(
+        "assay_ontology_term_id, is_single", [("EFO:0030062", False), ("EFO:0010961", False), ("EFO:0030062", True)]
+    )
     def test__validate_tissue_position_forbidden(self, assay_ontology_term_id, is_single):
         validator: Validator = Validator()
         validator._set_schema_def()
@@ -721,7 +723,7 @@ class TestCheckSpatial:
         assert validator.errors
         assert (
             f"obs['{tissue_position_name}'] is required for obs['assay_ontology_term_id'] 'EFO:0010961' "
-            "(Visium Spatial Gene Expression) and uns['spatial']['is_single'] True." in validator.errors[0]
+            "(Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True." in validator.errors[0]
         )
 
     @pytest.mark.parametrize("tissue_position_name", ["array_col", "array_row", "in_tissue"])

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -464,7 +464,11 @@ class TestValidate:
         validator._check_spatial()
         assert validator.errors
         assert (
+<<<<<<< HEAD
             "uns['spatial'] must contain at least one key representing the library_id when obs['assay_ontology_term_id'] "
+=======
+            "uns['spatial'] must contain the key 'library_id' for obs['assay_ontology_term_id'] "
+>>>>>>> 76c80db (Updated error messages)
             "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
             in validator.errors[0]
         )

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -326,11 +326,11 @@ class TestCheckSpatial:
         validator.validate_adata()
         assert not validator.errors
 
-    def test__validate_spatial_forbidden_if_not_visium_and_is_single_false(self):
+    def test__validate_spatial_forbidden_if_not_visium_or_slide_seqv2(self):
         validator: Validator = Validator()
         validator._set_schema_def()
 
-        # Create Visium uns (with spatial) with 10x 3' v2 obs.
+        # Create Visium adata (with spatial) with 10x 3' v2 obs.
         validator.adata = adata_visium.copy()
         validator.adata.obs = good_obs.copy()
 
@@ -689,15 +689,34 @@ class TestCheckSpatial:
             in validator.errors[0]
         )
 
-    def test__validate_tissue_position_forbidden_if_not_visium_or_is_single_false(self):
+    def test__validate_tissue_position_forbidden_if_not_visium(self):
         validator: Validator = Validator()
         validator._set_schema_def()
 
-        # Create Visium uns (with spatial) with 10x 3' v2 obs.
+        # Create Visium adata (with spatial) with 10x 3' v2 obs.
         validator.adata = adata_visium.copy()
         validator.adata.obs.assay_ontology_term_id = "EFO:0009899"
 
-        # Confirm tissue positions are not allowed for not Visium and not is single.
+        # Confirm tissue positions are not allowed for 10x 3' v2.
+        validator._check_spatial_obs()
+        assert len(validator.errors) == 3
+        tissue_position_names = ["array_col", "array_row", "in_tissue"]
+        for i, tissue_position_name in enumerate(tissue_position_names):
+            assert (
+                f"obs['{tissue_position_name}'] is only allowed for obs['assay_ontology_term_id'] "
+                "'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
+                in validator.errors[i]
+            )
+
+    def test__validate_tissue_position_forbidden_if_not_visium_and_is_single_false(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+
+        # Create Visium adata (with spatial) with is_single false.
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"]["is_single"] = False
+
+        # Confirm tissue positions are not allowed.
         validator._check_spatial_obs()
         assert len(validator.errors) == 3
         tissue_position_names = ["array_col", "array_row", "in_tissue"]

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -687,7 +687,14 @@ class TestCheckSpatial:
         )
 
     @pytest.mark.parametrize(
-        "assay_ontology_term_id, is_single", [("EFO:0030062", False), ("EFO:0010961", False), ("EFO:0030062", True)]
+        "assay_ontology_term_id, is_single",
+        [
+            (["EFO:0010961", "EFO:0030062"], [True, True]),
+            (["EFO:0010961", "EFO:0030062"], [False, True]),
+            ("EFO:0010961", False),
+            ("EFO:0030062", True),
+            ("EFO:0030062", False),
+        ],
     )
     def test__validate_tissue_position_forbidden(self, assay_ontology_term_id, is_single):
         validator: Validator = Validator()
@@ -718,6 +725,16 @@ class TestCheckSpatial:
         validator._check_spatial_obs()
         assert validator.errors
         assert f"obs['{tissue_position_name}'] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_REQUIRED}" in validator.errors[0]
+
+    def test__validate_tissue_position_not_required(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_slide_seqv2.copy()
+        validator.adata.obs["assay_ontology_term_id"] = ["EFO:0010961", "EFO:0030062"]
+        validator.adata.uns["spatial"]["is_single"] = False
+
+        validator._check_spatial_obs()
+        assert not validator.errors
 
     @pytest.mark.parametrize("tissue_position_name", ["array_col", "array_row", "in_tissue"])
     def test__validate_tissue_position_int_error(self, tissue_position_name):


### PR DESCRIPTION
## Reason for Change

- #829 

## Changes

- Updated `_check_spatial` to sequence spatial-specific checks.
- Moved existing `_check_spatial` functionality to `_check_spatial_uns`.
- Added `_check_spatial_obs`. 

## Testing

- Added unit tests.
- Tested with 5.1.0 datasets.