### PR TITLE
chore: add back return value from is_seurat_convertible

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -2115,7 +2115,7 @@ def validate(
     add_labels_file: str = None,
     ignore_labels: bool = False,
     verbose: bool = False,
-) -> (bool, list):
+) -> (bool, list, bool):
     from .write_labels import AnnDataLabelAppender
 
     """
@@ -2124,7 +2124,8 @@ def validate(
     :param Union[str, bytes, os.PathLike] h5ad_path: Path to h5ad file to validate
     :param str add_labels_file: Path to new h5ad file with ontology/gene labels added
 
-    :return (True, []) if successful validation, (False, [list_of_errors]) otherwise
+    :return (True, [], False) if successful validation, (False, [list_of_errors], False) otherwise;
+    last bool is for seurat convertability which is deprecated / unused
     :rtype tuple
     """
 
@@ -2138,7 +2139,7 @@ def validate(
 
     # Stop if validation was unsuccessful
     if not validator.is_valid:
-        return False, validator.errors
+        return False, validator.errors, False
 
     if add_labels_file:
         label_start = datetime.now()
@@ -2149,6 +2150,6 @@ def validate(
             f"{writer.was_writing_successful}"
         )
 
-        return (validator.is_valid and writer.was_writing_successful, validator.errors + writer.errors)
+        return (validator.is_valid and writer.was_writing_successful, validator.errors + writer.errors, False)
 
-    return True, validator.errors
+    return True, validator.errors, False

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -297,7 +297,7 @@ class TestValidate:
         with tempfile.TemporaryDirectory() as temp_dir:
             labels_path = "/".join([temp_dir, "labels.h5ad"])
 
-            success, errors = validate(h5ad_valid, labels_path)
+            success, errors, _ = validate(h5ad_valid, labels_path)
 
             import anndata as ad
 
@@ -312,7 +312,7 @@ class TestValidate:
             assert original_hash != expected_hash, "Writing labels did not change the dataset from the original."
 
     def test__validate_with_h5ad_valid_and_without_labels(self):
-        success, errors = validate(h5ad_valid)
+        success, errors, _ = validate(h5ad_valid)
 
         assert success
         assert not errors
@@ -321,14 +321,14 @@ class TestValidate:
         with tempfile.TemporaryDirectory() as temp_dir:
             labels_path = "/".join([temp_dir, "labels.h5ad"])
 
-            success, errors = validate(h5ad_invalid, labels_path)
+            success, errors, _ = validate(h5ad_invalid, labels_path)
 
             assert not success
             assert errors
             assert not os.path.exists(labels_path)
 
     def test__validate_with_h5ad_invalid_and_without_labels(self):
-        success, errors = validate(h5ad_invalid)
+        success, errors, _ = validate(h5ad_invalid)
 
         assert not success
         assert errors


### PR DESCRIPTION
## Reason for Change

makes the change to remove `is_seurat_convertible` more backwards compatible friendly by continuing to return `False`. we can remove this return value entirely with a future release, though i think it should technically be part of a major update if we do

## Changes

- returns `False` as the final tuple value always

## Testing

updated unit tests

## Notes for Reviewer