### PR TITLE
feat(schema 5.1.0): unique spatial assay ontology term id

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1508,12 +1508,17 @@ class Validator:
 
         :rtype none
         """
-        # Identical requirement is only applicable to spatial datasets.
+        # Identical check requires assay_ontology_term_id.
+        obs = getattr_anndata(self.adata, "obs")
+        if obs is None or "assay_ontology_term_id" not in obs:
+            return
+
+        # Identical check is only applicable to spatial datasets.
         if not self._is_supported_spatial_assay():
             return
 
         # Validate assay ontology term ids are identical.
-        term_count = self.adata.obs["assay_ontology_term_id"].nunique()
+        term_count = obs["assay_ontology_term_id"].nunique()
         if term_count > 1:
             self.errors.append(
                 "When obs['assay_ontology_term_id'] is either 'EFO:0010961' (Visium Spatial Gene Expression) or "

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -763,7 +763,7 @@ class TestCheckSpatial:
         assert validator.errors
         assert f"uns['spatial'][library_id]['{key}'] must be a dictionary." in validator.errors[0]
 
-    def test__validate_assay_type_ontology_term_id_unique_error(self):
+    def test__validate_assay_type_ontology_term_id_not_unique_error(self):
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()


### PR DESCRIPTION
## Reason for Change

- #873 

## Changes

- Added unique constraint to assay ontology term id for spatial assay.
- Refactored calls to `_validate_spatial_tissue_position(tissue_position_name...` into separate function for testability.

## Testing

- Added/updated unit tests.