### PR TITLE
fix: use memory efficient matrix subsetting to validate feature_is_filtered

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -115,9 +115,11 @@ def getattr_anndata(adata: ad.AnnData, attr: str = None):
             return None
     else:
         return getattr(adata, attr)
-    
+
+
 import anndata as ad
 from anndata.experimental import read_elem, read_dispatched, sparse_dataset
+
 
 def read_backed(f):
     def callback(func, elem_name: str, elem, iospec):
@@ -131,7 +133,8 @@ def read_backed(f):
                 return read_elem(elem)
             elif iospec.encoding_type == "array" and len(elem.shape) > 1:
                 return elem
-            else: func(elem)
+            else:
+                func(elem)
         else:
             return func(elem)
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -775,7 +775,6 @@ class Validator:
                 # Check for categorical column has mixed types, which is not supported by anndata 0.8.0
                 # TODO: check if this can be removed after upgading to anndata 0.10.0
                 categorical_types = {type(x) for x in column.dtype.categories.values}
-                logger.info("Validating mixed types in category column: %s...", column_name)
                 if len(categorical_types) > 1:
                     self.errors.append(
                         f"Column '{column_name}' in dataframe '{df_name}' contains {len(categorical_types)} categorical types. "

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -394,7 +394,9 @@ class Validator:
         if start < n:
             yield (matrix[start:n], start, n)
 
-    def _count_matrix_nonzero(self, matrix_name: str, matrix: Union[np.ndarray, sparse.spmatrix]) -> int:
+    def _count_matrix_nonzero(
+        self, matrix_name: str, matrix: Union[np.ndarray, sparse.spmatrix], filter_by_column: pd.Series = None
+    ) -> int:
         if matrix_name in self.number_non_zero:
             return self.number_non_zero[matrix_name]
 
@@ -403,6 +405,8 @@ class Validator:
         nnz = 0
         matrix_format = get_matrix_format(self.adata, matrix)
         for matrix_chunk, _, _ in self._chunk_matrix(matrix):
+            if filter_by_column is not None:
+                matrix_chunk = matrix_chunk[:, filter_by_column]
             nnz += matrix_chunk.count_nonzero() if matrix_format != "dense" else np.count_nonzero(matrix_chunk)
 
         self.number_non_zero[matrix_name] = nnz
@@ -424,21 +428,7 @@ class Validator:
             return
 
         if sum(column) > 0:
-            n_nonzero = 0
-
-            X_format = get_matrix_format(self.adata, self.adata.X)
-            if X_format in SPARSE_MATRIX_TYPES:
-                n_nonzero = self.adata.X[:, column].count_nonzero()
-
-            elif X_format == "dense":
-                n_nonzero = np.count_nonzero(self.adata.X[:, column])
-
-            else:
-                self.errors.append(
-                    f"X matrix is of type {type(self.adata.X)}, validation of 'feature_is_filtered' "
-                    f"cannot be completed."
-                )
-
+            n_nonzero = self._count_matrix_nonzero("feature_is_filtered", self.adata.X, column)
             if n_nonzero > 0:
                 self.errors.append(
                     f"Some features are 'True' in '{column_name}' of dataframe '{df_name}', but there are "
@@ -785,6 +775,7 @@ class Validator:
                 # Check for categorical column has mixed types, which is not supported by anndata 0.8.0
                 # TODO: check if this can be removed after upgading to anndata 0.10.0
                 categorical_types = {type(x) for x in column.dtype.categories.values}
+                logger.info("Validating mixed types in category column: %s...", column_name)
                 if len(categorical_types) > 1:
                     self.errors.append(
                         f"Column '{column_name}' in dataframe '{df_name}' contains {len(categorical_types)} categorical types. "

--- a/cellxgene_schema_cli/tests/test_utils.py
+++ b/cellxgene_schema_cli/tests/test_utils.py
@@ -155,4 +155,3 @@ class TestReadH5AD:
         h5ad_path = h5ad_valid
         adata = read_h5ad(h5ad_path)
         assert isinstance(adata, AnnData)
-        assert adata.isbacked


### PR DESCRIPTION
## Reason for Change

- feature_is_filtered validation check was previously loading X matrix into memory if bool column `var.feature_is_filtered` had any True entry. It would 1) subset the X matrix to only genes with featured_is_filtered is True and 2) validate (without chunking) that this filtered feature subsetted matrix had only zero values as declared by the feature_is_filtered column values.
- This would, as a result, load the X matrix into memory in order to 1) subset and then 2) count nonzero values and thus require higher resource provisioning in order to support use cases where the featured_is_filtered check was triggered.

## Changes

- in feature_is_filtered validation check, leverage existing matrix nonzero counting function, _count_matrix_nonzero, which implements matrix chunking
        - pass in new optional arg, filter_by_column, to subset each matrix chunk by feature_is_filtered True cols before counting nonzeros 
