### PR TITLE
feat: cellxgene-schema CLI must add validation for obsm['spatial']

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -980,13 +980,14 @@ class Validator:
                     self.errors.append(
                         f"Suffix for embedding key in 'adata.obsm' {key} does not match the regex pattern {regex_pattern}."
                     )
-            else:
+            elif key.lower() != "spatial":
                 if not re.match(regex_pattern, key):
                     self.errors.append(
                         f"Embedding key in 'adata.obsm' {key} does not match the regex pattern {regex_pattern}."
                     )
                 self.warnings.append(
-                    f"Embedding key in 'adata.obsm' {key} does not start with X_ and thus will not be available in Explorer"
+                    f"Embedding key in 'adata.obsm' {key} is not 'spatial' nor does it start with 'X_'. Thus, it will "
+                    f"not be available in Explorer"
                 )
                 issue_list = self.warnings
 
@@ -1016,6 +1017,15 @@ class Validator:
 
         if self._is_supported_spatial_assay() is False and obsm_with_x_prefix == 0:
             self.errors.append("At least one embedding in 'obsm' has to have a key with an 'X_' prefix.")
+
+        is_single = self.adata.uns["spatial"]["is_single"] if "spatial" in self.adata.uns and "is_single" in self.adata.uns["spatial"] else None
+        has_spatial_embedding = "spatial" in self.adata.obsm
+        if is_single and not has_spatial_embedding:
+            self.errors.append("'spatial' embedding is required in 'adata.obsm' if "
+                               "adata.uns['spatial']['is_single'] is True.")
+        elif is_single is None and has_spatial_embedding:
+            self.errors.append("'spatial' embedding is forbidden in 'adata.obsm' if "
+                               "adata.uns['spatial']['is_single'] is not set.")
 
     def _validate_annotation_mapping(self, component_name: str, component: Mapping):
         for key, value in component.items():

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1018,14 +1018,20 @@ class Validator:
         if self._is_supported_spatial_assay() is False and obsm_with_x_prefix == 0:
             self.errors.append("At least one embedding in 'obsm' has to have a key with an 'X_' prefix.")
 
-        is_single = self.adata.uns["spatial"]["is_single"] if "spatial" in self.adata.uns and "is_single" in self.adata.uns["spatial"] else None
+        is_single = (
+            self.adata.uns["spatial"]["is_single"]
+            if "spatial" in self.adata.uns and "is_single" in self.adata.uns["spatial"]
+            else None
+        )
         has_spatial_embedding = "spatial" in self.adata.obsm
         if is_single and not has_spatial_embedding:
-            self.errors.append("'spatial' embedding is required in 'adata.obsm' if "
-                               "adata.uns['spatial']['is_single'] is True.")
+            self.errors.append(
+                "'spatial' embedding is required in 'adata.obsm' if " "adata.uns['spatial']['is_single'] is True."
+            )
         elif is_single is None and has_spatial_embedding:
