### PR TITLE
feat: cellxgene-schema must update validation for X (Matrix Layers) for descendants of Visium

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -36,10 +36,14 @@ CONDITION_IS_VISIUM = "a descendant of 'EFO:0010961' (Visium Spatial Gene Expres
 CONDITION_IS_VISIUM_11M = f"'{ASSAY_VISIUM_11M} (Visium CytAssist Spatial Gene Expression, 11mm)"
 CONDITION_IS_SEQV2 = f"'{ASSAY_SLIDE_SEQV2}' (Slide-seqV2)"
 
+CONDITION_IS_VISIUM = "a descendant of 'EFO:0010961' (Visium Spatial Gene Expression)"
+CONDITION_IS_SEQV2 = f"'{ASSAY_SLIDE_SEQV2}' (Slide-seqV2)"
 
 
-ERROR_SUFFIX_VISIUM = f"obs['assay_ontology_term_id'] is either {CONDITION_IS_VISIUM} or {CONDITION_IS_SEQV2}"
+ERROR_SUFFIX_SPATIAL = f"obs['assay_ontology_term_id'] is either {CONDITION_IS_VISIUM} or {CONDITION_IS_SEQV2}"
+ERROR_SUFFIX_VISIUM = f"obs['assay_ontology_term_id'] is {CONDITION_IS_VISIUM}"
 ERROR_SUFFIX_VISIUM_11M = f"obs['assay_ontology_term_id'] is {CONDITION_IS_VISIUM_11M}"
+
 ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE = f"{ERROR_SUFFIX_VISIUM} and uns['spatial']['is_single'] is True"
 ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_FORBIDDEN = f"is only allowed for {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}"
 ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_REQUIRED = f"is required for {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}"
@@ -107,7 +111,7 @@ class Validator:
             # Visium 11M's max dimension size is distinct from other visium assays
             if bool(self.adata.obs['assay_ontology_term_id'].apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True)).any()):
                 self._visium_error_suffix = ERROR_SUFFIX_VISIUM_11M
-                self._hires_max_dimension_size = SPATIAL_HIRES_IMAGE_MAX_DIEMSNION_SIZE_VISIUM_11MM
+                self._hires_max_dimension_size = SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM
             elif self._is_visium_including_descendants():
                 self._visium_error_suffix = ERROR_SUFFIX_VISIUM
                 self._hires_max_dimension_size = SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1918,7 +1918,7 @@ class Validator:
                 .any()
             )
             self.is_visium = includes_and_visium
-        
+
         return includes_and_visium
 
     def _validate_spatial_image_shape(self, image_name: str, image: np.ndarray, max_dimension: int = None):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -36,15 +36,12 @@ CONDITION_IS_VISIUM = "a descendant of 'EFO:0010961' (Visium Spatial Gene Expres
 CONDITION_IS_VISIUM_11M = f"'{ASSAY_VISIUM_11M} (Visium CytAssist Spatial Gene Expression, 11mm)"
 CONDITION_IS_SEQV2 = f"'{ASSAY_SLIDE_SEQV2}' (Slide-seqV2)"
 
-CONDITION_IS_VISIUM = "a descendant of 'EFO:0010961' (Visium Spatial Gene Expression)"
-CONDITION_IS_SEQV2 = f"'{ASSAY_SLIDE_SEQV2}' (Slide-seqV2)"
-
-
 ERROR_SUFFIX_SPATIAL = f"obs['assay_ontology_term_id'] is either {CONDITION_IS_VISIUM} or {CONDITION_IS_SEQV2}"
 ERROR_SUFFIX_VISIUM = f"obs['assay_ontology_term_id'] is {CONDITION_IS_VISIUM}"
 ERROR_SUFFIX_VISIUM_11M = f"obs['assay_ontology_term_id'] is {CONDITION_IS_VISIUM_11M}"
 
-ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE = f"{ERROR_SUFFIX_VISIUM} and uns['spatial']['is_single'] is True"
+ERROR_SUFFIX_IS_SINGLE = "uns['spatial']['is_single'] is True"
+ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE = f"{ERROR_SUFFIX_VISIUM} and {ERROR_SUFFIX_IS_SINGLE}"
 ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_FORBIDDEN = f"is only allowed for {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}"
 ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_REQUIRED = f"is required for {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}"
 ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0 = f"{ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE} and in_tissue is 0"
