### PR TITLE
feat: update X matrix validation to validate Visium assays

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1188,9 +1188,8 @@ class Validator:
                 elif not all(np.apply_along_axis(np.any, axis=1, arr=matrix_chunk)):
                     has_row_of_zeros = True
 
-            if not has_invalid_nonzero_value:
-                if self._matrix_has_invalid_nonzero_values(matrix_chunk):
-                    has_invalid_nonzero_value = True
+            if not has_invalid_nonzero_value and self._matrix_has_invalid_nonzero_values(matrix_chunk):
+                has_invalid_nonzero_value = True
 
             if has_row_of_zeros and has_invalid_nonzero_value:
                 # Fail fast, exit loop and report

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -159,7 +159,7 @@ class Validator:
             return self._get_component_def(component)["columns"][column_name]
 
     def _has_forbidden_curie_ancestor(
-            self, term_id: str, column_name: str, forbidden_def: Dict[str, List[str]]
+        self, term_id: str, column_name: str, forbidden_def: Dict[str, List[str]]
     ) -> bool:
         """
         Validate if a single curie term id is a descendant term of any forbidden ancestors.
@@ -182,10 +182,10 @@ class Validator:
         return False
 
     def _validate_curie_ancestors(
-            self,
-            term_id: str,
-            allowed_ancestors: Dict[str, List[str]],
-            inclusive: bool = False,
+        self,
+        term_id: str,
+        allowed_ancestors: Dict[str, List[str]],
+        inclusive: bool = False,
     ) -> bool:
         """
         Validate a single curie term id is a valid descendant of any allowed ancestors
@@ -281,9 +281,9 @@ class Validator:
             for term_id in term_ids:
                 self._validate_curie(term_id, column_name, curie_constraints)
             if (
-                    curie_constraints["multi_term"].get("sorted", False)
-                    and len(term_ids) > 1
-                    and not all(term_ids[i].strip() <= term_ids[i + 1].strip() for i in range(len(term_ids) - 1))
+                curie_constraints["multi_term"].get("sorted", False)
+                and len(term_ids) > 1
+                and not all(term_ids[i].strip() <= term_ids[i + 1].strip() for i in range(len(term_ids) - 1))
             ):
                 self.errors.append(f"'{term_str}' in '{column_name}' is not in ascending lexical order.")
             if len(set(term_ids)) != len(term_ids):
@@ -313,7 +313,7 @@ class Validator:
                 self.errors.append(f"'{term_id}' in '{column_name}' is not allowed.")
                 return
             if "ancestors" in curie_constraints["forbidden"] and self._has_forbidden_curie_ancestor(
-                    term_id, column_name, curie_constraints["forbidden"]["ancestors"]
+                term_id, column_name, curie_constraints["forbidden"]["ancestors"]
             ):
                 return
 
@@ -323,14 +323,14 @@ class Validator:
             if "terms" in curie_constraints["allowed"]:
                 for ontology_name, allow_list in curie_constraints["allowed"]["terms"].items():
                     if ONTOLOGY_PARSER.is_valid_term_id(term_id, ontology_name) and (
-                            allow_list == ["all"] or term_id in set(allow_list)
+                        allow_list == ["all"] or term_id in set(allow_list)
                     ):
                         is_allowed = True
                         break
             if (
-                    not is_allowed
-                    and "ancestors" in curie_constraints["allowed"]
-                    and self._validate_curie_ancestors(term_id, curie_constraints["allowed"]["ancestors"])
+                not is_allowed
+                and "ancestors" in curie_constraints["allowed"]
+                and self._validate_curie_ancestors(term_id, curie_constraints["allowed"]["ancestors"])
             ):
                 is_allowed = True
 
