### PR TITLE
fix(schema 5.1.0): validate ['library_id']['images'][image] of type u…

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1757,7 +1757,7 @@ class Validator:
 
         :param np.ndarray image: the image to check the shape of.
 
-        :return True if image has shape (,,3), False otherwise.
+        :return True if image has shape (,,3 or 4), False otherwise.
         :rtype bool
         """
         return len(image.shape) == 3 and image.shape[2] in [3, 4]

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1752,15 +1752,15 @@ class Validator:
 
     def _is_valid_visium_image_shape(self, image: np.ndarray) -> bool:
         """
-        Determine if the image has shape (,,3); image is expected to be a 3D numpy array
-        with the size of the last dimension being three.
+        Determine if the image has shape (,,3 or 4); image is expected to be a 3D numpy array
+        with the size of the last dimension being three or four.
 
         :param np.ndarray image: the image to check the shape of.
 
         :return True if image has shape (,,3), False otherwise.
         :rtype bool
         """
-        return len(image.shape) == 3 and image.shape[2] == 3
+        return len(image.shape) == 3 and image.shape[2] in [3, 4]
 
     def _is_visium(self) -> bool:
         """
@@ -1776,7 +1776,7 @@ class Validator:
 
     def _validate_spatial_image_shape(self, image_name: str, image: np.ndarray, max_dimension: int = None):
         """
-        Validate the spatial image is of shape (,,3) and has a max dimension, if specified. A spatial image
+        Validate the spatial image is of shape (,,3 or 4) and has a max dimension, if specified. A spatial image
         is either spatial[library_id]['images']['hires'] or spatial[library_id]['images']['fullres']. Errors
         are added to self.errors if any.
 
@@ -1794,10 +1794,18 @@ class Validator:
             )
             return
 
-        # Confirm shape of image is valid: allowed shape is (,,3).
+        # Confirm type of ndarray is uint8.
+        if image.dtype != np.uint8:
+            self.errors.append(
+                f"uns['spatial'][library_id]['images']['{image_name}'] must be of type numpy.uint8, "
+                f"it is {image.dtype}."
+            )
+
+        # Confirm shape of image is valid: allowed shape is (,,3 or 4).
         if not self._is_valid_visium_image_shape(image):
             self.errors.append(
-                f"uns['spatial'][library_id]['images']['{image_name}'] must have shape (,,3), "
+                f"uns['spatial'][library_id]['images']['{image_name}'] must have a length of 3 and "
+                "either 3 (RGB color model for example) or 4 (RGBA color model for example) for its last dimension, "
                 f"it has shape {image.shape}."
             )
 

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -368,8 +368,8 @@ good_uns_with_visium_spatial = {
         "is_single": numpy.bool_(True),
         visium_library_id: {
             "images": {
-                "hires": numpy.zeros((2000, 100, 3)),
-                "fullres": numpy.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]),
+                "hires": numpy.zeros((2000, 100, 3), dtype=numpy.uint8),
+                "fullres": numpy.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], dtype=numpy.uint8),
             },
             "scalefactors": {
                 "spot_diameter_fullres": 1.0,

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -599,7 +599,8 @@ class TestCheckSpatial:
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"][visium_library_id]["images"][image_name] = np.zeros(image_shape, dtype=np.int16)
+        # Defaults to float64.
+        validator.adata.uns["spatial"][visium_library_id]["images"][image_name] = np.zeros(image_shape)
 
         # Confirm image is identified as invalid.
         validator._check_spatial_uns()

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -584,7 +584,7 @@ class TestCheckSpatial:
         validator.adata = adata_visium.copy()
         validator.adata.uns["spatial"][visium_library_id]["images"][image_name] = np.zeros(image_shape, dtype=np.uint8)
 
-        # Confirm image is identified as invalid.
+        # Confirm image is valid.
         validator._check_spatial_uns()
         assert not validator.errors
 

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -571,33 +571,89 @@ class TestCheckSpatial:
             in validator.warnings[0]
         )
 
-    def test__validate_images_hires_is_ndarray_error(self):
+    @pytest.mark.parametrize(
+        "image_name, image_shape",
+        [
+            ("hires", (1, 2000, 4)),
+            ("fullres", (1, 1, 4)),
+        ],
+    )
+    def test__validate_images_image_last_dimension_4_ok(self, image_name, image_shape):
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = "invalid"
+        validator.adata.uns["spatial"][visium_library_id]["images"][image_name] = np.zeros(image_shape, dtype=np.uint8)
 
-        # Confirm hires is identified as invalid.
+        # Confirm image is identified as invalid.
         validator._check_spatial_uns()
-        assert validator.errors
-        assert "uns['spatial'][library_id]['images']['hires'] must be of numpy.ndarray type" in validator.errors[0]
+        assert not validator.errors
 
-    def test__valide_images_hires_is_shape_error(self):
+    @pytest.mark.parametrize(
+        "image_name, image_shape",
+        [
+            ("hires", (1, 2000, 3)),
+            ("fullres", (1, 1, 3)),
+        ],
+    )
+    def test__validate_images_image_ndarray_type_error(self, image_name, image_shape):
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((1, 1))
+        validator.adata.uns["spatial"][visium_library_id]["images"][image_name] = np.zeros(image_shape, dtype=np.int16)
 
-        # Confirm hires is identified as invalid.
+        # Confirm image is identified as invalid.
         validator._check_spatial_uns()
         assert validator.errors
-        assert "uns['spatial'][library_id]['images']['hires'] must have shape (,,3)" in validator.errors[0]
+        assert (
+            f"uns['spatial'][library_id]['images']['{image_name}'] must be of type numpy.uint8" in validator.errors[0]
+        )
+
+    @pytest.mark.parametrize(
+        "image_name",
+        [
+            "hires",
+            "fullres",
+        ],
+    )
+    def test__validate_images_image_is_ndarray_error(self, image_name):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"][image_name] = "invalid"
+
+        # Confirm image is identified as invalid.
+        validator._check_spatial_uns()
+        assert validator.errors
+        assert (
+            f"uns['spatial'][library_id]['images']['{image_name}'] must be of numpy.ndarray type" in validator.errors[0]
+        )
+
+    @pytest.mark.parametrize(
+        "image_name",
+        [
+            "hires",
+            "fullres",
+        ],
+    )
+    def test__validate_images_image_is_shape_error(self, image_name):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.adata.uns["spatial"][visium_library_id]["images"][image_name] = np.zeros((1, 1), dtype=np.uint8)
+
+        # Confirm image is identified as invalid.
+        validator._check_spatial_uns()
+        assert validator.errors
+        assert (
+            f"uns['spatial'][library_id]['images']['{image_name}'] must have a length of 3 and either 3 (RGB color model "
+            "for example) or 4 (RGBA color model for example) for its last dimension" in validator.errors[0]
+        )
 
     def test__validate_images_hires_max_dimension_greater_than_error(self):
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((1, 2001, 3))
+        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((1, 2001, 3), dtype=np.uint8)
 
         # Confirm hires is identified as invalid.
         validator._check_spatial_uns()
@@ -611,7 +667,7 @@ class TestCheckSpatial:
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((1, 1999, 3))
+        validator.adata.uns["spatial"][visium_library_id]["images"]["hires"] = np.zeros((1, 1999, 3), dtype=np.uint8)
 
         # Confirm hires is identified as invalid.
         validator._check_spatial_uns()
@@ -620,28 +676,6 @@ class TestCheckSpatial:
             "The largest dimension of uns['spatial'][library_id]['images']['hires'] must be 2000 pixels"
             in validator.errors[0]
         )
-
-    def test__validate_images_fullres_is_ndarray_error(self):
-        validator: Validator = Validator()
-        validator._set_schema_def()
-        validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"][visium_library_id]["images"]["fullres"] = "invalid"
-
-        # Confirm fullres is identified as invalid.
-        validator._check_spatial_uns()
-        assert validator.errors
-        assert "uns['spatial'][library_id]['images']['fullres'] must be of numpy.ndarray type" in validator.errors[0]
-
-    def test__validate_images_fullres_is_shape_error(self):
-        validator: Validator = Validator()
-        validator._set_schema_def()
-        validator.adata = adata_visium.copy()
-        validator.adata.uns["spatial"][visium_library_id]["images"]["fullres"] = np.zeros((1, 1))
-
-        # Confirm fullres is identified as invalid.
-        validator._check_spatial_uns()
-        assert validator.errors
-        assert "uns['spatial'][library_id]['images']['fullres'] must have shape (,,3)" in validator.errors[0]
 
     def test__validate_scalefactors_required_error(self):
         validator: Validator = Validator()


### PR DESCRIPTION
…int8 and shape (,,3 or 4)

## Reason for Change

- #867 

## Changes

- Updated validation to allow for 3 or 4 for last dimension.
- Added validation for uint8.

## Testing

- Updated/added unit tests.