### PR TITLE
fix: load SparseDatasets into memory

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -11,6 +11,7 @@ import matplotlib.colors as mcolors
 import numpy as np
 import pandas as pd
 import scipy
+from anndata._core.sparse_dataset import SparseDataset
 from cellxgene_ontology_guide.ontology_parser import OntologyParser
 from pandas.core.computation.ops import UndefinedVariableError
 from scipy import sparse
@@ -1222,7 +1223,9 @@ class Validator:
             self._raw_layer_exists = False
             self.errors.append("All non-zero values in raw matrix must be positive integers of type numpy.float32.")
 
-    def _validate_raw_data_with_in_tissue_0(self, x: Union[np.ndarray, sparse.spmatrix], is_sparse_matrix: bool):
+    def _validate_raw_data_with_in_tissue_0(
+        self, x: Union[np.ndarray, sparse.spmatrix, SparseDataset], is_sparse_matrix: bool
+    ):
         """
         Special case validation checks for Visium data with is_single = True and in_tissue column in obs where in_tissue
         has at least one value 0. Static matrix size of 4992 rows, so chunking is not required.
@@ -1232,6 +1235,8 @@ class Validator:
         """
         has_tissue_0_non_zero_row = False
         has_tissue_1_zero_row = False
+        if isinstance(x, SparseDataset):
+            x = x.to_memory()
         if is_sparse_matrix:
             nonzero_row_indices, _ = x.nonzero()
         else:  # must be dense matrix

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -325,6 +325,17 @@ class TestCheckSpatial:
         validator.validate_adata()
         assert not validator.errors
 
+    def test__validate_from_file(self):
+        """Testing compatibility with SparseDatset types in Anndata"""
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, "slide_seqv2.h5ad")
+            adata_slide_seqv2.write_h5ad(file_path)
+            # Confirm spatial is valid.
+            validator.validate_adata(file_path)
+        assert not validator.errors
+
     def test__validate_spatial_visium_dense_matrix_ok(self):
         validator: Validator = Validator()
         validator._set_schema_def()


### PR DESCRIPTION
## Reason for Change
Anndata has a special class `SparseDataset` when loading a file to memory to reduce memory consumption. Unfortunately the data we need is not accesible from that class and needs to be loaded into memory before performing spatial validation, otherwise the following error occurs. 

```
Traceback (most recent call last):
  File "/Users/ngloria/code/single-cell-curation/venv/bin/cellxgene-schema", line 8, in <module>
    sys.exit(schema_cli())
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/cellxgene_schema/cli.py", line 47, in schema_validate
    is_valid, _, _ = validate(h5ad_file, add_labels_file, ignore_labels=ignore_labels, verbose=verbose)
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/cellxgene_schema/validate.py", line 2003, in validate
    validator.validate_adata(h5ad_path, to_memory=to_memory)
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/cellxgene_schema/validate.py", line 1954, in validate_adata
    self._deep_check()
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/cellxgene_schema/validate.py", line 1921, in _deep_check
    self._validate_raw()
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/cellxgene_schema/validate.py", line 1331, in _validate_raw
    if not self._has_valid_raw() and self._get_raw_x_loc() == "raw.X":
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/cellxgene_schema/validate.py", line 1186, in _has_valid_raw
    self._validate_raw_data_with_in_tissue_0(x, is_sparse_matrix)
  File "/Users/ngloria/code/single-cell-curation/venv/lib/python3.10/site-packages/cellxgene_schema/validate.py", line 1236, in _validate_raw_data_with_in_tissue_0
    nonzero_row_indices, _ = x.nonzero()
AttributeError: 'SparseDataset' object has no attribute 'nonzero'
```

## Changes

- Load SparseDataset into memory before performing spatial validation of X matrix. `_to_backed` is not being used because it causes a different error further down in the code and eventually lead to loading the sparse matrix into memory any ways.

## Testing

- added a test case that validated a spatial datasets loaded from a file.

## Notes for Reviewer
After this is merged a we will need to apply the changes made in 5.0.3 and release 5.0.4. The changes in 5.0.3 must be reversed before releasing 5.1.0.