@@ -99,10 +96,10 @@ class Validator:
                 .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
                 .any()
             ):
-                self._visium_error_suffix = ERROR_SUFFIX_VISIUM_11M
+                self._visium_error_suffix = f"{ERROR_SUFFIX_VISIUM_11M} and {ERROR_SUFFIX_IS_SINGLE}"
                 self._visium_and_is_single_true_matrix_size = VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE
             elif self._is_visium_including_descendants():
-                self._visium_error_suffix = ERROR_SUFFIX_VISIUM
+                self._visium_error_suffix = f"{ERROR_SUFFIX_VISIUM} and {ERROR_SUFFIX_IS_SINGLE}"
                 self._visium_and_is_single_true_matrix_size = VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE
         return self._visium_and_is_single_true_matrix_size
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1918,7 +1918,7 @@ class Validator:
                 .any()
             )
             self.is_visium = includes_and_visium
-
+        
         return includes_and_visium
 
     def _validate_spatial_image_shape(self, image_name: str, image: np.ndarray, max_dimension: int = None):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -4,7 +4,7 @@ import numbers
 import os
 import re
 from datetime import datetime
-from typing import Dict, List, Mapping, Optional, Union, Tuple
+from typing import Dict, List, Mapping, Optional, Union
 
 import anndata
 import matplotlib.colors as mcolors
@@ -89,12 +89,16 @@ class Validator:
 
     @property
     def visium_and_is_single_true_matrix_size(self) -> Optional[int]:
-        '''
+        """
         Returns the required matrix size based on assay type, if applicable, else returns None.
-        '''
+        """
         if self._visium_and_is_single_true_matrix_size is None:
             # Visium 11M's raw matrix size is distinct from other visium assays
-            if bool(self.adata.obs['assay_ontology_term_id'].apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True)).any()):
+            if bool(
+                self.adata.obs["assay_ontology_term_id"]
+                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
+                .any()
+            ):
                 self._visium_error_suffix = ERROR_SUFFIX_VISIUM_11M
                 self._visium_and_is_single_true_matrix_size = VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE
             elif self._is_visium_including_descendants():
@@ -104,20 +108,22 @@ class Validator:
 
     @property
     def hires_max_dimension_size(self) -> Optional[int]:
-        '''
+        """
         Returns the restricted hires image dimension based on assay type, if applicable, else returns None.
