### PR TITLE
fix: use latest ontology schema version for dry run

### DIFF
--- a/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
@@ -130,7 +130,7 @@ def dry_run(curator_report_filepath: str, replaced_by_filepath: str) -> None:
     base_url = BASE_API[os.getenv("corpus_env", default="dev")]
     datasets = fetch_public_datasets(base_url)  # type: ignore
     public_curator_report_entry_map = defaultdict(dict)  # type: ignore
-    onto_parser = OntologyParser(schema_version="v5.0.0")
+    onto_parser = OntologyParser()
     with open(curator_report_filepath, "w") as f:
         # for every dataset, check its ontology term metadata to see if any terms are deprecated. If so, report.
         f.write("Deprecated Terms in Public Datasets:\n\n")


### PR DESCRIPTION
## Reason for Change

- ontology dry run was pinned to reading schema 5.0.0 ontology files rather than latest release

## Changes

- init OntologyParser without schema_version arg, so it loads latest release. Unpin from schema 5.0.0, which is soon to be deprecated.