### PR TITLE
feat: add validator changes for fruit fly cell type ontology term id

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -185,6 +185,21 @@ components:
                         - ZFA:0009000
                     exceptions:
                       - unknown
+            - # If organism is fruit fly
+                rule: "organism_ontology_term_id == 'NCBITaxon:7227'"
+                error_message_suffix: >-
+                    When 'organism_ontology_term_id' is 'NCBITaxon:7227' (Drosophila melanogaster),
+                    'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'FBbt:0007002' (cell).
+                type: curie
+                curie_constraints:
+                    ontologies:
+                      - FBbt
+                    allowed:
+                      ancestors:
+                        FBbt:
+                        - FBbt:0007002
+                    exceptions:
+                      - unknown
         # if organism is none of the above
         error_message_suffix: >-
             When 'organism_ontology_term_id'-specific requirements are not defined in the schema definition,

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -189,7 +189,7 @@ components:
                 rule: "organism_ontology_term_id == 'NCBITaxon:7227'"
                 error_message_suffix: >-
                     When 'organism_ontology_term_id' is 'NCBITaxon:7227' (Drosophila melanogaster),
-                    'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'FBbt:0007002' (cell).
+                    'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'FBbt:00007002' (cell).
                 type: curie
                 curie_constraints:
                     ontologies:
@@ -197,7 +197,7 @@ components:
                     allowed:
                       ancestors:
                         FBbt:
-                        - FBbt:0007002
+                        - FBbt:00007002
                     exceptions:
                       - unknown
         # if organism is none of the above

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2755,6 +2755,7 @@ class TestFruitFly:
         obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:7227"
         obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "FBbt:00049192"
         obs.loc[obs.index[0], "self_reported_ethnicity_ontology_term_id"] = "na"
+        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "FBdv:00005370"
         return obs
 
     @pytest.fixture
@@ -2763,6 +2764,7 @@ class TestFruitFly:
         obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:7227"
         obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "unknown"
         obs.loc[obs.index[0], "self_reported_ethnicity_ontology_term_id"] = "na"
+        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "FBdv:00005370"
         return obs
 
     @pytest.fixture
@@ -2824,12 +2826,12 @@ class TestFruitFly:
                 "ERROR: 'CL:0000001' in 'organism_cell_type_ontology_term_id' is not a valid ontology term id of 'FBbt'.",
             ),
             (
-                "FBbt:00007002",  # Same ontology, not a descendant of FBbt:0007002
-                "ERROR: 'FBbt:00007002' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
+                "FBbt:00007001",  # Same ontology, not a descendant of FBbt:00007002
+                "ERROR: 'FBbt:00007001' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
             ),
             (
-                "FBbt:0007002",  # Do not accept FBbt:0007002 itself, must be a descendant
-                "ERROR: 'FBbt:0007002' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
+                "FBbt:00007002",  # Do not accept FBbt:00007002 itself, must be a descendant
+                "ERROR: 'FBbt:00007002' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
             ),
             (
                 "na",  # Allowed for other organisms, not allowed if organism is zebrafih

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2793,7 +2793,7 @@ class TestFruitFly:
         If organism_ontolology_term_id is "NCBITaxon:7227" for Drosophila melanogaster,
         this MUST be the most accurate FBdv term
         """
-        validator = validator_with_adata
+        validator = validator_with_fruitfly_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "HsapDv:0000001"
         validator.validate_adata()

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2776,7 +2776,7 @@ class TestFruitFly:
     def validator_with_visium_fruitfly_adata(self, validator_with_visium_assay, fruitfly_visium_obs):
         validator_with_visium_assay.adata.obs = fruitfly_visium_obs
         return validator_with_visium_assay
-    
+
     def test_development_stage_ontology_term_id_fruitfly(self, validator_with_fruitfly_adata):
         """
         If organism_ontolology_term_id is "NCBITaxon:7227" for Drosophila melanogaster,
@@ -2800,7 +2800,7 @@ class TestFruitFly:
             "term id of 'FBdv'. When 'organism_ontology_term_id' is 'NCBITaxon:7227' (Drosophila melanogaster), "
             "'development_stage_ontology_term_id' MUST be the most accurate FBdv term."
         ]
