### PR TITLE
chore: bump cog version for schema 5.3.0

### DIFF
--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata>=0.8,<0.11
-cellxgene-ontology-guide==1.2.0 # update before a schema migration
+cellxgene-ontology-guide==1.3.0 # update before a schema migration
 click<9
 Cython<4
 numpy<2

--- a/scripts/schema_bump_dry_run_ontologies/requirements.txt
+++ b/scripts/schema_bump_dry_run_ontologies/requirements.txt
@@ -1,2 +1,2 @@
 requests<3
-cellxgene-ontology-guide==1.2.0
+cellxgene-ontology-guide==1.3.0


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/cellxgene-ontology-guide/241

## Changes

- bumps COG version to 1.3.0, which i just released here: https://github.com/chanzuckerberg/cellxgene-ontology-guide/pull/243

## Testing

n/a

## Notes for Reviewer