### PR TITLE
feat: validate development_stage_ontology_term_id for Zebrafish

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: main
   pull_request:
-    branches: "*"
+    branches: "**"
 
 jobs:
 

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -319,16 +319,16 @@ components:
           - # If organism is Zebrafish
             rule: "organism_ontology_term_id == 'NCBITaxon:7955'"
             error_message_suffix: >-
-              When 'organism_ontology_term_id' is 'NCBITaxon:7955' (Danio rerio),
-              'development_stage_ontology_term_id' MUST be the most accurate descendant of 'ZFS:0000001' and it
-              MUST NOT be 'ZFS:0000000' for Unknown. The str 'unknown' is acceptable.
+             When 'organism_ontology_term_id' is 'NCBITaxon:7955' (Danio rerio),
+             'development_stage_ontology_term_id' MUST be the most accurate descendant of 'ZFS:0100000' and it
+             MUST NOT be 'ZFS:0000000' for Unknown. The str 'unknown' is acceptable.
             type: curie
             curie_constraints:
               ontologies:
-                - ZFS
+                - ZFA
               allowed:
                 ancestors:
-                  ZFS:
+                  ZFA:
                     - ZFS:0100000
               forbidden:
                 terms:

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -329,7 +329,7 @@ components:
               allowed:
                 ancestors:
                   ZFS:
-                    - ZFS:0000001
+                    - ZFS:0100000
               forbidden:
                 terms:
                   - ZFS:0000000
@@ -337,7 +337,7 @@ components:
                 - unknown
         # If organism is none of the above
         error_message_suffix: >-
-          When 'organism_ontology_term_id' is not 'NCBITaxon:10090' nor 'NCBITaxon:9606',
+          When 'organism_ontology_term_id'-specific requirements are not defined in the schema definition,
           'development_stage_ontology_term_id' MUST be a descendant term id of 'UBERON:0000105'
           excluding 'UBERON:0000071', or unknown.
         curie_constraints:

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -316,7 +316,26 @@ components:
                     - MmusDv:0000001
               exceptions:
                 - unknown
-        # If organism is not humnan nor mouse
+          - # If organism is Zebrafish
+            rule: "organism_ontology_term_id == 'NCBITaxon:7955'"
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is 'NCBITaxon:7955' (Danio rerio),
+              'development_stage_ontology_term_id' MUST be the most accurate descendant of 'ZFS:0000001' and it
+              MUST NOT be 'ZFS:0000000' for Unknown. The str 'unknown' is acceptable.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - ZFS
+              allowed:
+                ancestors:
+                  ZFS:
+                    - ZFS:0000001
+              forbidden:
+                terms:
+                  - ZFS:0000000
+              exceptions:
+                - unknown
+        # If organism is none of the above
         error_message_suffix: >-
           When 'organism_ontology_term_id' is not 'NCBITaxon:10090' nor 'NCBITaxon:9606',
           'development_stage_ontology_term_id' MUST be a descendant term id of 'UBERON:0000105'

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -21,7 +21,7 @@ from .utils import SPARSE_MATRIX_TYPES, get_matrix_format, getattr_anndata, read
 
 logger = logging.getLogger(__name__)
 
-ONTOLOGY_PARSER = OntologyParser(schema_version=f"v{schema.get_current_schema_version()}")
+ONTOLOGY_PARSER = OntologyParser(schema_version="5.2.1-experimental")
 
 ASSAY_VISIUM = "EFO:0010961"
 ASSAY_SLIDE_SEQV2 = "EFO:0030062"

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata>=0.8,<0.12
-git+https://github.com/chanzuckerberg/cellxgene-ontology-guide/@2024-q4/experimental-species#subdirectory=api/python
+cellxgene-ontology-guide==1.3.0a0
 click<9
 Cython<4
 numpy<2

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata>=0.8,<0.12
-cellxgene-ontology-guide==1.2.0 # update before a schema migration
+git+https://github.com/chanzuckerberg/cellxgene-ontology-guide/@2024-q4/experimental-species#subdirectory=api/python
 click<9
 Cython<4
 numpy<2

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="5.2.1+experimental",
+    version="5.2.1-alpha",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="5.2.0",
+    version="5.2.1-alpha",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="5.2.1-alpha",
+    version="5.2.1+experimental",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2497,15 +2497,17 @@ class TestAddingLabels:
 
 
 class TestZebrafish:
-
     """
     Tests for the zebrafish schema
     """
+
     @pytest.mark.parametrize(
         "development_stage_ontology_term_id",
         ["ZFS:0000016", "unknown"],
     )
