### PR TITLE
feat: add support for validating c. elegans

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -283,9 +283,6 @@ components:
                 ancestors:
                   WBbt:
                     - WBbt:0005766
-              forbidden:
-                terms:
-                  - WBbt:0005766
         # if organism is none of the above
         error_message_suffix: >-
           When 'organism_ontology_term_id'-specific requirements are not defined in the schema definition,
@@ -505,9 +502,6 @@ components:
                 ancestors:
                   WBls:
                     - WBls:0000075
-              forbidden:
-                terms:
-                  - WBls:0000075
               exceptions:
                 - unknown
         # If organism is none of the above

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -200,6 +200,21 @@ components:
                         - FBbt:00007002
                     exceptions:
                       - unknown
+            - # If organism is c. elegans
+                rule: "organism_ontology_term_id == 'NCBITaxon:6239'"
+                error_message_suffix: >-
+                    When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans),
+                    'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'WBbt:0004017' (cell).
+                type: curie
+                curie_constraints:
+                    ontologies:
+                      - WBbt
+                    allowed:
+                      ancestors:
+                        WBbt:
+                        - WBbt:0004017
+                    exceptions:
+                      - unknown
         # if organism is none of the above
         error_message_suffix: >-
             When 'organism_ontology_term_id'-specific requirements are not defined in the schema definition,
@@ -254,6 +269,23 @@ components:
                 ancestors:
                   FBbt:
                     - FBbt:00007002
+          - # If organism is c. elegans
+            rule: "organism_ontology_term_id == 'NCBITaxon:6239'"
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans),
+              'organism_tissue_ontology_term_id' MUST be the most accurate descendant
+              of WBbt:0005766 for Anatomy
+            type: curie
+            curie_constraints:
+              ontologies:
+                - WBbt
+              allowed:
+                ancestors:
+                  WBbt:
+                    - WBbt:0005766
+              forbidden:
+                terms:
+                  - WBbt:0005766
         # if organism is none of the above
         error_message_suffix: >-
           When 'organism_ontology_term_id'-specific requirements are not defined in the schema definition,
@@ -264,8 +296,26 @@ components:
           exceptions:
             - na
       sex_ontology_term_id:
-        error_message_suffix: "Only 'PATO:0000383', 'PATO:0000384', 'PATO:0001340', or 'unknown' are allowed."
         type: curie
+        dependencies:
+          - # If organism is c. elegans
+            rule: "organism_ontology_term_id == 'NCBITaxon:6239'"
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans),
+              'sex_ontology_term_id' MUST be 'PATO:0000384' for male, 'PATO:0001340' for hermaphrodite, or 'unknown'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - PATO
+              allowed:
+                terms:
+                  PATO:
+                    - PATO:0000384
+                    - PATO:0001340
+              exceptions:
+                - unknown
+        # if organism is none of the above
+        error_message_suffix: "Only 'PATO:0000383', 'PATO:0000384', 'PATO:0001340', or 'unknown' are allowed."
         curie_constraints:
           ontologies:
             - PATO
@@ -440,6 +490,24 @@ components:
             curie_constraints:
               ontologies:
                 - FBdv
+              exceptions:
+                - unknown
+          - # If organism is C. elegans
+            rule: "organism_ontology_term_id == 'NCBITaxon:6239'"
+            error_message_suffix: >-
+             When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans),
+             'development_stage_ontology_term_id' MUST be the most accurate descendant of 'WBls:0000075'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - WBls
+              allowed:
+                ancestors:
+                  WBls:
+                    - WBls:0000075
+              forbidden:
+                terms:
+                  - WBls:0000075
               exceptions:
                 - unknown
         # If organism is none of the above
@@ -711,10 +779,10 @@ components:
           - "organoid"
           - "tissue"
         dependencies:
-          - # If organism_ontology_term_id is NCBITaxon:7955 or NCBITaxon:7227, 'tissue_type' MUST be 'tissue'
-            rule: "organism_ontology_term_id == 'NCBITaxon:7955' | organism_ontology_term_id == 'NCBITaxon:7227'"
+          - # If organism_ontology_term_id is NCBITaxon:7955, NCBITaxon:7227, or NCBITaxon:6239 'tissue_type' MUST be 'tissue'
+            rule: "organism_ontology_term_id == 'NCBITaxon:7955' | organism_ontology_term_id == 'NCBITaxon:7227' | organism_ontology_term_id == 'NCBITaxon:6239'"
             type: categorical
             error_message_suffix: >-