-            self.errors.append("'spatial' embedding is forbidden in 'adata.obsm' if "
-                               "adata.uns['spatial']['is_single'] is not set.")
+            self.errors.append(
+                "'spatial' embedding is forbidden in 'adata.obsm' if " "adata.uns['spatial']['is_single'] is not set."
+            )
 
     def _validate_annotation_mapping(self, component_name: str, component: Mapping):
         for key, value in component.items():

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -140,7 +140,7 @@ good_obs_visium = pd.DataFrame(
             "HANCESTRO:0575",
             "HsapDv:0000003",
             "donor_1",
-            "nucleus",
+            "na",
         ],
         [
             "CL:0000192",
@@ -193,7 +193,7 @@ good_obs_slide_seqv2 = pd.DataFrame(
             "HANCESTRO:0575",
             "HsapDv:0000003",
             "donor_1",
-            "nucleus",
+            "na",
         ],
         [
             "CL:0000192",
@@ -336,7 +336,7 @@ non_raw_X[0, 0] = 1.5
 # ---
 # 5.Creating valid obsm
 good_obsm = {"X_umap": numpy.zeros([X.shape[0], 2])}
-
+good_obsm_spatial = {"X_umap": numpy.zeros([X.shape[0], 2]), "spatial": numpy.zeros([X.shape[0], 2])}
 
 # ---
 # 6. Putting all the components created in the previous steps into minimal anndata that used for testing in
@@ -387,7 +387,7 @@ adata_with_colors = anndata.AnnData(
 
 # Expected anndata with Visium spatial data
 adata_visium = anndata.AnnData(
-    X=sparse.csr_matrix(X), obs=good_obs_visium, uns=good_uns_with_visium_spatial, obsm=good_obsm, var=good_var
+    X=sparse.csr_matrix(X), obs=good_obs_visium, uns=good_uns_with_visium_spatial, obsm=good_obsm_spatial, var=good_var
 )
 
 # Expected anndata with Slide-seqV2 spatial data
@@ -395,7 +395,7 @@ adata_slide_seqv2 = anndata.AnnData(
     X=sparse.csr_matrix(X),
     obs=good_obs_slide_seqv2,
     uns=good_uns_with_slide_seqV2_spatial,
-    obsm=good_obsm,
+    obsm=good_obsm_spatial,
     var=good_var,
 )
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -74,6 +74,7 @@ def validator_with_slide_seq_v2_assay(validator) -> Validator:
     validator.adata = examples.adata_slide_seqv2.copy()
     return validator
 
+
 @pytest.fixture
 def label_writer(validator_with_validated_adata) -> AnnDataLabelAppender:
     """
@@ -2040,8 +2041,10 @@ class TestObsm:
         validator = validator_with_adata
         validator.adata.obsm["spatial"] = validator.adata.obsm["X_umap"]
         validator.validate_adata()
-        assert validator.errors == ["ERROR: 'spatial' embedding is forbidden in 'adata.obsm' if "
-                                    "adata.uns['spatial']['is_single'] is not set."]
+        assert validator.errors == [
+            "ERROR: 'spatial' embedding is forbidden in 'adata.obsm' if "
+            "adata.uns['spatial']['is_single'] is not set."
+        ]
 
     def test_obsm_values_warn_start_with_X(self, validator_with_adata):
         validator = validator_with_adata

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -64,6 +64,17 @@ def validator_with_adata_missing_raw(validator) -> Validator:
 
 
 @pytest.fixture
+def validator_with_visium_assay(validator) -> Validator:
+    validator.adata = examples.adata_visium.copy()
+    return validator
+
+
+@pytest.fixture
+def validator_with_slide_seq_v2_assay(validator) -> Validator:
+    validator.adata = examples.adata_slide_seqv2.copy()
+    return validator
+
+@pytest.fixture
 def label_writer(validator_with_validated_adata) -> AnnDataLabelAppender:
     """
     Fixture that returns an AnnDataLabelAppender object
@@ -1905,60 +1916,64 @@ class TestObsm:
     Fail cases for adata.obsm
     """
 
-    def test_obsm_values_ara_numpy(self, validator_with_adata):
+    @pytest.mark.parametrize("key", ["X_tsne", "spatial"])
+    def test_obsm_values_ara_numpy(self, validator_with_visium_assay, key):
         """
         values in obsm MUST be a numpy.ndarray
         """
-        validator = validator_with_adata
+        validator = validator_with_visium_assay
         obsm = validator.adata.obsm
-        obsm["X_tsne"] = pd.DataFrame(obsm["X_umap"], index=validator.adata.obs_names)
+        obsm[key] = pd.DataFrame(obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: All embeddings have to be of 'numpy.ndarray' type, "
-            "'adata.obsm['X_tsne']' is <class 'pandas.core.frame.DataFrame'>')."
+            f"'adata.obsm['{key}']' is <class 'pandas.core.frame.DataFrame'>')."
         ]
 
-    def test_obsm_values_infinity(self, validator_with_adata):
+    @pytest.mark.parametrize("key", ["X_umap", "spatial"])
+    def test_obsm_values_infinity(self, validator_with_visium_assay, key):
         """
         values in obsm cannot have any infinity values
         """
-        validator = validator_with_adata
-        validator.adata.obsm["X_umap"][0:100, 1] = numpy.inf
+        validator = validator_with_visium_assay
+        validator.adata.obsm[key][0:100, 1] = numpy.inf
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: adata.obsm['X_umap'] contains positive infinity or negative infinity values."
+            f"ERROR: adata.obsm['{key}'] contains positive infinity or negative infinity values."
         ]
 
-    def test_obsm_values_str(self, validator_with_adata):
+    @pytest.mark.parametrize("key", ["X_umap", "spatial"])
+    def test_obsm_values_str(self, validator_with_visium_assay, key):
         """
         values in obsm must be numerical types, strings are not valid
         """
-        validator = validator_with_adata
+        validator = validator_with_visium_assay
         obsm = validator.adata.obsm
-        all_string = numpy.full(obsm["X_umap"].shape, "test")
-        obsm["X_umap"] = all_string
+        all_string = numpy.full(obsm[key].shape, "test")
+        obsm[key] = all_string
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: adata.obsm['X_umap'] has an invalid data type. It should be float, integer, or unsigned "
+            f"ERROR: adata.obsm['{key}'] has an invalid data type. It should be float, integer, or unsigned "
             "integer of any precision (8, 16, 32, or 64 bits)."
         ]
 
-    def test_obsm_values_nan(self, validator_with_adata):
+    @pytest.mark.parametrize("key", ["X_umap", "spatial"])
+    def test_obsm_values_nan(self, validator_with_visium_assay, key):
         """
         values in obsm cannot all be NaN
         """
-        validator = validator_with_adata
+        validator = validator_with_visium_assay
         obsm = validator.adata.obsm
         # It's okay if only one value is NaN
-        obsm["X_umap"][0:100, 1] = numpy.nan
+        obsm[key][0:100, 1] = numpy.nan
         validator.validate_adata()
         assert validator.errors == []
 
         # It's not okay if all values are NaN
-        all_nan = numpy.full(obsm["X_umap"].shape, numpy.nan)
-        obsm["X_umap"] = all_nan
+        all_nan = numpy.full(obsm[key].shape, numpy.nan)
+        obsm[key] = all_nan
         validator.validate_adata()
-        assert validator.errors == ["ERROR: adata.obsm['X_umap'] contains all NaN values."]
+        assert validator.errors == [f"ERROR: adata.obsm['{key}'] contains all NaN values."]
 
     def test_obsm_values_no_X_embedding__non_spatial_dataset(self, validator_with_adata):
         validator = validator_with_adata
@@ -1972,7 +1987,8 @@ class TestObsm:
         assert validator.is_spatial is False
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
+            "WARNING: Embedding key in 'adata.obsm' harmony is not 'spatial' nor does it start with 'X_'. "
+            "Thus, it will not be available in Explorer",
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
 
@@ -1990,6 +2006,7 @@ class TestObsm:
         validator.adata.obsm["harmony"] = validator.adata.obsm["X_umap"]
         validator.adata.uns["default_embedding"] = "harmony"
         validator.adata.uns["spatial"] = uns_spatial
+        validator.adata.obsm["spatial"] = validator.adata.obsm["X_umap"]
         del validator.adata.obsm["X_umap"]
         validator.adata.obs["assay_ontology_term_id"] = assay_ontology_term_id
         validator.adata.obs["suspension_type"] = "na"
@@ -1998,13 +2015,42 @@ class TestObsm:
         assert validator.errors == []
         assert validator.is_spatial is True
 
+    def test_obsm_values_spatial_embedding_missing__is_single_true(self, validator_with_visium_assay):
+        validator = validator_with_visium_assay
+        del validator.adata.obsm["spatial"]
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: 'spatial' embedding is required in 'adata.obsm' if adata.uns['spatial']['is_single'] is True."
+        ]
+
+    def test_obsm_values_spatial_embedding_missing__is_single_false(self, validator_with_visium_assay):
+        validator = validator_with_visium_assay
+        validator.adata.uns["spatial"] = {"is_single": False}
+        del validator.adata.obsm["spatial"]
+        validator.validate_adata()
+        assert validator.errors == []
+
+    def test_obsm_values_spatial_embedding_present__is_single_false(self, validator_with_visium_assay):
+        validator = validator_with_visium_assay
+        validator.adata.uns["spatial"] = {"is_single": False}
+        validator.validate_adata()
+        assert validator.errors == []
+
+    def test_obsm_values_spatial_embedding_present__is_single_none(self, validator_with_adata):
+        validator = validator_with_adata
+        validator.adata.obsm["spatial"] = validator.adata.obsm["X_umap"]
+        validator.validate_adata()
+        assert validator.errors == ["ERROR: 'spatial' embedding is forbidden in 'adata.obsm' if "
+                                    "adata.uns['spatial']['is_single'] is not set."]
+
     def test_obsm_values_warn_start_with_X(self, validator_with_adata):
         validator = validator_with_adata
         validator.adata.obsm["harmony"] = pd.DataFrame(validator.adata.obsm["X_umap"], index=validator.adata.obs_names)
         validator.validate_adata()
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' harmony does not start with X_ and thus will not be available in Explorer",
+            "WARNING: Embedding key in 'adata.obsm' harmony is not 'spatial' nor does it start with 'X_'. "
+            "Thus, it will not be available in Explorer",
             "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['harmony']' is <class 'pandas.core.frame.DataFrame'>').",
         ]
 
@@ -2032,7 +2078,8 @@ class TestObsm:
         ]
         assert validator.warnings == [
             "WARNING: Dataframe 'var' only has 4 rows. Features SHOULD NOT be filtered from expression matrix.",
-            "WARNING: Embedding key in 'adata.obsm' 3D does not start with X_ and thus will not be available in Explorer",
+            "WARNING: Embedding key in 'adata.obsm' 3D is not 'spatial' nor does it start with 'X_'. "
+            "Thus, it will not be available in Explorer",
             "WARNING: All embeddings have to be of 'numpy.ndarray' type, 'adata.obsm['3D']' is <class 'pandas.core.frame.DataFrame'>').",
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
@@ -2073,17 +2120,18 @@ class TestObsm:
         validator.validate_adata()
         assert validator.errors == []
 
-    def test_obsm_shape_one_column(self, validator_with_adata):
+    @pytest.mark.parametrize("key", ["X_umap", "spatial"])
+    def test_obsm_shape_one_column(self, validator_with_visium_assay, key):
         """
         Curators MUST annotate one or more two-dimensional (m >= 2) embeddings
         """
         # Makes 1 column array
-        validator = validator_with_adata
-        validator.adata.obsm["X_umap"] = numpy.delete(validator.adata.obsm["X_umap"], 0, 1)
+        validator = validator_with_visium_assay
+        validator.adata.obsm[key] = numpy.delete(validator.adata.obsm[key], 0, 1)
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: All embeddings must have as many rows as cells, and "
-            "at least two columns. 'adata.obsm['X_umap']' has shape "
+            f"at least two columns. 'adata.obsm['{key}']' has shape "
             "of '(2, 1)'."
         ]
 

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -312,7 +312,7 @@ class TestValidate:
         validator.adata = adata_visium.copy()
 
         # Confirm spatial is valid.
-        validator._check_spatial()
+        validator.validate_adata()
         assert not validator.errors
 
     def test__validate_spatial_slide_seqV2_ok(self):
@@ -321,7 +321,7 @@ class TestValidate:
         validator.adata = adata_slide_seqv2.copy()
 
         # Confirm spatial is valid.
-        validator._check_spatial()
+        validator.validate_adata()
         assert not validator.errors
 
     def test__validate_spatial_forbidden_if_10x(self):


### PR DESCRIPTION
## Reason for Change

- #806 

## Changes

- Update validate_obsm to account for new obsm['spatial'] embedding rules (see ticket)
- validating value of 'spatial' embedding is already covered by existing code in validate_obsm because they mirror validation for X_{suffix} embeddings; just had to add an elif conditional to make sure the checks are marked as 'error' if they fail, rather than 'warning' (previous behavior for non-X prefixed embeddings). Updated tests for these checks to pass in "spatial" as well as "X_{suffix}" to ensure coverage
- Update warning msg in validate_obsm about obsm embeddings without the "X_" prefix not appearing in Explorer. "spatial" embedding key WILL appear in Explorer despite not having an X_ prefix. So far, this is the only supported case for non X_ prefixed obsm embedding keys appearing in Explorer
- Update test_validate tests for adata_with_visium and adata_with_slide_seq_v2 to test validating the entire adata, not just the spatial rules. test_validate has historically been used for end-to-end adata validation testing, and test_schema_compliance for testing specific subsetted error cases. Does not require adding new tests, since the success case of validating the full adata will also cover the success case of validating spatial rules. 

## Notes for Reviewer
- Confirmation from Brian R in Slack that 'spatial' embedding key WILL be reflected in Explorer, despite not starting with "X_"