### PR TITLE
chore: remove seurat references in validator

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -2,8 +2,6 @@ title: Corpora schema version 5.X.X
 type: anndata
 # If sparsity of any expression matrix is greater than this and not csr sparse matrix, then there will be warning.
 sparsity: 0.5
-# If the R array will exceed this number in size, then Seurat conversion will fail
-max_size_for_seurat: 2147483647  # 2^31 - 1 (max value for 4-byte signed int)
 # Perform the checks for "raw" requirements IF:
 raw:
   obs:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -54,7 +54,6 @@ class Validator:
         self.is_valid = False
         self.h5ad_path = ""
         self._raw_layer_exists = None
-        self.is_seurat_convertible: bool = True
         self.is_spatial = None
         self.is_visium = None
         self.is_visium_and_is_single_true = None
@@ -925,65 +924,6 @@ class Validator:
                     f"and it is not a 'scipy.sparse.csr_matrix'. It is STRONGLY RECOMMENDED "
                     f"to use this type of matrix for the given sparsity."
                 )
-
-    def _validate_seurat_convertibility(self):
-        """
-        Use length of component matrices to determine if the anndata object will be unable to be converted to Seurat by
-        virtue of the R language's array size limit (4-byte signed int length). Add warning for each matrix which is
-        too large.
-        rtype: None
-        """
-        # Seurat conversion is not supported for Visium datasets.
-        if self._is_visium():
-            self.warnings.append(
-                "Datasets with assay_ontology_term_id 'EFO:0010961' (Visium Spatial Gene Expression) are not compatible with Seurat."
-            )
-            self.is_seurat_convertible = False
-            return
-
-        to_validate = [(self.adata.X, "X")]
-        # check if there's raw data
-        if self.adata.raw:
-            to_validate.append((self.adata.raw.X, "raw.X"))
-        # Check length of component arrays
-        for matrix, matrix_name in to_validate:
-            matrix_format = get_matrix_format(self.adata, matrix)
-            if matrix_format in SPARSE_MATRIX_TYPES:
-                effective_r_array_size = self._count_matrix_nonzero(matrix_name, matrix)
-                is_sparse = True
-            elif matrix_format == "dense":
-                effective_r_array_size = max(matrix.shape)
-                is_sparse = False
-            else:
-                self.warnings.append(
-                    f"Unable to verify seurat convertibility for matrix {matrix_name} " f"of type {type(matrix)}"
-                )
-                continue
-
-            if effective_r_array_size > self.schema_def["max_size_for_seurat"]:
-                if is_sparse:
-                    self.warnings.append(
-                        f"This dataset cannot be converted to the .rds (Seurat v4) format. "
-                        f"{effective_r_array_size} nonzero elements in matrix {matrix_name} exceed the "
-                        f"limitations in the R dgCMatrix sparse matrix class (2^31 - 1 nonzero "
-                        f"elements)."
-                    )
-                else:
-                    self.warnings.append(
-                        f"This dataset cannot be converted to the .rds (Seurat v4) format. "
-                        f"{effective_r_array_size} elements in at least one dimension of matrix "
-                        f"{matrix_name} exceed the limitations in the R dgCMatrix sparse matrix class "
-                        f"(2^31 - 1 nonzero elements)."
-                    )
-
-                self.is_seurat_convertible = False
-
-        if self.adata.raw and self.adata.raw.X.shape[1] != self.adata.raw.var.shape[0]:
-            self.errors.append(
-                "This dataset has a mismatch between 1) the number of features in raw.X and 2) the number of features "
-                "in raw.var. These counts must be identical."
-            )
-            self.is_seurat_convertible = False
 
     def _validate_obsm(self):
         """
@@ -1976,7 +1916,7 @@ def validate(
     add_labels_file: str = None,
     ignore_labels: bool = False,
     verbose: bool = False,
-) -> (bool, list, bool):
+) -> (bool, list):
     from .write_labels import AnnDataLabelAppender
 
     """
