### PR TITLE
feat: support for visium descendants in obs['assay_ontology_term_id']

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -172,7 +172,7 @@ class Validator:
             try:
                 _spatial = (
                     self._is_visium_including_descendants()
-                    or self.adata.obs.assay_ontology_term_id.isin([ASSAY_SLIDE_SEQV2]).any()
+                    or self.adata.obs.assay_ontology_term_id.isin([ASSAY_SLIDE_SEQV2]).astype(bool).any()
                 )
                 self.is_spatial = bool(_spatial)
             except AttributeError:


### PR DESCRIPTION
## Reason for Change
- #1102 

## Changes
- support for visium descendants in obs['assay_ontology_term_id'] 
- update `validator.reset()` function to include optional parameters to set key constants e.g. spatial hi res image size, tissue position matrix size.
- squash bug related to `categorial` vs `string` dtypes 

## Testing
- no notes.

## Notes for Reviewer
- updating the `reset()` function enables test fixtures to use smaller images and matrices, where necessary, without flagging additional errors.