-    def test_development_stage_ontology_term_id_zebrafish(self, validator_with_adata, development_stage_ontology_term_id):
+    def test_development_stage_ontology_term_id_zebrafish(
+        self, validator_with_adata, development_stage_ontology_term_id
+    ):
         """
         If organism_ontolology_term_id is "NCBITaxon:7955" for Danio rerio,
         this MUST be the most accurate ZFS:0100000 descendant or "unknown" and MUST NOT be ZFS:0000000.
@@ -2544,7 +2546,9 @@ class TestZebrafish:
             ),
         ],
     )
-    def test_development_stage_ontology_term_id_zebrafish__invalid(self, validator_with_adata, development_stage_ontology_term_id, error):
+    def test_development_stage_ontology_term_id_zebrafish__invalid(
+        self, validator_with_adata, development_stage_ontology_term_id, error
+    ):
         """
         If organism_ontolology_term_id is "NCBITaxon:7955" for Danio rerio,
         this MUST be the most accurate ZFS:0100000 descendant or "unknown" and MUST NOT be ZFS:0000000.

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -655,9 +655,9 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'EFO:0000001' in 'development_stage_ontology_term_id' is "
-            "not a valid ontology term id of 'UBERON'. When 'organism_ontology_term_id' is not 'NCBITaxon:10090' "
-            "nor 'NCBITaxon:9606', 'development_stage_ontology_term_id' MUST be a descendant term id of "
-            "'UBERON:0000105' excluding 'UBERON:0000071', or unknown."
+            "not a valid ontology term id of 'UBERON'. When 'organism_ontology_term_id'-specific requirements are "
+            "not defined in the schema definition, 'development_stage_ontology_term_id' MUST be a descendant term "
+            "id of 'UBERON:0000105' excluding 'UBERON:0000071', or unknown."
         ]
 
         # All other it MUST be descendants of UBERON:0000105 and not UBERON:0000071
@@ -672,9 +672,9 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: 'UBERON:0000071' in 'development_stage_ontology_term_id' is not allowed. When "
-            "'organism_ontology_term_id' is not 'NCBITaxon:10090' "
-            "nor 'NCBITaxon:9606', 'development_stage_ontology_term_id' MUST be a descendant term id of "
-            "'UBERON:0000105' excluding 'UBERON:0000071', or unknown.",
+            "'organism_ontology_term_id'-specific requirements are "
+            "not defined in the schema definition, 'development_stage_ontology_term_id' MUST be a descendant term "
+            "id of 'UBERON:0000105' excluding 'UBERON:0000071', or unknown."
         ]
 
     def test_disease_ontology_term_id(self, validator_with_adata):
@@ -2494,3 +2494,73 @@ class TestAddingLabels:
         case.assertCountEqual(label_writer.adata.obs["donor_id"].dtype.categories, ["donor_1", "donor_2", "donor_3"])
         label_writer._remove_categories_with_zero_values()
         case.assertCountEqual(label_writer.adata.obs["donor_id"].dtype.categories, ["donor_1", "donor_2"])
+
+
+class TestZebrafish:
+
+    """
+    Tests for the zebrafish schema
+    """
+    @pytest.mark.parametrize(
+        "development_stage_ontology_term_id",
+        ["ZFS:0000016", "unknown"],
+    )
+    def test_development_stage_ontology_term_id_zebrafish(self, validator_with_adata, development_stage_ontology_term_id):
+        """
+        If organism_ontolology_term_id is "NCBITaxon:7955" for Danio rerio,
+        this MUST be the most accurate ZFS:0100000 descendant or "unknown" and MUST NOT be ZFS:0000000.
+        """
+        validator = validator_with_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:7955"
+        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = development_stage_ontology_term_id
+        # must set to na for non-human organisms
+        obs.loc[
+            obs.index[0],
+            "self_reported_ethnicity_ontology_term_id",
+        ] = "na"
+        validator.validate_adata()
+        assert not validator.errors
+
+    @pytest.mark.parametrize(
+        "development_stage_ontology_term_id,error",
+        [
+            (
+                "HsapDv:0000001",  # Wrong ontology
+                "ERROR: 'HsapDv:0000001' in 'development_stage_ontology_term_id' is not a valid ontology term id of "
+                "'ZFA'.",
+            ),
+            (
+                "ZFA:0000001",  # Same ontology, not a descendant of ZFS:0100000
+                "ERROR: 'ZFA:0000001' in 'development_stage_ontology_term_id' is not an allowed term id.",
+            ),
+            (
+                "ZFS:0100000",  # Do not accept ZFS:0100000 itself, must be a descendant
+                "ERROR: 'ZFS:0100000' in 'development_stage_ontology_term_id' is not an allowed term id.",
+            ),
+            (
+                "ZFS:0000000",  # Descendant of ZFS:0100000 but explicitly forbidden term
+                "ERROR: 'ZFS:0000000' in 'development_stage_ontology_term_id' is not allowed.",
+            ),
+        ],
+    )
+    def test_development_stage_ontology_term_id_zebrafish__invalid(self, validator_with_adata, development_stage_ontology_term_id, error):
+        """
+        If organism_ontolology_term_id is "NCBITaxon:7955" for Danio rerio,
+        this MUST be the most accurate ZFS:0100000 descendant or "unknown" and MUST NOT be ZFS:0000000.
+        """
+        zebrafish_error_message_suffix = (
+            "When 'organism_ontology_term_id' is 'NCBITaxon:7955' (Danio rerio), "
+            "'development_stage_ontology_term_id' MUST be the most accurate descendant of 'ZFS:0100000' and it "
+            "MUST NOT be 'ZFS:0000000' for Unknown. The str 'unknown' is acceptable."
+        )
+        validator = validator_with_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:7955"
+        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = development_stage_ontology_term_id
+        obs.loc[
+            obs.index[0],
+            "self_reported_ethnicity_ontology_term_id",
+        ] = "na"
+        validator.validate_adata()
+        assert validator.errors == [error + " " + zebrafish_error_message_suffix]


### PR DESCRIPTION
## Reason for Change

- #1052 & #1053 
- see https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/drafts/5.2.1-experimental.md#development_stage_ontology_term_id

## Changes

- use 5.2.1-experimental COG/ontology parser 
- add validation requirements for development_stage_ontology_term_id for Zebrafish

## Testing

- unit tests