@@ -1985,8 +1925,7 @@ def validate(
     :param Union[str, bytes, os.PathLike] h5ad_path: Path to h5ad file to validate
     :param str add_labels_file: Path to new h5ad file with ontology/gene labels added
 
-    :return (True, [], <bool>) if successful validation, (False, [list_of_errors], <bool>) otherwise; last bool is for
-    seurat convertibility
+    :return (True, []) if successful validation, (False, [list_of_errors]) otherwise
     :rtype tuple
     """
 
@@ -2004,7 +1943,7 @@ def validate(
 
     # Stop if validation was unsuccessful
     if not validator.is_valid:
-        return False, validator.errors, validator.is_seurat_convertible
+        return False, validator.errors
 
     if add_labels_file:
         label_start = datetime.now()
@@ -2017,8 +1956,7 @@ def validate(
 
         return (
             validator.is_valid and writer.was_writing_successful,
-            validator.errors + writer.errors,
-            validator.is_seurat_convertible,
+            validator.errors + writer.errors
         )
 
-    return True, validator.errors, validator.is_seurat_convertible
+    return True, validator.errors

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1827,10 +1827,6 @@ class Validator:
         # Checks spatial
         self._check_spatial()
 
-        # Checks Seurat convertibility
-        logger.debug("Validating Seurat convertibility...")
-        self._validate_seurat_convertibility()
-
         # Checks each component
         for component_name, component_def in self.schema_def["components"].items():
             logger.debug(f"Validating component: {component_name}")
@@ -1954,9 +1950,6 @@ def validate(
             f"{writer.was_writing_successful}"
         )
 
-        return (
-            validator.is_valid and writer.was_writing_successful,
-            validator.errors + writer.errors
-        )
+        return (validator.is_valid and writer.was_writing_successful, validator.errors + writer.errors)
 
     return True, validator.errors

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -27,10 +27,8 @@ from fixtures.examples_validate import (
     adata_visium,
     adata_with_labels,
     good_obs,
-    good_obsm,
     good_uns,
     good_uns_with_visium_spatial,
-    good_var,
     h5ad_invalid,
     h5ad_valid,
     visium_library_id,
@@ -995,6 +993,7 @@ class TestCheckSpatial:
             f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}."
             in validator.errors[0]
         )
+
 
 class TestValidatorValidateDataFrame:
     @pytest.mark.parametrize("_type", [np.int64, np.int32, int, np.float64, np.float32, float, str])

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -297,7 +297,7 @@ class TestValidate:
         with tempfile.TemporaryDirectory() as temp_dir:
             labels_path = "/".join([temp_dir, "labels.h5ad"])
 
-            success, errors, is_seurat_convertible = validate(h5ad_valid, labels_path)
+            success, errors = validate(h5ad_valid, labels_path)
 
             import anndata as ad
 
@@ -306,36 +306,32 @@ class TestValidate:
             assert adata.raw.X.has_canonical_format
             assert success
             assert not errors
-            assert is_seurat_convertible
             assert os.path.exists(labels_path)
             expected_hash = "55fbc095218a01cad33390f534d6690af0ecd6593f27d7cd4d26e91072ea8835"
             original_hash = self.hash_file(h5ad_valid)
             assert original_hash != expected_hash, "Writing labels did not change the dataset from the original."
 
     def test__validate_with_h5ad_valid_and_without_labels(self):
-        success, errors, is_seurat_convertible = validate(h5ad_valid)
+        success, errors = validate(h5ad_valid)
 
         assert success
         assert not errors
-        assert is_seurat_convertible
 
     def test__validate_with_h5ad_invalid_and_with_labels(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             labels_path = "/".join([temp_dir, "labels.h5ad"])
 
-            success, errors, is_seurat_convertible = validate(h5ad_invalid, labels_path)
+            success, errors = validate(h5ad_invalid, labels_path)
 
             assert not success
             assert errors
-            assert is_seurat_convertible
             assert not os.path.exists(labels_path)
 
     def test__validate_with_h5ad_invalid_and_without_labels(self):
-        success, errors, is_seurat_convertible = validate(h5ad_invalid)
+        success, errors = validate(h5ad_invalid)
 
         assert not success
         assert errors
-        assert is_seurat_convertible
 
 
 class TestCheckSpatial:
@@ -999,57 +995,6 @@ class TestCheckSpatial:
             f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}."
             in validator.errors[0]
         )
-
-
-class TestSeuratConvertibility:
-    def validation_helper(self, matrix, raw=None):
-        data = anndata.AnnData(X=matrix, obs=good_obs, uns=good_uns, obsm=good_obsm, var=good_var)
-        if raw:
-            data.raw = raw
-        self.validator: Validator = Validator()
-        self.validator._set_schema_def()
-        self.validator.schema_def["max_size_for_seurat"] = 2**3 - 1  # Reduce size required to fail (faster tests)
-        self.validator.adata = data
-
-    def test_determine_seurat_convertibility(self):
-        # Sparse matrix with too many nonzero values is not Seurat-convertible
-        sparse_matrix_too_large = sparse.csr_matrix(np.ones((good_obs.shape[0], good_var.shape[0]), dtype=np.float32))
-        self.validation_helper(sparse_matrix_too_large)
-        self.validator._validate_seurat_convertibility()
-        assert len(self.validator.warnings) == 1
-        assert not self.validator.is_seurat_convertible
-
-        # Reducing nonzero count by 1, to within limit, makes it Seurat-convertible
-        sparse_matrix_with_zero = sparse.csr_matrix(np.ones((good_obs.shape[0], good_var.shape[0]), dtype=np.float32))
-        sparse_matrix_with_zero[0, 0] = 0
-        self.validation_helper(sparse_matrix_with_zero)
-        self.validator._validate_seurat_convertibility()
-        assert len(self.validator.warnings) == 0
-        assert self.validator.is_seurat_convertible
-
-        # Dense matrices with a dimension that exceeds limit will fail -- zeros are irrelevant
-        dense_matrix_with_zero = np.zeros((good_obs.shape[0], good_var.shape[0]), dtype=np.float32)
-        self.validation_helper(dense_matrix_with_zero)
-        self.validator.schema_def["max_size_for_seurat"] = 2**2 - 1
-        self.validator._validate_seurat_convertibility()
-        assert len(self.validator.warnings) == 1
-        assert not self.validator.is_seurat_convertible
-
-        # Dense matrices with dimensions in bounds but total count over will succeed
-        dense_matrix = np.ones((good_obs.shape[0], good_var.shape[0]), dtype=np.float32)
-        self.validation_helper(dense_matrix)
-        self.validator.schema_def["max_size_for_seurat"] = 2**3 - 1
-        self.validator._validate_seurat_convertibility()
-        assert len(self.validator.warnings) == 0
-        assert self.validator.is_seurat_convertible
-
-        # Visium datasets are not Seurat-convertible
-        self.validation_helper(sparse_matrix_with_zero)
-        self.validator.adata.obs = adata_visium.obs.copy()
-        self.validator._validate_seurat_convertibility()
-        assert len(self.validator.warnings) == 1
-        assert not self.validator.is_seurat_convertible
-
 
 class TestValidatorValidateDataFrame:
     @pytest.mark.parametrize("_type", [np.int64, np.int32, int, np.float64, np.float32, float, str])


### PR DESCRIPTION
## Reason for Change

- #[1112](https://github.com/chanzuckerberg/single-cell-curation/issues/1112)
- seurat conversion is no longer supported and the validator need no longer check

## Changes
- remove Seurat Validator and references to the Seurat Validator
- remove tests involving Seurat validator
- remove `seurat_is_convertible` status from the return signature for the `validate()` function

## Testing
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer