### PR TITLE
chore: suspension type validation refactor

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -357,15 +357,17 @@ components:
               multi_term:
                 delimiter: ","
                 sorted: True
-        # If organism is not Human
-        error_message_suffix: >-
-          When 'organism_ontology_term_id' is NOT 'NCBITaxon:9606' (Homo sapiens),
-          self_reported_ethnicity_ontology_term_id MUST be 'na'.
-        curie_constraints:
-          ontologies:
-            - NA
-          exceptions:
-            - na
+          - # If organism is not human
+            rule: "organism_ontology_term_id != 'NCBITaxon:9606'"
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is NOT 'NCBITaxon:9606' (Homo sapiens),
+              self_reported_ethnicity_ontology_term_id MUST be 'na'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - NA
+              exceptions:
+                - na
         add_labels:
           - type: curie
             to_column: self_reported_ethnicity
@@ -402,23 +404,25 @@ components:
                     - MmusDv:0000001
               exceptions:
                 - unknown
-        # If organism is not humnan nor mouse
-        error_message_suffix: >-
-          When 'organism_ontology_term_id' is not 'NCBITaxon:10090' nor 'NCBITaxon:9606',
-          'development_stage_ontology_term_id' MUST be a descendant term id of 'UBERON:0000105'
-          excluding 'UBERON:0000071', or unknown.
-        curie_constraints:
-          ontologies:
-            - UBERON
-          allowed:
-            ancestors:
-              UBERON:
-                - UBERON:0000105
-          exceptions:
-            - unknown
-          forbidden:
-            terms:
-              - UBERON:0000071
+          - # If organism is not human nor mouse
+            rule: "organism_ontology_term_id != 'NCBITaxon:9606' & organism_ontology_term_id != 'NCBITaxon:10090'"
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is not 'NCBITaxon:10090' nor 'NCBITaxon:9606',
+              'development_stage_ontology_term_id' MUST be a descendant term id of 'UBERON:0000105'
+              excluding 'UBERON:0000071', or unknown.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - UBERON
+              allowed:
+                ancestors:
+                  UBERON:
+                    - UBERON:0000105
+              exceptions:
+                - unknown
+              forbidden:
+                terms:
+                  - UBERON:0000071
         add_labels:
           - type: curie
             to_column: development_stage

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -136,6 +136,94 @@ components:
         add_labels:
           - type: curie
             to_column: assay
+        dependencies:
+          - # If suspension_type is cell
+            rule: "suspension_type == 'cell'"
+            error_message_suffix: >-
+              'suspension_type' is 'cell', but 'assay_ontology_term_id' does not match one of the corresponding assays
+              for 'cell' in the schema definition.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - EFO
+              allowed:
+                terms:
+                  EFO:
+                    - EFO:0030080
+                    - EFO:0700004
+                    - EFO:0700003
+                    - EFO:0010010
+                    - EFO:0008722
+                    - EFO:0700011
+                    - EFO:0008780
+                    - EFO:0008796
+                    - EFO:0030060
+                    - EFO:0030002
+                    - EFO:0008853
+                    - EFO:0022490
+                    - EFO:0010550
+                    - EFO:0030028
+                    - EFO:0008919
+                    - EFO:0010184
+                    - EFO:0009919
+                    - EFO:0008953
+                    - EFO:0700010
+                ancestors:
+                  EFO:
+                    - EFO:0030080
+                    - EFO:0008919
+                    - EFO:0010184
+          - # If suspension_type is nucleus
+            rule: "suspension_type == 'nucleus'"
+            error_message_suffix: >-
+              'suspension_type' is 'nucleus', but 'assay_ontology_term_id' does not match one of the corresponding
+              assays for 'nucleus' in the schema definition.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - EFO
+              allowed:
+                terms:
+                  EFO:
+                    - EFO:0030080
+                    - EFO:0007045
+                    - EFO:0010010
+                    - EFO:0008720
+                    - EFO:0008722
+                    - EFO:0700011
+                    - EFO:0008780
+                    - EFO:0030060
+                    - EFO:0002761
+                    - EFO:0022490
+                    - EFO:0030026
+                    - EFO:0010550
+                    - EFO:0030028
+                    - EFO:0010184
+                    - EFO:0009919
+                    - EFO:0700010
+                ancestors:
+                  EFO:
+                    - EFO:0030080
+                    - EFO:0007045
+                    - EFO:0002761
+                    - EFO:0010184
+          - # If suspension_type is na
+            rule: "suspension_type == 'na'"
+            error_message_suffix: >-
+              'suspension_type' is 'na', but 'assay_ontology_term_id' does not match one of the corresponding
+              assays for 'na' in the schema definition.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - EFO
+              allowed:
+                terms:
+                  EFO:
+                    - EFO:0008992
+                    - EFO:0008994
+                ancestors:
+                  EFO:
+                    - EFO:0008994
       disease_ontology_term_id:
         error_message_suffix: "Only 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed"
         type: curie
