### PR TITLE
feat: map_species command for organism specific ontology terms to CL/UBERON mappings

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -94,9 +94,24 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     migrate(input_file, output_file, collection_id, dataset_id)
 
 
+@click.command(
+    name="map-species",
+    short_help="Annotate non-human, non-mouse anndata with CL and UBERON equivalent terms",
+    help="Annotate non-human, non-mouse anndata with CL and UBERON equivalent terms, based on values in"
+    "organism-specific columns (e.g. organism_cell_type_ontology_term_id and organism_tissue_ontology_term_id)",
+)
+@click.argument("input_file", nargs=1, type=click.Path(exists=True, dir_okay=False))
+@click.argument("output_file", nargs=1, type=click.Path(exists=False, dir_okay=False))
+def map_species(input_file, output_file):
+    from .map_species import map_species
+
+    map_species(input_file, output_file)
+
+
 schema_cli.add_command(schema_validate)
 schema_cli.add_command(migrate)
 schema_cli.add_command(remove_labels)
+schema_cli.add_command(map_species)
 
 if __name__ == "__main__":
     schema_cli()

--- a/cellxgene_schema_cli/cellxgene_schema/map_species.py
+++ b/cellxgene_schema_cli/cellxgene_schema/map_species.py
@@ -1,0 +1,40 @@
+import logging
+
+import anndata as ad
+from cellxgene_ontology_guide.ontology_parser import OntologyParser
+
+logger = logging.getLogger(__name__)
+
+
+def map_species(input_file, output_file):
+    ontology_parser = OntologyParser("5.2.1-experimental")
+    adata = ad.read_h5ad(input_file, backed="r")
+    map_columns = [
+        ("organism_cell_type_ontology_term_id", "cell_type_ontology_term_id", "CL"),
+        ("organism_tissue_ontology_term_id", "tissue_ontology_term_id", "UBERON"),
+    ]
+    for map_from, map_to, ontology in map_columns:
+        logger.info(f"Mapping {ontology} terms to {map_to}")
+        if not hasattr(adata.obs, map_to):
+            logger.info(f"No existing {map_to} column detected, creating one and defaulting to empty strings.")
+            adata.obs[map_to] = ""
+        for category, group in adata.obs.groupby(map_from):
+            try:
+                closest_terms = ontology_parser.get_closest_bridge_term_ids(category, ontology)
+            except Exception:
+                logger.error(f"{category} in {map_from} is not a valid ontology term ID, cannot find {ontology} map.")
+                continue
+            if len(closest_terms) < 1:
+                logger.warning(f"{category} has no closest match for {ontology} in its ancestry tree.")
+            elif len(closest_terms) == 1:
+                adata.obs.loc[group.index, map_to] = closest_terms[0]
+                logger.info(f"Setting {category} {map_to} rows to single closest match: {closest_terms[0]}")
+            else:
+                logger.warning(
+                    f"{category} has multiple closest matches for {ontology} in its ancestry tree: "
+                    f"{closest_terms}. Pick one based on biological context and assign manually."
+                )
+        adata.obs[map_to] = adata.obs[map_to].astype("category")
+
+    logger.info(f"Mappings complete, writing to {output_file}")
+    adata.write_h5ad(output_file, compression="gzip")

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata>=0.8,<0.12
-cellxgene-ontology-guide==1.3.0a0
+cellxgene-ontology-guide==1.3.0a1
 click<9
 Cython<4
 numpy<2

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="5.2.1-alpha",
+    version="5.2.1-alpha.1",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/tests/test_map_species.py
+++ b/cellxgene_schema_cli/tests/test_map_species.py
@@ -1,0 +1,123 @@
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import numpy
+import pandas as pd
+import pytest
+from cellxgene_schema.map_species import OntologyParser, map_species
+from cellxgene_schema.validate import Validator
+from fixtures.examples_validate import adata
+
+
+@pytest.fixture
+def zebrafish_adata():
+    zebrafish_adata = adata.copy()
+    obs = zebrafish_adata.obs
+    obs.drop(columns=["cell_type_ontology_term_id", "tissue_ontology_term_id"], inplace=True)
+    obs["organism_ontology_term_id"] = "NCBITaxon:7955"
+    obs["development_stage_ontology_term_id"] = "ZFS:0000016"
+    obs["self_reported_ethnicity_ontology_term_id"] = "na"
+    obs["tissue_type"] = "tissue"
+
+    obs["organism_ontology_term_id"] = obs["organism_ontology_term_id"].astype("category")
+    obs["development_stage_ontology_term_id"] = obs["development_stage_ontology_term_id"].astype("category")
+    obs["self_reported_ethnicity_ontology_term_id"] = obs["self_reported_ethnicity_ontology_term_id"].astype("category")
+    obs["tissue_type"] = obs["tissue_type"].astype("category")
+
+    # single match
+    obs["organism_cell_type_ontology_term_id"] = "ZFA:0005769"
+
+    # single match
+    obs["organism_tissue_ontology_term_id"] = "ZFA:0000047"
+
+    zebrafish_adata.var = pd.DataFrame(
+        [[False], [False], [False], [False], [False], [False]],
+        index=[
+            "ENSDARG00000103202",
+            "ENSDARG00000096156",
+            "ENSDARG00000076160",
+            "ENSDARG00000117163",
+            "ENSDARG00000096187",
+            "ENSDARG00000009657",
+        ],
+        columns=["feature_is_filtered"],
+    )
+    zebrafish_adata.X = numpy.ones([zebrafish_adata.obs.shape[0], zebrafish_adata.var.shape[0]], dtype=numpy.float32)
+    zebrafish_adata.raw = zebrafish_adata.copy()
+    zebrafish_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+    return zebrafish_adata
+
+
+@pytest.fixture
+def validator_with_adata(zebrafish_adata):
+    validator = Validator()
+    validator.adata = zebrafish_adata.copy()
+    return validator
+
+
+def test_map_species__valid_output(validator_with_adata):
+    with TemporaryDirectory() as tmp:
+        input_file = tmp + "input.h5ad"
+        validator_with_adata.adata.copy().write_h5ad(input_file, compression="gzip")
+        output_file = tmp + "output.h5ad"
+        map_species(input_file, output_file)
+
+        assert validator_with_adata.validate_adata(output_file) is True
+
+
+def test_map_species_log_ouput(validator_with_adata, caplog):
+    obs = validator_with_adata.adata.obs
+    # test single match, error match, multiple options
+    obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "ZFA:0009384"
+    obs.loc[obs.index[1], "organism_tissue_ontology_term_id"] = "ZFA:0"
+
+    with TemporaryDirectory() as tmp:
+        input_file = tmp + "input.h5ad"
+        validator_with_adata.adata.copy().write_h5ad(input_file, compression="gzip")
+        output_file = tmp + "output.h5ad"
+        map_species(input_file, output_file)
+        assert (
+            "ZFA:0009384 has multiple closest matches for CL in its ancestry tree: ['CL:0000075', 'CL:0002077']"
+            in caplog.text
+        )
+        assert "Setting ZFA:0005769 cell_type_ontology_term_id rows to single closest match: CL:0000018" in caplog.text
+        assert (
+            "ZFA:0 in organism_tissue_ontology_term_id is not a valid ontology term ID, cannot find UBERON map."
+            in caplog.text
+        )
+        assert "Setting ZFA:0000047 tissue_ontology_term_id rows to single closest match: UBERON:0000004" in caplog.text
+
+        # output should be invalid, per logs
+        assert validator_with_adata.validate_adata(output_file) is False
+
+
+def test_map_species_log_output_no_match(zebrafish_adata, caplog):
+    with TemporaryDirectory() as tmp, mock.patch.object(
+        OntologyParser, "get_closest_bridge_term_ids", mock.Mock(return_value=[])
+    ):
+        input_file = tmp + "input.h5ad"
+        zebrafish_adata.copy().write_h5ad(input_file, compression="gzip")
+        output_file = tmp + "output.h5ad"
+        map_species(input_file, output_file)
+        assert "ZFA:0005769 has no closest match for CL in its ancestry tree." in caplog.text
+        assert "ZFA:0000047 has no closest match for UBERON in its ancestry tree." in caplog.text
+
+
+def test_map_species__with_existing_cols(validator_with_adata):
+    obs = validator_with_adata.adata.obs
+    obs["cell_type_ontology_term_id"] = ""
+    obs["tissue_ontology_term_id"] = ""
+    # set-up organism_cell_type and organism_tissue term IDs with one of multiple matching CL/UBERON options
+    # leave single match rows blank, to be set by map_species
+    obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "ZFA:0009384"
+    obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "CL:0000075"
+    obs.loc[obs.index[0], "organism_tissue_ontology_term_id"] = "ZFA:0005914"
+    obs.loc[obs.index[0], "tissue_ontology_term_id"] = "UBERON:0001769"
+
+    with TemporaryDirectory() as tmp:
+        input_file = tmp + "input.h5ad"
+        validator_with_adata.adata.copy().write_h5ad(input_file, compression="gzip")
+        output_file = tmp + "output.h5ad"
+        map_species(input_file, output_file)
+
+        assert validator_with_adata.validate_adata(output_file) is True


### PR DESCRIPTION
## Reason for Change

- https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/1071

## Changes

- CLI function to map cell_type_ontology_term_id and tissue_ontology_term_id in anndata obs based on values in organism_*_ontology_term_id 
- if multiple matching values possible, will report accordingly in a log statement and not assign a value.
- if no matching values found, will report accordingly in a log warning

## Testing

- unit tests