-              when 'organism_ontology_term_id' is NCBITaxon:7955 or NCBITaxon:7227
+              when 'organism_ontology_term_id' is NCBITaxon:7955, NCBITaxon:7227, or NCBITaxon:6239
             enum:
               - "tissue"

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata>=0.8,<0.11
-cellxgene-ontology-guide==1.3.0a1
+cellxgene-ontology-guide==1.3.2a0
 click<9
 Cython<4
 numpy<2

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="5.2.1-alpha.1",
+    version="5.2.1-alpha.2",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -3066,7 +3066,7 @@ class TestRoundworm:
             ),
             (
                 "WBls:0000075",  # Do not accept WBls:0000075 itself, must be a descendant
-                "ERROR: 'WBls:0000075' in 'development_stage_ontology_term_id' is not allowed.",
+                "ERROR: 'WBls:0000075' in 'development_stage_ontology_term_id' is not an allowed term id.",
             ),
         ],
     )
@@ -3193,7 +3193,7 @@ class TestRoundworm:
             ),
             (
                 "WBbt:0005766",  # Must be descendant of WBbt:0005766, not itself
-                "ERROR: 'WBbt:0005766' in 'organism_tissue_ontology_term_id' is not allowed.",
+                "ERROR: 'WBbt:0005766' in 'organism_tissue_ontology_term_id' is not an allowed term id.",
             ),
             (
                 "na",  # Allowed for other organisms, not allowed if organism is c. elegans

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -463,6 +463,8 @@ class TestObs:
             "ERROR: Checking values with dependencies failed for "
             "adata.obs['organism_tissue_ontology_term_id'], this is likely due "
             "to missing dependent column in adata.obs.",
+            "ERROR: Checking values with dependencies failed for adata.obs['sex_ontology_term_id'], "
+            "this is likely due to missing dependent column in adata.obs.",
             "ERROR: Checking values with dependencies failed for "
             "adata.obs['self_reported_ethnicity_ontology_term_id'], this is likely due "
             "to missing dependent column in adata.obs.",
@@ -2763,7 +2765,8 @@ class TestZebrafish:
         validator.validate_adata()
         error_message = (
             f"ERROR: Column 'tissue_type' in dataframe 'obs' contains invalid values '['{tissue_type}']'. "
-            f"Values must be one of ['tissue'] when 'organism_ontology_term_id' is NCBITaxon:7955 or NCBITaxon:7227"
+            f"Values must be one of ['tissue'] when 'organism_ontology_term_id' is NCBITaxon:7955, NCBITaxon:7227, "
+            f"or NCBITaxon:6239"
         )
         assert error_message in validator.errors
 
@@ -2993,6 +2996,271 @@ class TestFruitFly:
         validator.validate_adata()
         error_message = (
             f"ERROR: Column 'tissue_type' in dataframe 'obs' contains invalid values '['{tissue_type}']'. "
-            f"Values must be one of ['tissue'] when 'organism_ontology_term_id' is NCBITaxon:7955 or NCBITaxon:7227"
+            f"Values must be one of ['tissue'] when 'organism_ontology_term_id' is NCBITaxon:7955, NCBITaxon:7227, or "
+            f"NCBITaxon:6239"
+        )
+        assert error_message in validator.errors
+
+
+class TestRoundworm:
+    """
+    Tests for the roundworm / c. elegans schema
+    """
+
+    @pytest.fixture
+    def roundworm_obs(self):
+        obs = examples.adata.copy().obs
+        obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:6239"
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "WBbt:0008611"
+        obs.loc[obs.index[0], "self_reported_ethnicity_ontology_term_id"] = "na"
+        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "WBls:0000001"
+        obs.loc[obs.index[0], "organism_tissue_ontology_term_id"] = "WBbt:0006749"
+        obs.loc[obs.index[0], "sex_ontology_term_id"] = "PATO:0000384"
+        return obs
+
+    @pytest.fixture
+    def roundworm_visium_obs(self):
+        obs = examples.adata_visium.copy().obs
+        obs.loc[obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:6239"
+        obs.loc[obs.index[0], "self_reported_ethnicity_ontology_term_id"] = "na"
+        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = "WBls:0000001"
+        obs.loc[obs.index[0], "organism_tissue_ontology_term_id"] = "WBbt:0006749"
+        obs.loc[obs.index[0], "sex_ontology_term_id"] = "PATO:0000384"
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "unknown"
+        return obs
+
+    @pytest.fixture
+    def validator_with_roundworm_adata(self, validator_with_adata, roundworm_obs):
+        validator_with_adata.adata.obs = roundworm_obs
+        return validator_with_adata
+
+    @pytest.fixture
+    def validator_with_visium_roundworm_adata(self, validator_with_visium_assay, roundworm_visium_obs):
+        validator_with_visium_assay.adata.obs = roundworm_visium_obs
+        return validator_with_visium_assay
+
+    @pytest.mark.parametrize(
+        "development_stage_ontology_term_id",
+        ["WBls:0000104", "unknown"],
+    )
+    def test_development_stage_ontology_term_id_roundworm(
+        self, validator_with_roundworm_adata, development_stage_ontology_term_id
+    ):
+        """
+        If organism_ontolology_term_id is "NCBITaxon:6239" for C. elegans,
+        this MUST be the most accurate WBls term or 'unknown'
+        """
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = development_stage_ontology_term_id
+        validator.validate_adata()
+        assert not validator.errors
+
+    @pytest.mark.parametrize(
+        "development_stage_ontology_term_id,error",
+        [
+            (
+                "HsapDv:0000001",  # Wrong ontology
+                "ERROR: 'HsapDv:0000001' in 'development_stage_ontology_term_id' is not a valid ontology term id of "
+                "'WBls'.",
+            ),
+            (
+                "WBls:0000075",  # Do not accept WBls:0000075 itself, must be a descendant
+                "ERROR: 'WBls:0000075' in 'development_stage_ontology_term_id' is not allowed.",
+            ),
+        ],
+    )
+    def test_development_stage_ontology_term_id_roundworm__invalid(
+        self, validator_with_roundworm_adata, development_stage_ontology_term_id, error
+    ):
+        """
+        If organism_ontolology_term_id is "NCBITaxon:6239" for C. elegans,
+        this MUST be the most accurate WBls:0000075 descendant.
+
+        NOTE: as of current implementation, all WBls terms are descendants of WBls:0000075
+        """
+        roundworm_error_message_suffix = (
+            "When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans), "
+            "'development_stage_ontology_term_id' MUST be the most accurate descendant of 'WBls:0000075'."
+        )
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "development_stage_ontology_term_id"] = development_stage_ontology_term_id
+        validator.validate_adata()
+        assert validator.errors == [error + " " + roundworm_error_message_suffix]
+
+    @pytest.mark.parametrize(
+        "organism_cell_type_ontology_term_id",
+        ["WBbt:0005762", "unknown"],
+    )
+    def test_organism_cell_type_ontology_term_id(
+        self, validator_with_roundworm_adata, organism_cell_type_ontology_term_id
+    ):
+        """
+        If organism_ontolology_term_id is "NCBITaxon:6239" for C. elegans,
+        MUST be a descendant term id of 'WBbt:0004017' (cell) or 'unknown'
+        """
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = organism_cell_type_ontology_term_id
+        validator.validate_adata()
+        assert not validator.errors
+
+    @pytest.mark.parametrize(
+        "organism_cell_type_ontology_term_id,error",
+        [
+            (
+                "CL:0000001",  # Wrong ontology
+                "ERROR: 'CL:0000001' in 'organism_cell_type_ontology_term_id' is not a valid ontology term id of 'WBbt'.",
+            ),
+            (
+                "WBbt:0000100",  # Same ontology, not a descendant of WBbt:0004017
+                "ERROR: 'WBbt:0000100' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
+            ),
+            (
+                "WBbt:0004017",  # Do not accept WBbt:0004017 itself, must be a descendant
+                "ERROR: 'WBbt:0004017' in 'organism_cell_type_ontology_term_id' is not an allowed term id.",
+            ),
+            (
+                "na",  # Allowed for other organisms, not allowed if organism is fruit fly
+                "ERROR: 'na' in 'organism_cell_type_ontology_term_id' is not a valid ontology term id of 'WBbt'.",
+            ),
+        ],
+    )
+    def test_organism_cell_type_ontology_term_id__invalid(
+        self, validator_with_roundworm_adata, organism_cell_type_ontology_term_id, error
+    ):
+        validator = validator_with_roundworm_adata
+        roundworm_error_message_suffix = (
+            "When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans), "
+            "'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'WBbt:0004017' (cell)."
+        )
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = organism_cell_type_ontology_term_id
+        validator.validate_adata()
+        assert validator.errors == [error + " " + roundworm_error_message_suffix]
+
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_roundworm_adata):
+        validator = validator_with_visium_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "in_tissue"] = 0
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "unknown"
+        validator.validate_adata()
+        assert not validator.errors
+
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0_invalid(
+        self, validator_with_visium_roundworm_adata
+    ):
+        validator = validator_with_visium_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "in_tissue"] = 0
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "WBbt:0005739"
+        validator.validate_adata()
+        assert (
+            "obs['cell_type_ontology_term_id'] must be 'unknown' and obs['organism_cell_type_ontology_term_id'] must "
+            "be 'unknown' or 'na' depending on the value of 'organism_ontology_term_id' (see schema definition)"
+            in validator.errors[0]
+        )
+
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0__na(self, validator_with_visium_roundworm_adata):
+        validator = validator_with_visium_roundworm_adata
+        error_message = (
+            "ERROR: 'na' in 'organism_cell_type_ontology_term_id' is not a valid ontology term id of 'WBbt'. "
+            "When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans), "
+            "'organism_cell_type_ontology_term_id' MUST be a descendant term id of 'WBbt:0004017' (cell)."
+        )
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "in_tissue"] = 0
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "na"
+        validator.validate_adata()
+        # Passes visium check but fails organism_cell_type_ontology_term_id check
+        assert validator.errors == [error_message]
+
+    def test_organism_tissue_type_ontology_term_id(self, validator_with_roundworm_adata):
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "organism_tissue_ontology_term_id"] = "WBbt:0006750"  # valid descendant of WBbt:0005766
+        validator.validate_adata()
+        assert not validator.errors
+
+    @pytest.mark.parametrize(
+        "organism_tissue_ontology_term_id,error",
+        [
+            (
+                "UBERON:0000001",  # Wrong ontology
+                "ERROR: 'UBERON:0000001' in 'organism_tissue_ontology_term_id' is not a valid ontology term id "
+                "of 'WBbt'.",
+            ),
+            (
+                "WBbt:0005766",  # Must be descendant of WBbt:0005766, not itself
+                "ERROR: 'WBbt:0005766' in 'organism_tissue_ontology_term_id' is not allowed.",
+            ),
+            (
+                "na",  # Allowed for other organisms, not allowed if organism is c. elegans
+                "ERROR: 'na' in 'organism_tissue_ontology_term_id' is not a valid ontology term id of 'WBbt'.",
+            ),
+            (
+                "unknown",
+                "ERROR: 'unknown' in 'organism_tissue_ontology_term_id' is not a valid ontology term id of 'WBbt'.",
+            ),
+        ],
+    )
+    def test_organism_tissue_ontology_term_id__invalid(
+        self, validator_with_roundworm_adata, organism_tissue_ontology_term_id, error
+    ):
+        validator = validator_with_roundworm_adata
+        roundworm_error_message_suffix = (
+            "When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans), "
+            "'organism_tissue_ontology_term_id' MUST be the most accurate descendant "
+            "of WBbt:0005766 for Anatomy"
+        )
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "organism_tissue_ontology_term_id"] = organism_tissue_ontology_term_id
+        validator.validate_adata()
+        assert validator.errors == [error + " " + roundworm_error_message_suffix]
+
+    def test_organism_tissue_type_valid(self, validator_with_roundworm_adata):
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "tissue_type"] = "tissue"
+        assert not validator.errors
+
+    @pytest.mark.parametrize(
+        "tissue_type",
+        ["cell culture", "organoid"],
+    )
+    def test_organism_tissue_type__invalid(self, validator_with_roundworm_adata, tissue_type):
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.tissue_type = obs.tissue_type.cat.add_categories(["organoid"])
+        obs.loc[obs.index[0], "tissue_type"] = tissue_type
+        validator.validate_adata()
+        error_message = (
+            f"ERROR: Column 'tissue_type' in dataframe 'obs' contains invalid values '['{tissue_type}']'. "
+            f"Values must be one of ['tissue'] when 'organism_ontology_term_id' is NCBITaxon:7955, NCBITaxon:7227, "
+            f"or NCBITaxon:6239"
+        )
+        assert error_message in validator.errors
+
+    @pytest.mark.parametrize(
+        "sex_ontology_term_id",
+        ["unknown", "PATO:0000384", "PATO:0001340"],
+    )
+    def test_sex_ontology_term_id_valid(self, validator_with_roundworm_adata, sex_ontology_term_id):
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "sex_ontology_term_id"] = sex_ontology_term_id
+        validator.validate_adata()
+        assert not validator.errors
+
+    def test_sex_ontology_term_id__invalid(self, validator_with_roundworm_adata):
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "sex_ontology_term_id"] = "PATO:0000383"  # allowed for other organisms, not c. elegans
+        validator.validate_adata()
+        error_message = (
+            "ERROR: 'PATO:0000383' in 'sex_ontology_term_id' is not an allowed term id. When "
+            "'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans), "
+            "'sex_ontology_term_id' MUST be 'PATO:0000384' for male, 'PATO:0001340' for hermaphrodite, or 'unknown'."
         )
         assert error_message in validator.errors


### PR DESCRIPTION
## Reason for Change

- #1128 (work for gencode / feature_reference done in separate PR)
- see corresponding c. elegans schema reqs in https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/drafts/5.2.1-experimental.md

## Changes

- add c. elegans validation rules for:
     - development stage ontology term ID
     - sex ontology term ID
     - organism_cell_type ontology term ID
     - organism_tissue_type ontology term ID
     - tissue_type
- COG ontology bump to use experimental COG release with c. elegans ontologies (1.3.2a0)
- bump CLI version to 5.2.1a2

## Testing

- unit tests (no real c. elegans examples yet to test against)

## Notes for Reviewer