### PR TITLE
chore: dependabot tuning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
         update-types:
           - patch
           - minor
+        exclude-patterns:
+          - "anndata"
   - package-ecosystem: pip
     directory: "/scripts/schema_bump_dry_run_ontologies"
     open-pull-requests-limit: 5
@@ -66,3 +68,5 @@ updates:
         update-types:
           - patch
           - minor
+        exclude-patterns:
+          - "tiledb"

--- a/scripts/migration_assistant/requirements.txt
+++ b/scripts/migration_assistant/requirements.txt
@@ -1,2 +1,2 @@
-jinja2==3.1.4
-bumpversion==0.6.0
+jinja2<4
+bumpversion==0.6.0 # this package is no longer maintained

--- a/scripts/schema_bump_dry_run_genes/requirements.txt
+++ b/scripts/schema_bump_dry_run_genes/requirements.txt
@@ -1,4 +1,5 @@
 requests==2.31.0
 tiledb==0.21.4 # Should match version pinned in single-cell-data-portal
 pandas==2.0.1
+pyarrow>=1.0.0
 jinja2<4

--- a/scripts/schema_bump_dry_run_genes/requirements.txt
+++ b/scripts/schema_bump_dry_run_genes/requirements.txt
@@ -1,5 +1,4 @@
 requests==2.31.0
 tiledb==0.21.4 # Should match version pinned in single-cell-data-portal
 pandas==2.0.1
-pyarrow>=1.0.0
 jinja2<4


### PR DESCRIPTION
## Reason for Change

adjusting the dependabot settings to avoid commit to pre-major versions which may include breaking changes.

## Changes

- treat anndata and tiledb special because they don't have a major release and they need special consideration before upgrading.
- remove pyarrow requirement because it is unused in the actual code.
