### PR TITLE
fix(5.1.0): type check for spatial and nested values

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -75,7 +75,10 @@ class Validator:
         """
         return (
             self.adata.uns["spatial"]["is_single"]
-            if hasattr(self.adata, "uns") and "spatial" in self.adata.uns and "is_single" in self.adata.uns["spatial"]
+            if hasattr(self.adata, "uns")
+            and "spatial" in self.adata.uns
+            and self.adata.uns["spatial"]
+            and "is_single" in self.adata.uns["spatial"]
             else None
         )
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -81,7 +81,7 @@ class Validator:
             self.adata.uns["spatial"]["is_single"]
             if hasattr(self.adata, "uns")
             and "spatial" in self.adata.uns
-            and self.adata.uns["spatial"]
+            and isinstance(self.adata.uns["spatial"], dict)
             and "is_single" in self.adata.uns["spatial"]
             else None
         )

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1508,9 +1508,9 @@ class Validator:
             return
 
         # spatial is required for supported spatial assays.
-        if uns_spatial is None:
+        if not isinstance(uns_spatial, dict):
             self.errors.append(
-                "uns['spatial'] is required for obs['assay_ontology_term_id'] values "
+                "A dict in uns['spatial'] is required for obs['assay_ontology_term_id'] values "
                 "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)."
             )
             return
@@ -1571,9 +1571,12 @@ class Validator:
         if "images" not in uns_library_id:
             self.errors.append("uns['spatial'][library_id] must contain the key 'images'.")
         # images is specified: proceed with validation of images.
+        elif not isinstance(uns_library_id["images"], dict):
+            self.errors.append("uns['spatial'][library_id]['images'] must be a dictionary.")
         else:
             # Confirm shape of images is valid: allowed keys are fullres and hires.
             uns_images = uns_library_id["images"]
+
             if not self._has_no_extra_keys(uns_images, ["fullres", "hires"]):
                 self.errors.append(
                     "uns['spatial'][library_id]['images'] can only contain the keys 'fullres' and 'hires'."
@@ -1602,6 +1605,8 @@ class Validator:
         if "scalefactors" not in uns_library_id:
             self.errors.append("uns['spatial'][library_id] must contain the key 'scalefactors'.")
         # scalefactors is specified: proceed with validation of scalefactors.
+        elif not isinstance(uns_library_id["scalefactors"], dict):
+            self.errors.append("uns['spatial'][library_id]['scalefactors'] must be a dictionary.")
         else:
             # Confirm shape of scalefactors is valid: allowed keys are spot_diameter_fullres and tissue_hires_scalef.
             uns_scalefactors = uns_library_id["scalefactors"]

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -361,7 +361,7 @@ class TestCheckSpatial:
         validator.validate_adata()
         assert not validator.errors
 
-    @pytest.mark.parametrize("spatial", [None, "invalid"])
+    @pytest.mark.parametrize("spatial", [None, "invalid", 1, 1.0, True])
     def test__validate_spatial_type_error(self, spatial):
         validator: Validator = Validator()
         validator._set_schema_def()

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -334,6 +334,20 @@ class TestCheckSpatial:
         validator.validate_adata()
         assert not validator.errors
 
+    def test__validate_spatial_type_error(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"] = "invalid"
+
+        # Confirm key type dict is required.
+        validator._check_spatial_uns()
+        assert validator.errors
+        assert (
+            "A dict in uns['spatial'] is required for obs['assay_ontology_term_id'] values 'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)."
+            in validator.errors[0]
+        )
+
     def test__validate_spatial_is_single_false_ok(self):
         validator: Validator = Validator()
         validator._set_schema_def()
@@ -369,7 +383,7 @@ class TestCheckSpatial:
         validator._check_spatial_uns()
         assert len(validator.errors) == 1
         assert (
-            "uns['spatial'] is required for obs['assay_ontology_term_id'] values "
+            "A dict in uns['spatial'] is required for obs['assay_ontology_term_id'] values "
             "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)." in validator.errors[0]
         )
 
@@ -383,7 +397,7 @@ class TestCheckSpatial:
         validator._check_spatial_uns()
         assert len(validator.errors) == 1
         assert (
-            "uns['spatial'] is required for obs['assay_ontology_term_id'] values "
+            "A dict in uns['spatial'] is required for obs['assay_ontology_term_id'] values "
             "'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)." in validator.errors[0]
         )
 
@@ -696,6 +710,18 @@ class TestCheckSpatial:
             "uns['spatial'][library_id]['scalefactors']['tissue_hires_scalef'] must be of type float"
             in validator.errors[0]
         )
+
+    @pytest.mark.parametrize("key", ["scalefactors", "images"])
+    def test__validate_library_id_key_value_type_error(self, key):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id][key] = "invalid"
+
+        # Confirm key type dict is required.
+        validator._check_spatial_uns()
+        assert validator.errors
+        assert f"uns['spatial'][library_id]['{key}'] must be a dictionary." in validator.errors[0]
 
     @pytest.mark.parametrize(
         "assay_ontology_term_id, is_single",

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -334,14 +334,15 @@ class TestCheckSpatial:
         validator.validate_adata()
         assert not validator.errors
 
-    def test__validate_spatial_type_error(self):
+    @pytest.mark.parametrize("spatial", [None, "invalid"])
+    def test__validate_spatial_type_error(self, spatial):
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"] = "invalid"
+        validator.adata.uns["spatial"] = spatial
 
         # Confirm key type dict is required.
-        validator._check_spatial_uns()
+        validator.validate_adata()
         assert validator.errors
         assert (
             "A dict in uns['spatial'] is required for obs['assay_ontology_term_id'] values 'EFO:0010961' (Visium Spatial Gene Expression) and 'EFO:0030062' (Slide-seqV2)."


### PR DESCRIPTION
## Reason for Change

- #862

## Changes

- assert the `uns['spatial]`, `uns['spatial'][library_id]["scalefactors"]`, and `uns['spatial'][library_id]["images"]` or type `dict`.

## Testing

- updated tests cases with new error messages and added additional test cases to verify new functionality.


## Notes for Reviewer