-        '''
+        """
         if self._hires_max_dimension_size is None:
             # Visium 11M's max dimension size is distinct from other visium assays
-            if bool(self.adata.obs['assay_ontology_term_id'].apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True)).any()):
+            if bool(
+                self.adata.obs["assay_ontology_term_id"]
+                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
+                .any()
+            ):
                 self._visium_error_suffix = ERROR_SUFFIX_VISIUM_11M
                 self._hires_max_dimension_size = SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM
             elif self._is_visium_including_descendants():
                 self._visium_error_suffix = ERROR_SUFFIX_VISIUM
                 self._hires_max_dimension_size = SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE
         return self._hires_max_dimension_size
-
-
 
     def _is_single(self) -> bool | None:
         """
@@ -1266,7 +1272,6 @@ class Validator:
             self._raw_layer_exists = True
             is_sparse_matrix = matrix_format in SPARSE_MATRIX_TYPES
 
-            
             is_visium_and_is_single_true = self._is_visium_and_is_single_true()
             if is_visium_and_is_single_true and x.shape[0] != self.visium_and_is_single_true_matrix_size:
                 self._raw_layer_exists = False
@@ -1956,7 +1961,7 @@ class Validator:
                 .apply(lambda assay: is_ontological_descendant_of(ONTOLOGY_PARSER, assay, ASSAY_VISIUM, True))
                 .any()
             )
-      
+
         return self.is_visium
 
     def _validate_spatial_image_shape(self, image_name: str, image: np.ndarray, max_dimension: int = None):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -19,6 +19,7 @@ from cellxgene_schema.validate import (
     ERROR_SUFFIX_VISIUM,
     ERROR_SUFFIX_VISIUM_11M,
     ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE,
+    ERROR_SUFFIX_IS_SINGLE,
     SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE,
     SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM,
     VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE,
@@ -336,14 +337,14 @@ class TestExpressionMatrix:
         validator.validate_adata()
         if assay_ontology_term_id == ASSAY_VISIUM_11M:
             _errors = [
-                f"ERROR: When {ERROR_SUFFIX_VISIUM_11M}, the raw matrix must be the "
+                f"ERROR: When {ERROR_SUFFIX_VISIUM_11M} and {ERROR_SUFFIX_IS_SINGLE}, the raw matrix must be the "
                 "unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
                 f"{validator.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is 2.",
                 "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
             ]
         else:
             _errors = [
-                f"ERROR: When {ERROR_SUFFIX_VISIUM}, the raw matrix must be the "
+                f"ERROR: When {ERROR_SUFFIX_VISIUM} and {ERROR_SUFFIX_IS_SINGLE}, the raw matrix must be the "
                 "unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
                 f"{validator.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is 2.",
                 "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
@@ -387,13 +388,13 @@ class TestExpressionMatrix:
         validator.validate_adata()
         if assay_ontology_term_id == ASSAY_VISIUM_11M:
             assert (
-                validator.errors[0] == f"ERROR: When {ERROR_SUFFIX_VISIUM_11M}, the raw matrix must be the "
+                validator.errors[0] == f"ERROR: When {ERROR_SUFFIX_VISIUM_11M} and {ERROR_SUFFIX_IS_SINGLE}, the raw matrix must be the "
                 "unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
                 f"{validator.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is 2."
             )
         else:
             assert (
-                validator.errors[0] == f"ERROR: When {ERROR_SUFFIX_VISIUM}, the raw matrix must be the "
+                validator.errors[0] == f"ERROR: When {ERROR_SUFFIX_VISIUM} and {ERROR_SUFFIX_IS_SINGLE}, the raw matrix must be the "
                 "unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
                 f"{validator.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is 2."
             )

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -16,10 +16,10 @@ from cellxgene_schema.schema import get_schema_definition
 from cellxgene_schema.utils import getattr_anndata
 from cellxgene_schema.validate import (
     ASSAY_VISIUM_11M,
+    ERROR_SUFFIX_IS_SINGLE,
     ERROR_SUFFIX_VISIUM,
     ERROR_SUFFIX_VISIUM_11M,
     ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE,
-    ERROR_SUFFIX_IS_SINGLE,
     SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE,
     SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM,
     VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE,
@@ -388,13 +388,15 @@ class TestExpressionMatrix:
         validator.validate_adata()
         if assay_ontology_term_id == ASSAY_VISIUM_11M:
             assert (
-                validator.errors[0] == f"ERROR: When {ERROR_SUFFIX_VISIUM_11M} and {ERROR_SUFFIX_IS_SINGLE}, the raw matrix must be the "
+                validator.errors[0]
+                == f"ERROR: When {ERROR_SUFFIX_VISIUM_11M} and {ERROR_SUFFIX_IS_SINGLE}, the raw matrix must be the "
                 "unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
                 f"{validator.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is 2."
             )
         else:
             assert (
-                validator.errors[0] == f"ERROR: When {ERROR_SUFFIX_VISIUM} and {ERROR_SUFFIX_IS_SINGLE}, the raw matrix must be the "
+                validator.errors[0]
+                == f"ERROR: When {ERROR_SUFFIX_VISIUM} and {ERROR_SUFFIX_IS_SINGLE}, the raw matrix must be the "
                 "unfiltered feature-barcode matrix 'raw_feature_bc_matrix'. It must have exactly "
                 f"{validator.visium_and_is_single_true_matrix_size} rows. Raw matrix row count is 2."
             )

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -23,7 +23,7 @@ from cellxgene_schema.validate import (
     VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE,
     VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE,
     SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE,
-    SPATIAL_HIRES_IMAGE_MAX_DIEMSNION_SIZE_VISIUM_11MM,
+    SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM,
     Validator,
 )
 from fixtures.examples_validate import (
@@ -314,7 +314,7 @@ class TestExpressionMatrix:
         "assay_ontology_term_id, req_matrix_size, image_size",
         [
             ("EFO:0022858", VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE, SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE),
-            ("EFO:0022860", VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE, SPATIAL_HIRES_IMAGE_MAX_DIEMSNION_SIZE_VISIUM_11MM),
+            ("EFO:0022860", VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE, SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM),
         ],
     )
     def test_raw_values__invalid_visium_and_is_single_true_row_length(self, validator_with_visium_assay, assay_ontology_term_id, req_matrix_size, image_size):
@@ -350,7 +350,7 @@ class TestExpressionMatrix:
         "assay_ontology_term_id, req_matrix_size, image_size",
         [
             ("EFO:0022858", VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE, SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE),
-            ("EFO:0022860", VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE, SPATIAL_HIRES_IMAGE_MAX_DIEMSNION_SIZE_VISIUM_11MM),
+            ("EFO:0022860", VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE, SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM),
         ],
     )
     def test_raw_values__multiple_invalid_in_tissue_errors(self, validator_with_visium_assay, assay_ontology_term_id, req_matrix_size, image_size):
@@ -549,7 +549,7 @@ class TestObs:
             assert validator.errors == []
         else:
             assert validator.errors == [
-                "obs['in_tissue'] is only allowed for obs['assay_ontology_term_id'] is a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) and uns['spatial']['is_single'] is True."
+                f"obs['in_tissue'] is only allowed for {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE}."
             ]
 
     @pytest.mark.parametrize("reserved_column", schema_def["components"]["obs"]["reserved_columns"])

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -247,13 +247,13 @@ class TestExpressionMatrix:
             "ERROR: Each cell must have at least one non-zero value in its row in the raw matrix.",
             "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
         ]
-
+    # TODO:[EM] try multiple combinations 
     def test_raw_values__contains_zero_row_in_tissue_1_mixed_in_tissue_values(self, validator_with_visium_assay):
         """
         Raw Matrix contains a row with all zeros and in_tissue is 1, and there are also values with in_tissue 0.
         """
 
-        validator = validator_with_visium_assay
+        validator: Validator = validator_with_visium_assay
         validator.adata.X[1] = numpy.zeros(validator.adata.var.shape[0], dtype=numpy.float32)
         validator.adata.raw.X[1] = numpy.zeros(validator.adata.var.shape[0], dtype=numpy.float32)
         validator.validate_adata()
@@ -262,6 +262,7 @@ class TestExpressionMatrix:
             "non-zero value in its row in the raw matrix.",
             "ERROR: Raw data may be missing: data in 'raw.X' does not meet schema requirements.",
         ]
+
 
     def test_raw_values__contains_all_zero_rows_in_tissue_0(self, validator_with_visium_assay):
         """

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -364,7 +364,7 @@ class TestCheckSpatial:
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.visium_and_is_single_true_matrix_size = 2
+        validator._visium_and_is_single_true_matrix_size = 2
         # Confirm spatial is valid.
         validator.validate_adata()
         assert not validator.errors
@@ -384,7 +384,7 @@ class TestCheckSpatial:
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.visium_and_is_single_true_matrix_size = 2
+        validator._visium_and_is_single_true_matrix_size = 2
         validator.adata.X = validator.adata.X.toarray()
         validator.adata.raw = validator.adata.copy()
         validator.adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
@@ -1141,7 +1141,7 @@ class TestCheckSpatial:
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.visium_and_is_single_true_matrix_size = 2
+        validator._visium_and_is_single_true_matrix_size = 2
 
         # invalidate spatial embeddings with NaN value
         validator.adata.obsm["spatial"][0, 1] = np.nan


### PR DESCRIPTION
## Reason for Change

- #1099 
- apply spatial X requirements when assay is any descendant of visium
- different X row length depending on Visium 11mm vs any other Visium assay

## Changes
- updated error messages to include Visium 11mm where relevant
- custom validator dynamic  properties (i.e. `@property`) for visium assay dependent values


## Testing
- added paramterized tests for descendant visium assay and visium 11 assay

## Notes for Reviewer
- There was a pretty hefty rebase required for this.