@@ -367,8 +367,8 @@ class Validator:
 
     @staticmethod
     def _chunk_matrix(
-            matrix: Union[np.ndarray, sparse.spmatrix],
-            obs_chunk_size: Optional[int] = 10_000,
+        matrix: Union[np.ndarray, sparse.spmatrix],
+        obs_chunk_size: Optional[int] = 10_000,
     ):
         """
         Iterator which chunks the _named_ or _specified_ matrix by the
@@ -523,7 +523,7 @@ class Validator:
                 self.errors[i] = self.errors[i] + " " + column_def["error_message_suffix"]
 
     def _validate_column_dependencies(
-            self, df: pd.DataFrame, df_name: str, column_name: str, dependencies: List[dict]
+        self, df: pd.DataFrame, df_name: str, column_name: str, dependencies: List[dict]
     ) -> pd.Series:
         """
         Validates subset of columns based on dependencies, for instance development_stage_ontology_term_id has
@@ -592,10 +592,10 @@ class Validator:
             ancestor_list.append(val)
 
         def is_ancestor_match(
-                term_id: str,
-                ontologies: List[str],
-                ancestors: List[str],
-                ancestor_inclusive: bool,
+            term_id: str,
+            ontologies: List[str],
+            ancestors: List[str],
+            ancestor_inclusive: bool,
         ) -> bool:
             allowed_ancestors = dict(zip(ontologies, ancestors))
             return validate_curie_ancestors_vectorized(term_id, allowed_ancestors, inclusive=ancestor_inclusive)
@@ -822,17 +822,17 @@ class Validator:
 
         for key, value in uns_dict.items():
             if any(
-                    isinstance(value, sparse_class)
-                    for sparse_class in (scipy.sparse.csr_matrix, scipy.sparse.csc_matrix, scipy.sparse.coo_matrix)
+                isinstance(value, sparse_class)
+                for sparse_class in (scipy.sparse.csr_matrix, scipy.sparse.csc_matrix, scipy.sparse.coo_matrix)
             ):
                 if value.nnz == 0:  # number non-zero
                     self.errors.append(f"uns['{key}'] cannot be an empty value.")
             elif (
-                    value is not None
-                    and not isinstance(value, numbers.Number)
-                    and type(value) is not bool
-                    and not (isinstance(value, (np.bool_, np.bool)))
-                    and len(value) == 0
+                value is not None
+                and not isinstance(value, numbers.Number)
+                and type(value) is not bool
+                and not (isinstance(value, (np.bool_, np.bool)))
+                and len(value) == 0
             ):
                 self.errors.append(f"uns['{key}'] cannot be an empty value.")
             if key.endswith("_colors"):
@@ -1151,15 +1151,17 @@ class Validator:
             is_visium_and_is_single_true = self._is_visium_and_is_single_true()
             if is_visium_and_is_single_true and x.shape[0] != self.visium_and_is_single_true_matrix_size:
                 self._raw_layer_exists = False
-                self.errors.append(f"When {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}, the raw matrix must be the "
-                                   f"unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
-                                   f"{self.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is "
-                                   f"{x.shape[0]}.")
+                self.errors.append(
+                    f"When {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}, the raw matrix must be the "
+                    f"unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
+                    f"{self.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is "
+                    f"{x.shape[0]}."
+                )
 
             if (
-                is_visium_and_is_single_true and
-                "in_tissue" in self.adata.obs and
-                0 in self.adata.obs["in_tissue"].values
+                is_visium_and_is_single_true
+                and "in_tissue" in self.adata.obs
+                and 0 in self.adata.obs["in_tissue"].values
             ):
                 self._validate_raw_data_with_in_tissue_0(x, is_sparse_matrix)
             else:
@@ -1199,9 +1201,7 @@ class Validator:
             self.errors.append("Each cell must have at least one non-zero value in its row in the raw matrix.")
         if has_invalid_nonzero_value:
             self._raw_layer_exists = False
