### PR TITLE
fix: api_key_file_path for get_datasets

### DIFF
--- a/notebooks/curation_api/python/get_datasets.ipynb
+++ b/notebooks/curation_api/python/get_datasets.ipynb
@@ -37,6 +37,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "319174cf",
+   "metadata": {},
+   "source": [
+    "#### <font color='#bc00b0'>Please fill in the required values:</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a04e62c6",
+   "metadata": {},
+   "source": [
+    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdf74c99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key_file_path = \"path/to/api-key-file\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9501afeb",
    "metadata": {},
    "source": [
@@ -50,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "set_api_access_config()"
+    "set_api_access_config(api_key_file_path)"
    ]
   },
   {
@@ -94,7 +120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/curation_api/python/get_datasets.ipynb
+++ b/notebooks/curation_api/python/get_datasets.ipynb
@@ -48,7 +48,7 @@
    "id": "a04e62c6",
    "metadata": {},
    "source": [
-    "<font color='#bc00b0'>(Required) Provide the path to your api key file</font>"
+    "<font color='#bc00b0'>(Required for fetching private Datasets) Provide the path to your api key file</font>"
    ]
   },
   {
@@ -120,7 +120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Reason for Change

- #857 

## Changes

- Updated `get_datasets` notebook to include usage of `api_key_file_path` as well as the corresponding markdown.