@@ -345,237 +433,6 @@ components:
           - "cell"
           - "nucleus"
           - "na"
-        error_message_suffix: >-
-          when 'assay_ontology_term_id' does not match one of the assays in the schema definition.
-        # if no dependencies are matched
-        warning_message: >-
-          Data contains assay(s) that are not represented in the 'suspension_type' schema definition table. Ensure you have
-          selected the most appropriate value for the assay(s) between 'cell', 'nucleus', and 'na'. Please contact cellxgene@chanzuckerberg.com
-          during submission so that the assay(s) can be added to the schema definition document.
-        dependencies:
-          - # If assay_ontology_term_id is EFO:0030080 or its descendants, 'suspension_type' MUST be 'cell' or 'nucleus'
-            complex_rule:
-              match_ancestors:
-                column: assay_ontology_term_id
-                ancestors:
-                  EFO:
-                    - EFO:0030080
-                inclusive: True
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030080 or its descendants
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0007045 or its descendants, 'suspension_type' MUST be 'nucleus'
-            complex_rule:
-              match_ancestors:
-                column: assay_ontology_term_id
-                ancestors:
-                  EFO:
-                    - EFO:0007045
-                inclusive: True
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0007045 or its descendants
-            enum:
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0010184 or its descendants, 'suspension_type' MUST be 'cell' or 'nucleus'
-            complex_rule:
-              match_ancestors:
-                column: assay_ontology_term_id
-                ancestors:
-                  EFO:
-                    - EFO:0010184
-                inclusive: True
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0010184 or its descendants
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008994 or its descendants, 'suspension_type' MUST be 'na'
-            complex_rule:
-              match_ancestors:
-                column: assay_ontology_term_id
-                ancestors:
-                  EFO:
-                    - EFO:0008994
-                inclusive: True
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008994 or its descendants
-            enum:
-              - "na"
-          - # If assay_ontology_term_id is EFO:0008919 or its descendants, 'suspension_type' MUST be 'cell'
-            complex_rule:
-              match_ancestors:
-                column: assay_ontology_term_id
-                ancestors:
-                  EFO:
-                    - EFO:0008919
-                inclusive: True
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008919 or its descendants
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0002761 or its descendants, 'suspension_type' MUST be 'nucleus'
-            complex_rule:
-              match_ancestors:
-                column: assay_ontology_term_id
-                ancestors:
-                  EFO:
-                    - EFO:0002761
-                inclusive: True
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0002761 or its descendants
-            enum:
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0010010, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0010010'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0010010
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008720, 'suspension_type' MUST be 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0008720'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008720
-            enum:
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008722, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0008722'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008722
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0030002, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0030002'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030002
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0008853, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0008853'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008853
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0030026, 'suspension_type' MUST be 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0030026'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030026
-            enum:
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0010550, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0010550'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0010550
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008796, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0008796'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008796
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0700003, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0700003'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0700003
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0700004, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0700004'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0700004
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0008780, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0008780'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008780
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008953, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0008953'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008953
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0700010, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0700010'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0700010
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0700011, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0700011'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0700011
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0009919, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0009919'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0009919
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0030060, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0030060'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030060
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0022490, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0022490'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0022490
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0030028, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0030028'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030028
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008992, 'suspension_type' MUST be 'na'
-            rule: "assay_ontology_term_id == 'EFO:0008992'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008992
-            enum:
-              - "na"
       tissue_type:
         type: categorical
         enum:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -568,7 +568,7 @@ class Validator:
         :param dict column_def: schema definition for this specific column,
         e.g. schema_def["obs"]["columns"]["cell_type_ontology_term_id"]
 
-        :rtype bool: True if no errors caught, False if errors caught sand thus not valid
+        :rtype bool: True if no errors caught, False if errors caught and thus not valid
         """
 
         # error_original_count will count the number of error messages prior to validating the column, this

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1092,13 +1092,11 @@ class TestObs:
             "self_reported_ethnicity_ontology_term_id",
         ] = ["HANCESTRO:0005,HANCESTRO:0014"]
         validator.validate_adata()
-        assert validator.errors == [
-            self.get_format_error_message(
-                error_message_suffix,
-                "ERROR: '['HANCESTRO:0005,HANCESTRO:0014']' in 'self_reported_ethnicity_ontology_term_id' is not "
-                "a valid ontology term value, it must be a string.",
-            )
-        ]
+        assert validator.errors[1] == self.get_format_error_message(
+            error_message_suffix,
+            "ERROR: '['HANCESTRO:0005,HANCESTRO:0014']' in 'self_reported_ethnicity_ontology_term_id' is not "
+            "a valid ontology term value, it must be a string.",
+        )
 
     def test_organism_ontology_term_id(self, validator_with_adata):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -473,9 +473,6 @@ class TestObs:
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: Dataframe 'obs' is missing column " "'assay_ontology_term_id'.",
-            "ERROR: Checking values with dependencies failed for "
-            "adata.obs['suspension_type'], this is likely due "
-            "to missing dependent column in adata.obs.",
         ]
 
     @pytest.mark.parametrize(
@@ -962,7 +959,7 @@ class TestObs:
         validator = validator_with_adata
         error_message_suffix = validator.schema_def["components"]["obs"]["columns"][
             "self_reported_ethnicity_ontology_term_id"
-        ]["error_message_suffix"]
+        ]["dependencies"][-1]["error_message_suffix"]
         # Mouse organism ID
         validator.adata.obs.loc[validator.adata.obs.index[0], "organism_ontology_term_id"] = "NCBITaxon:10090"
         # Required to set to avoid development_stage_ontology_term_id errors
@@ -1095,11 +1092,13 @@ class TestObs:
             "self_reported_ethnicity_ontology_term_id",
         ] = ["HANCESTRO:0005,HANCESTRO:0014"]
         validator.validate_adata()
-        assert validator.errors[1] == self.get_format_error_message(
-            error_message_suffix,
-            "ERROR: '['HANCESTRO:0005,HANCESTRO:0014']' in 'self_reported_ethnicity_ontology_term_id' is not "
-            "a valid ontology term value, it must be a string.",
-        )
+        assert validator.errors == [
+            self.get_format_error_message(
+                error_message_suffix,
+                "ERROR: '['HANCESTRO:0005,HANCESTRO:0014']' in 'self_reported_ethnicity_ontology_term_id' is not "
+                "a valid ontology term value, it must be a string.",
+            )
+        ]
 
     def test_organism_ontology_term_id(self, validator_with_adata):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1371,9 +1371,9 @@ class TestObs:
         obs.loc[obs.index[1], "assay_ontology_term_id"] = assay
         validator.validate_adata()
         assert validator.errors == [
-            f"ERROR: Column 'suspension_type' in dataframe 'obs' contains invalid values "
-            f"'['{invalid_suspension_type}']'. Values must be one of {suspension_types} when "
-            f"'assay_ontology_term_id' is {assay}"
+            f"ERROR: '{assay}' in 'assay_ontology_term_id' is not an allowed term id. 'suspension_type' is "
+            f"'{invalid_suspension_type}', but 'assay_ontology_term_id' does not match one of the corresponding assays "
+            f"for '{invalid_suspension_type}' in the schema definition."
         ]
 
     @pytest.mark.parametrize(
@@ -1404,9 +1404,9 @@ class TestObs:
         obs.loc[obs.index[1], "suspension_type"] = invalid_suspension_type
         validator.validate_adata()
         assert validator.errors == [
-            f"ERROR: Column 'suspension_type' in dataframe 'obs' contains invalid values "
-            f"'['{invalid_suspension_type}']'. Values must be one of {suspension_types} when "
-            f"'assay_ontology_term_id' is {assay} or its descendants"
+            f"ERROR: '{assay}' in 'assay_ontology_term_id' is not an allowed term id. 'suspension_type' is "
+            f"'{invalid_suspension_type}', but 'assay_ontology_term_id' does not match one of the corresponding assays "
+            f"for '{invalid_suspension_type}' in the schema definition."
         ]
 
     def test_suspension_type_with_descendant_term_id_failure(self, validator_with_adata):
@@ -1421,9 +1421,9 @@ class TestObs:
 
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Column 'suspension_type' in dataframe 'obs' contains invalid values "
-            "'['nucleus']'. Values must be one of ['na'] when "
-            "'assay_ontology_term_id' is EFO:0008994 or its descendants"
+            "ERROR: 'EFO:0022615' in 'assay_ontology_term_id' is not an allowed term id. 'suspension_type' is "
+            "'nucleus', but 'assay_ontology_term_id' does not match one of the corresponding assays "
+            "for 'nucleus' in the schema definition."
         ]
 
     def test_suspension_type_with_descendant_term_id_success(self, validator_with_adata):
@@ -1438,23 +1438,6 @@ class TestObs:
 
         validator.validate_adata()
         assert validator.errors == []
-
-    def test_suspension_type_unrecognized_assay(self, validator_with_adata):
-        """
-        suspension_id categorical with str categories. This field MUST be "cell", "nucleus", or "na". The allowed
-        values depend on the assay_ontology_term_id. MUST warn if the corresponding assay is not recognized.
-        """
-        validator = validator_with_adata
-        obs = validator.adata.obs
-        obs.loc[obs.index[1], "assay_ontology_term_id"] = "EFO:0700005"
-        validator.validate_adata()
-        assert validator.errors == []
-        assert validator.warnings == [
-            "WARNING: Data contains assay(s) that are not represented in the 'suspension_type' schema "
-            "definition table. Ensure you have selected the most appropriate value for the assay(s) between "
-            "'cell', 'nucleus', and 'na'. Please contact cellxgene@chanzuckerberg.com "
-            "during submission so that the assay(s) can be added to the schema definition document."
-        ]
 
     def test_categories_with_zero_values_warn(self, validator_with_adata):
         validator = validator_with_adata


### PR DESCRIPTION
## Reason for Change

- Suspension type implementation introduced needless complication into schema definition yaml and was not performant, in exchange for more detailed error messages
- I don't think this trade-off has been worthwhile, so I propose simplifying the suspension type validation to follow patterns other fields' validation use and improve performance by reducing the total number of pandas df queries the validator runs.
- TODO: Refactor loses ability to warn but still accept unrecognized assays. Must account for that

## Changes

- remove "complex_rule" pattern in schema_definition.yaml, use 'dependencies -> rule' pattern 
- remove "complex_rule" implementation in valdiate.py (designed to be extensible, but no new field using it has come up in the last two years)
- group queries by suspension type (3) rather than by assay type (25 and counting)
- use slightly more generic error messages to accommodate this pattern (instead of specifying what suspension_types are valid for a failing assay x suspension_type combo, just flags that it is an invalid combo and to check the schema for a valid suspension type for the given assay type)
- small refactor to schema_definition.yaml to list all dependent validation rules for a field under "dependencies" rather than supporting both a list under 'dependencies' and a "default" validation defined outside of "dependencies". This affected self_reported_ethnicity_ontology_term_id and development_stage_ontology_term_id.
- small refactor to "_validate_column" command to account for removing "default" dependency behavior. 

## Testing

- unit tests for regression testing
- TBD notebook testing for performance improvement

## Notes for Reviewer