### PR TITLE
fix: update migration_template for linting and generate_script.py to add GENCODE_MAPPER

### DIFF
--- a/scripts/migration_assistant/generate_script.py
+++ b/scripts/migration_assistant/generate_script.py
@@ -13,7 +13,7 @@ target_file = os.path.join(file_path, "../../cellxgene_schema_cli/cellxgene_sche
 def get_template() -> Template:
     with open(os.path.join(file_path, "migration_template.jinja"), "r") as fp:
         input_file = fp.read()
-    template = Template(input_file, trim_blocks=True, lstrip_blocks=True)
+    template = Template(input_file, keep_trailing_newline=True, trim_blocks=True, lstrip_blocks=True)
     return template
 
 

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -90,6 +90,12 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
 
+
+    # Dictionary for CURATOR-DEFINED remapping of deprecated feature IDs, if any, to new feature IDs.
+    GENCODE_MAPPER = {}
+    if GENCODE_MAPPER:
+        dataset = utils.remap_deprecated_features(adata=dataset, remapped_features=GENCODE_MAPPER)
+
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
     if DEPRECATED_FEATURE_IDS:
         dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -90,7 +90,6 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
 
-
     # Dictionary for CURATOR-DEFINED remapping of deprecated feature IDs, if any, to new feature IDs.
     GENCODE_MAPPER = {}
     if GENCODE_MAPPER:

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -99,6 +99,11 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
 
+    # Dictionary for CURATOR-DEFINED remapping of deprecated feature IDs, if any, to new feature IDs.
+    GENCODE_MAPPER = {}
+    if GENCODE_MAPPER:
+        dataset = utils.remap_deprecated_features(adata=dataset, remapped_features=GENCODE_MAPPER)
+
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
     if DEPRECATED_FEATURE_IDS:
         dataset = utils.remove_deprecated_features(dataset, DEPRECATED_FEATURE_IDS)
@@ -197,6 +202,11 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # elif collection_id == "<collection_2_id>":
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
+
+    # Dictionary for CURATOR-DEFINED remapping of deprecated feature IDs, if any, to new feature IDs.
+    GENCODE_MAPPER = {}
+    if GENCODE_MAPPER:
+        dataset = utils.remap_deprecated_features(adata=dataset, remapped_features=GENCODE_MAPPER)
 
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
     if DEPRECATED_FEATURE_IDS:
@@ -302,6 +312,11 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # elif collection_id == "<collection_2_id>":
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
+
+    # Dictionary for CURATOR-DEFINED remapping of deprecated feature IDs, if any, to new feature IDs.
+    GENCODE_MAPPER = {}
+    if GENCODE_MAPPER:
+        dataset = utils.remap_deprecated_features(adata=dataset, remapped_features=GENCODE_MAPPER)
 
     # AUTOMATED, DO NOT CHANGE -- IF GENCODE UPDATED, DEPRECATED FEATURE FILTERING ALGORITHM WILL GO HERE.
     if DEPRECATED_FEATURE_IDS:


### PR DESCRIPTION
## Reason for Change

- See failing tests / lint in https://github.com/chanzuckerberg/single-cell-curation/actions/runs/9117090874/job/25067180453?pr=913

## Changes

- add GENCODE_MAPPER, newly added and tested for in migrate.py for 5.0.0, as default empty map defined in migration_template  even if no GENCODE changes occurred (to fulfill tests written for it)
- keep trailing newline when generating migration script, to satisfy linting in auto-generated migrate script