-    
+
     @pytest.mark.parametrize(
         "organism_cell_type_ontology_term_id",
         ["FBbt:00049192", "unknown"],

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2828,8 +2828,8 @@ class TestFruitFly:
                 "ERROR: 'CL:0000001' in 'organism_cell_type_ontology_term_id' is not a valid ontology term id of 'FBbt'.",
             ),
             (
-                "FBbt:00007001",  # Same ontology, not a descendant of FBbt:0007002
-                "ERROR: 'FBbt:00007001' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
+                "FBbt:00007002",  # Same ontology, not a descendant of FBbt:0007002
+                "ERROR: 'FBbt:00007002' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
             ),
             (
                 "FBbt:0007002",  # Do not accept FBbt:0007002 itself, must be a descendant
@@ -2847,7 +2847,7 @@ class TestFruitFly:
         validator = validator_with_fruitfly_adata
         fruitfly_error_message_suffix = (
             "When 'organism_ontology_term_id' is 'NCBITaxon:7227' (Drosophila melanogaster), "
-            "'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'FBbt:00007001' (cell)."
+            "'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'FBbt:00007002' (cell)."
         )
         obs = validator.adata.obs
         obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = organism_cell_type_ontology_term_id
@@ -2881,7 +2881,7 @@ class TestFruitFly:
         error_message = (
             "ERROR: 'na' in 'organism_cell_type_ontology_term_id' is not a valid ontology term id of 'FBbt'. "
             "When 'organism_ontology_term_id' is 'NCBITaxon:7227' (Drosophila melanogaster), "
-            "'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'FBbt:00007001' (cell)."
+            "'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'FBbt:00007002' (cell)."
         )
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2754,7 +2754,6 @@ class TestFruitFly:
         obs = examples.adata.copy().obs
         obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:7227"
         obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "FBbt:00049192"
-        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "FBdv:00005370"
         obs.loc[obs.index[0], "self_reported_ethnicity_ontology_term_id"] = "na"
         return obs
 
@@ -2763,7 +2762,6 @@ class TestFruitFly:
         obs = examples.adata_visium.copy().obs
         obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:7227"
         obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "unknown"
-        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "FBdv:00005370"
         obs.loc[obs.index[0], "self_reported_ethnicity_ontology_term_id"] = "na"
         return obs
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2756,7 +2756,6 @@ class TestFruitFly:
         obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "FBbt:00049192"
         obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "FBdv:00005370"
         obs.loc[obs.index[0], "self_reported_ethnicity_ontology_term_id"] = "na"
-        obs.loc[obs.index[0], "organism_tissue_ontology_term_id"] = "FBbt:00000450"
         return obs
 
     @pytest.fixture
@@ -2766,7 +2765,6 @@ class TestFruitFly:
         obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "unknown"
         obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "FBdv:00005370"
         obs.loc[obs.index[0], "self_reported_ethnicity_ontology_term_id"] = "na"
-        obs.loc[obs.index[0], "organism_tissue_ontology_term_id"] = "FBbt:00000450"
         return obs
 
     @pytest.fixture

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2834,7 +2834,7 @@ class TestFruitFly:
                 "ERROR: 'FBbt:00007002' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
             ),
             (
-                "na",  # Allowed for other organisms, not allowed if organism is zebrafih
+                "na",  # Allowed for other organisms, not allowed if organism is fruit fly
                 "ERROR: 'na' in 'organism_cell_type_ontology_term_id' is not a valid ontology term id of 'FBbt'.",
             ),
         ],


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/cs-platform-661fffc5c6339904f8f42cb2/issues/gh/chanzuckerberg/single-cell-curation/1046

## Changes

- adds validation rules for organism_cell_type_ontology_term_id for fruit fly

## Testing

adds unit tests

## Notes for Reviewer