### PR TITLE
fix: handle both string and category encoded "assay_ontology_term_id"

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1648,8 +1648,10 @@ class Validator:
             return
 
         # Validate all out of tissue (in_tissue==0) spatial spots have unknown cell ontology term
-        is_spatial = self.adata.obs["assay_ontology_term_id"].apply(
-            lambda assay: is_ontological_descendant_of(ONTOLOGY_PARSER, assay, ASSAY_VISIUM, True)
+        is_spatial = (
+            self.adata.obs["assay_ontology_term_id"]
+            .apply(lambda assay: is_ontological_descendant_of(ONTOLOGY_PARSER, assay, ASSAY_VISIUM, True))
+            .astype(bool)
         )
         is_not_tissue = self.adata.obs["in_tissue"] == 0
         is_not_unknown = self.adata.obs["cell_type_ontology_term_id"] != "unknown"
@@ -1676,9 +1678,9 @@ class Validator:
             not (self.is_visium_and_is_single_true)
             or (
                 ~(
-                    self.adata.obs["assay_ontology_term_id"].apply(
-                        lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM, True)
-                    )
+                    self.adata.obs["assay_ontology_term_id"]
+                    .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM, True))
+                    .astype(bool)
                 )
                 & (self.adata.obs[tissue_position_name].notnull())
             ).any()
@@ -1697,9 +1699,9 @@ class Validator:
             tissue_position_name not in self.adata.obs
             or (
                 (
-                    self.adata.obs["assay_ontology_term_id"].apply(
-                        lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM, True)
-                    )
+                    self.adata.obs["assay_ontology_term_id"]
+                    .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM, True))
+                    .astype(bool)
                 )
                 & (self.adata.obs[tissue_position_name].isnull())
             ).any()

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -633,14 +633,20 @@ class TestObs:
         ]
         assert validator.errors == [self.get_format_error_message(error_message_suffix, error)]
 
-    def test_assay_ontology_term_id__is_categorical(self, validator_with_visium_assay):
+    def test_assay_ontology_term_id__as_categorical(self, validator_with_visium_assay):
         """
         Formally, assay_ontology_term_id is expected to be a categorical variable of type string. However, it should work for categorical dtypes as well.
         """
         validator: Validator = validator_with_visium_assay
+        
+        # check encoding as string
+        validator._validate_obsm()
+        assert validator.errors == []
+        validator.reset()
+        
         # force encoding as 'categorical'
         validator.adata.obs["assay_ontology_term_id"] = validator.adata.obs["assay_ontology_term_id"].astype("category")
-        validator.validate_adata()
+        validator._validate_obsm()
         assert validator.errors == []
 
     def test_cell_type_ontology_term_id_invalid_term(self, validator_with_adata):

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -562,6 +562,7 @@ class TestObs:
         # reset and test
         validator.reset()
         validator.adata.obs["assay_ontology_term_id"] = assay_ontology_term_id
+        validator.adata.obs["assay_ontology_term_id"] = validator.adata.obs["assay_ontology_term_id"].astype("category")
         validator._validate_spatial_tissue_position("in_tissue", 0, 1)
         if is_descendant:
             assert validator.errors == []
@@ -631,6 +632,16 @@ class TestObs:
             "error_message_suffix"
         ]
         assert validator.errors == [self.get_format_error_message(error_message_suffix, error)]
+
+    def test_assay_ontology_term_id__is_categorical(self, validator_with_visium_assay):
+        """
+        Formally, assay_ontology_term_id is expected to be a categorical variable of type string. However, it should work for categorical dtypes as well.
+        """
+        validator: Validator = validator_with_visium_assay
+        # force encoding as 'categorical'
+        validator.adata.obs["assay_ontology_term_id"] = validator.adata.obs["assay_ontology_term_id"].astype("category")
+        validator.validate_adata()
+        assert validator.errors == []
 
     def test_cell_type_ontology_term_id_invalid_term(self, validator_with_adata):
         validator = validator_with_adata

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -638,12 +638,12 @@ class TestObs:
         Formally, assay_ontology_term_id is expected to be a categorical variable of type string. However, it should work for categorical dtypes as well.
         """
         validator: Validator = validator_with_visium_assay
-        
+
         # check encoding as string
         validator._validate_obsm()
         assert validator.errors == []
         validator.reset()
-        
+
         # force encoding as 'categorical'
         validator.adata.obs["assay_ontology_term_id"] = validator.adata.obs["assay_ontology_term_id"].astype("category")
         validator._validate_obsm()

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -640,13 +640,13 @@ class TestObs:
         validator: Validator = validator_with_visium_assay
 
         # check encoding as string
-        validator._validate_obsm()
+        validator._check_spatial_obs()
         assert validator.errors == []
         validator.reset()
 
         # force encoding as 'categorical'
         validator.adata.obs["assay_ontology_term_id"] = validator.adata.obs["assay_ontology_term_id"].astype("category")
-        validator._validate_obsm()
+        validator._check_spatial_obs()
         assert validator.errors == []
 
     def test_cell_type_ontology_term_id_invalid_term(self, validator_with_adata):


### PR DESCRIPTION


## Reason for Change
- #1134 


## Changes
- in cases where a unary operation is applied to "category" dtype column, be sure to cast the result as boolean

## Testing
- a single test was added specifically for the 'assay_ontology_term_id' obs field checking that it works when encoded as a normal string or as a category.

## Notes for Reviewer
- This should not introduce any new ambiguity, however, it does not remove existing ambiguity elsewhere in the codebase whereby some implicit assumptions about column encoding may be violated.