-            self.errors.append(
-                "All non-zero values in raw matrix must be positive integers of type numpy.float32."
-            )
+            self.errors.append("All non-zero values in raw matrix must be positive integers of type numpy.float32.")
 
     def _validate_raw_data_with_in_tissue_0(self, x: Union[np.ndarray, sparse.spmatrix], is_sparse_matrix: bool):
         """
@@ -1218,17 +1218,9 @@ class Validator:
         else:  # must be dense matrix
             nonzero_row_indices = np.where(np.any(x != 0, axis=1))[0]
         for i in range(x.shape[0]):
-            if (
-                    not has_tissue_0_non_zero_row and
-                    i in nonzero_row_indices and
-                    self.adata.obs["in_tissue"][i] == 0
-            ):
+            if not has_tissue_0_non_zero_row and i in nonzero_row_indices and self.adata.obs["in_tissue"][i] == 0:
                 has_tissue_0_non_zero_row = True
-            elif (
-                    not has_tissue_1_zero_row and
-                    i not in nonzero_row_indices and
-                    self.adata.obs["in_tissue"][i] == 1
-            ):
+            elif not has_tissue_1_zero_row and i not in nonzero_row_indices and self.adata.obs["in_tissue"][i] == 1:
                 has_tissue_1_zero_row = True
             if has_tissue_0_non_zero_row and has_tissue_1_zero_row:
                 # exit early and report
@@ -1236,12 +1228,16 @@ class Validator:
 
         if not has_tissue_0_non_zero_row:
             self._raw_layer_exists = False
-            self.errors.append("If obs['in_tissue'] contains at least one value 0, then there must be at least "
-                               "one row with obs['in_tissue'] == 0 that has a non-zero value in the raw matrix.")
+            self.errors.append(
+                "If obs['in_tissue'] contains at least one value 0, then there must be at least "
+                "one row with obs['in_tissue'] == 0 that has a non-zero value in the raw matrix."
+            )
         if has_tissue_1_zero_row:
             self._raw_layer_exists = False
-            self.errors.append("Each observation with obs['in_tissue'] == 1 must have at least one "
-                               "non-zero value in its row in the raw matrix.")
+            self.errors.append(
+                "Each observation with obs['in_tissue'] == 1 must have at least one "
+                "non-zero value in its row in the raw matrix."
+            )
         if self._matrix_has_invalid_nonzero_values(x):
             self._raw_layer_exists = False
             self.errors.append("All non-zero values in raw matrix must be positive integers of type numpy.float32.")
@@ -1486,9 +1482,9 @@ class Validator:
 
         # Validate cell type: must be "unknown" if Visium and is_single is True and in_tissue is 0.
         if (
-                (self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM)
-                & (self.adata.obs["in_tissue"] == 0)
-                & (self.adata.obs["cell_type_ontology_term_id"] != "unknown")
+            (self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM)
+            & (self.adata.obs["in_tissue"] == 0)
+            & (self.adata.obs["cell_type_ontology_term_id"] != "unknown")
         ).any():
             self.errors.append(
                 f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}."
@@ -1503,11 +1499,11 @@ class Validator:
         """
         # Tissue position is foribidden if assay is not Visium and is_single is True.
         if tissue_position_name in self.adata.obs and (
-                not self._is_visium_and_is_single_true()
-                or (
-                        ~(self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM)
-                        & (self.adata.obs[tissue_position_name].notnull())
-                ).any()
+            not self._is_visium_and_is_single_true()
+            or (
+                ~(self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM)
+                & (self.adata.obs[tissue_position_name].notnull())
+            ).any()
         ):
             self.errors.append(f"obs['{tissue_position_name}'] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_FORBIDDEN}.")
             return
@@ -1520,11 +1516,11 @@ class Validator:
         # - there's at least one row with Visum, tissue position column is required
         # - for any Visium row, tissue position is required.
         if (
-                tissue_position_name not in self.adata.obs
-                or (
+            tissue_position_name not in self.adata.obs
+            or (
                 (self.adata.obs["assay_ontology_term_id"] == ASSAY_VISIUM)
                 & (self.adata.obs[tissue_position_name].isnull())
-        ).any()
+            ).any()
         ):
             self.errors.append(f"obs['{tissue_position_name}'] {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_REQUIRED}.")
             return
