### PR TITLE
chore: forbid any NaN in spatial embeddings #

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1004,7 +1004,7 @@ class Validator:
                 if np.isinf(value).any():
                     issue_list.append(f"adata.obsm['{key}'] contains positive infinity or negative infinity values.")
 
-                # spatial embeddings can't have any NaN
+                # spatial embeddings can't have any NaN; other embeddings can't be all NaNs
                 if key_is_spatial and np.any(np.isnan(value)):
                     issue_list.append("adata.obs['spatial] contains at least one NaN value.")
                 elif np.all(np.isnan(value)):

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1050,8 +1050,7 @@ class TestCheckSpatial:
         validator.adata.obsm["spatial"][0, 1] = np.nan
         # Confirm spatial is valid.
         validator.validate_adata()
-        assert len(validator.errors) == 1
-        assert validator.errors[0] == "ERROR: adata.obs['spatial] contains at least one NaN value."
+        assert validator.errors == ["ERROR: adata.obs['spatial] contains at least one NaN value."]
 
 
 class TestValidatorValidateDataFrame:

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1040,6 +1040,19 @@ class TestCheckSpatial:
             in validator.errors[0]
         )
 
+    def test__validate_embeddings_non_nans(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator.visium_and_is_single_true_matrix_size = 2
+
+        # invalidate spatial embeddings with NaN value
+        validator.adata.obsm["spatial"][0, 1] = np.nan
+        # Confirm spatial is valid.
+        validator.validate_adata()
+        assert len(validator.errors) == 1
+        assert validator.errors[0] == "ERROR: adata.obs['spatial] contains at least one NaN value."
+
 
 class TestValidatorValidateDataFrame:
     @pytest.mark.parametrize("_type", [np.int64, np.int32, int, np.float64, np.float32, float, str])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,8 @@ show_error_codes = true
 ignore_missing_imports = true
 warn_unreachable = true
 warn_unused_configs = true
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "cellxgene_schema_cli"
+]


### PR DESCRIPTION
## Reason for Change
- #1105 
- compliance with 5.3 schema

## Changes
- add NaN check for spatial embeddings - no NaNs allowed
- convenience change: pyproject.toml - pytest block adds cellxgene_schema_cli to python path

## Testing
- added one test to test_validate
- modified existing test in test_compliance
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer
- notice the change to pyproject.toml. It's useful for vscode dev (allows me to interactively debug tests) and it shouldn't interfere with other environments. I'm happy to take out if it has unintended consequences.