@@ -1893,10 +1889,10 @@ class Validator:
 
 
 def validate(
-        h5ad_path: Union[str, bytes, os.PathLike],
-        add_labels_file: str = None,
-        ignore_labels: bool = False,
-        verbose: bool = False,
+    h5ad_path: Union[str, bytes, os.PathLike],
+    add_labels_file: str = None,
+    ignore_labels: bool = False,
+    verbose: bool = False,
 ) -> (bool, list, bool):
     from .write_labels import AnnDataLabelAppender
 

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -398,6 +398,8 @@ adata_with_colors = anndata.AnnData(
 adata_visium = anndata.AnnData(
     X=sparse.csr_matrix(X), obs=good_obs_visium, uns=good_uns_with_visium_spatial, obsm=good_obsm_spatial, var=good_var
 )
+adata_visium.raw = adata_visium.copy()
+adata_visium.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
 
 # Expected anndata with Slide-seqV2 spatial data
 adata_slide_seqv2 = anndata.AnnData(

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -16,7 +16,7 @@ from cellxgene_schema.utils import getattr_anndata
 from cellxgene_schema.validate import (
     ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE,
     Validator,
-    VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE
+    VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE,
 )
 from cellxgene_schema.write_labels import AnnDataLabelAppender
 
@@ -265,7 +265,9 @@ class TestExpressionMatrix:
         validator = validator_with_visium_assay
         validator.adata.obs["in_tissue"] = 0
         validator.adata.obs["cell_type_ontology_term_id"] = "unknown"
-        validator.adata.X = numpy.zeros([validator.adata.obs.shape[0], validator.adata.var.shape[0]], dtype=numpy.float32)
+        validator.adata.X = numpy.zeros(
+            [validator.adata.obs.shape[0], validator.adata.var.shape[0]], dtype=numpy.float32
+        )
         validator.adata.raw = validator.adata.copy()
         validator.adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
         validator.validate_adata()
@@ -312,8 +314,9 @@ class TestExpressionMatrix:
 
         validator = validator_with_visium_assay
         validator.visium_and_is_single_true_matrix_size = VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE
-        validator.adata.X = numpy.zeros([validator.adata.obs.shape[0], validator.adata.var.shape[0]],
-                                        dtype=numpy.float32)
+        validator.adata.X = numpy.zeros(
+            [validator.adata.obs.shape[0], validator.adata.var.shape[0]], dtype=numpy.float32
+        )
         validator.adata.raw = validator.adata.copy()
         validator.adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
         validator.validate_adata()

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -13,7 +13,11 @@ import pytest
 import scipy.sparse
 from cellxgene_schema.schema import get_schema_definition
 from cellxgene_schema.utils import getattr_anndata
-from cellxgene_schema.validate import Validator
+from cellxgene_schema.validate import (
+    ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE,
+    Validator,
+    VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE
+)
 from cellxgene_schema.write_labels import AnnDataLabelAppender
 
 schema_def = get_schema_definition()
@@ -66,6 +70,7 @@ def validator_with_adata_missing_raw(validator) -> Validator:
 @pytest.fixture
 def validator_with_visium_assay(validator) -> Validator:
     validator.adata = examples.adata_visium.copy()
+    validator.visium_and_is_single_true_matrix_size = 2
     return validator
 
 
@@ -177,6 +182,21 @@ class TestExpressionMatrix:
             "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
         ]
 
+    @pytest.mark.parametrize("invalid_value", [1.5, -1])
+    def test_raw_values__invalid_spatial(self, validator_with_visium_assay, invalid_value):
+        """
+        When both `adata.X` and `adata.raw.X` are present, but `adata.raw.X` contains negative or non-integer values,
+        an error is raised.
+        """
+
+        validator = validator_with_visium_assay
+        validator.adata.raw.X[0, 1] = invalid_value
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: All non-zero values in raw matrix must be positive integers of type numpy.float32.",
+            "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
+        ]
+
     @pytest.mark.parametrize("datatype", [int, "float16", "float64"])
     def test_raw_values__wrong_datatype(self, validator_with_adata, datatype):
         """
@@ -203,6 +223,108 @@ class TestExpressionMatrix:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: Each cell must have at least one non-zero value in its row in the raw matrix.",
+            "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
+        ]
+
+    def test_raw_values__contains_zero_row_in_tissue_1(self, validator_with_visium_assay):
+        """
+        Raw Matrix contains a row with all zeros and in_tissue is 1, but no values are in_tissue 0.
+        """
+
+        validator = validator_with_visium_assay
+        validator.adata.obs["in_tissue"] = 1
+        validator.adata.X[0] = numpy.zeros(validator.adata.var.shape[0], dtype=numpy.float32)
+        validator.adata.raw.X[0] = numpy.zeros(validator.adata.var.shape[0], dtype=numpy.float32)
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: Each cell must have at least one non-zero value in its row in the raw matrix.",
+            "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
+        ]
+
+    def test_raw_values__contains_zero_row_in_tissue_1_mixed_in_tissue_values(self, validator_with_visium_assay):
+        """
+        Raw Matrix contains a row with all zeros and in_tissue is 1, and there are also values with in_tissue 0.
+        """
+
+        validator = validator_with_visium_assay
+        validator.adata.X[1] = numpy.zeros(validator.adata.var.shape[0], dtype=numpy.float32)
+        validator.adata.raw.X[1] = numpy.zeros(validator.adata.var.shape[0], dtype=numpy.float32)
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: Each observation with obs['in_tissue'] == 1 must have at least one "
+            "non-zero value in its row in the raw matrix.",
+            "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
+        ]
+
+    def test_raw_values__contains_all_zero_rows_in_tissue_0(self, validator_with_visium_assay):
+        """
+        When both `adata.X` and `adata.raw.X` are present, but `adata.raw.X` contains all rows with all zeros
+        and in_tissue is 0
+        """
+
+        validator = validator_with_visium_assay
+        validator.adata.obs["in_tissue"] = 0
+        validator.adata.obs["cell_type_ontology_term_id"] = "unknown"
+        validator.adata.X = numpy.zeros([validator.adata.obs.shape[0], validator.adata.var.shape[0]], dtype=numpy.float32)
+        validator.adata.raw = validator.adata.copy()
+        validator.adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: If obs['in_tissue'] contains at least one value 0, then there must be at least "
+            "one row with obs['in_tissue'] == 0 that has a non-zero value in the raw matrix.",
+            "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
+        ]
+
+    def test_raw_values__contains_some_zero_rows_in_tissue_0(self, validator_with_visium_assay):
+        """
+        When both `adata.X` and `adata.raw.X` are present, but `adata.raw.X` contains some rows with all zeros
+        and in_tissue is 0. Success case.
+        """
+
+        validator = validator_with_visium_assay
+        validator.adata.obs["in_tissue"] = 0
+        validator.adata.obs["cell_type_ontology_term_id"] = "unknown"
+        validator.adata.X[0] = numpy.zeros(validator.adata.var.shape[0], dtype=numpy.float32)
+        validator.adata.raw.X[0] = numpy.zeros(validator.adata.var.shape[0], dtype=numpy.float32)
+        validator.validate_adata()
+        assert validator.errors == []
+
+    def test_raw_values__invalid_visium_and_is_single_true_row_length(self, validator_with_visium_assay):
+        """
+        Dataset is visium and uns['is_single'] is True, but raw.X is the wrong length.
+        """
+        validator = validator_with_visium_assay
+        validator.visium_and_is_single_true_matrix_size = VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE
+
+        validator.validate_adata()
+        assert validator.errors == [
+            f"ERROR: When {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}, the raw matrix must be the "
+            "unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
+            f"{validator.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is 2.",
+            "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
+        ]
+
+    def test_raw_values__multiple_invalid_in_tissue_errors(self, validator_with_visium_assay):
+        """
+        Dataset is visium and uns['is_single'] is True, in_tissue has both 0 and 1 values and there
+        are issues validating rows of both in the matrix.
+        """
+
+        validator = validator_with_visium_assay
+        validator.visium_and_is_single_true_matrix_size = VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE
+        validator.adata.X = numpy.zeros([validator.adata.obs.shape[0], validator.adata.var.shape[0]],
+                                        dtype=numpy.float32)
+        validator.adata.raw = validator.adata.copy()
+        validator.adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+        validator.validate_adata()
+        assert validator.errors == [
+            f"ERROR: When {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}, the raw matrix must be the "
+            "unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
+            f"{validator.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is 2.",
+            "ERROR: If obs['in_tissue'] contains at least one value 0, then there must be at least "
+            "one row with obs['in_tissue'] == 0 that has a non-zero value in the raw matrix.",
+            "ERROR: Each observation with obs['in_tissue'] == 1 must have at least one "
+            "non-zero value in its row in the raw matrix.",
             "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
         ]
 
@@ -2008,6 +2130,7 @@ class TestObsm:
         validator.adata.uns = adata_spatial.uns
         validator.adata.uns["default_embedding"] = "harmony"
         validator.adata.obsm["spatial"] = validator.adata.obsm["X_umap"]
+        validator.visium_and_is_single_true_matrix_size = 2
         del validator.adata.obsm["X_umap"]
         validator.adata.obs = adata_spatial.obs
         validator.adata.obs["assay_ontology_term_id"] = assay_ontology_term_id

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -15,8 +15,8 @@ from cellxgene_schema.schema import get_schema_definition
 from cellxgene_schema.utils import getattr_anndata
 from cellxgene_schema.validate import (
     ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE,
-    Validator,
     VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE,
+    Validator,
 )
 from cellxgene_schema.write_labels import AnnDataLabelAppender
 

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -319,7 +319,33 @@ class TestCheckSpatial:
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
+        validator.visium_and_is_single_true_matrix_size = 2
+        # Confirm spatial is valid.
+        validator.validate_adata()
+        assert not validator.errors
 
+    def test__validate_spatial_visium_dense_matrix_ok(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.visium_and_is_single_true_matrix_size = 2
+        validator.adata.X = validator.adata.X.toarray()
+        validator.adata.raw = validator.adata.copy()
+        validator.adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+        # Confirm spatial is valid.
+        validator.validate_adata()
+        assert not validator.errors
+
+    def test__validate_spatial_visium_and_is_single_false_ok(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"] = {"is_single": False}
+        del validator.adata.obsm["spatial"]
+        # Format adata.obs into valid shape for Visium and is_single False.
+        validator.adata.obs.pop("array_col")
+        validator.adata.obs.pop("array_row")
+        validator.adata.obs.pop("in_tissue")
         # Confirm spatial is valid.
         validator.validate_adata()
         assert not validator.errors


### PR DESCRIPTION
## Reason for Change

- #828

## Changes

- refactor _has_valid_raw to split raw data validation into two branches: validating visium assay datasets with is_single True and in_tissue 0 values (introduces totally new validation rule that requires row-by-row iteration: rows in the matrix corresponding to `obs['in_tissue'] == 0` rows CAN be all zeros--as long as there is at least ONE non-zero value among the group of in_tissue == 0 rows)
- I chose not to introduce matrix chunking to the visium + is_single + in_tissue 0 data validation branch because we previously validate that its length is 4992 exactly, which is less than our default chunking size. Memory shouldn't be a concern in this case 
- moved typical data validation pathway for all other cases to _validate_raw_data method
       - this includes datasets where visium + is_single + in_tissue is 1 for all cases because that pathway has the same value ruleset as the other assays we validate for. The only diff is validating 4992 rows for visium + is_single datasets, so that check is done outside of this helper function. 