### PR TITLE
chore: update logging to log by donor id instead

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -960,7 +960,6 @@ class Validator:
                                 f"Column '{column_name}' in dataframe '{df_name}' contains a category '{category}' with "
                                 f"zero observations. These categories will be removed when `--add-labels` flag is present."
                             )
-                    self._validate_genetic_ancestry()
                 categorical_types = {type(x) for x in column.dtype.categories.values}
                 # Check for columns that have illegal categories, which are not supported by anndata 0.8.0
                 # TODO: check if this can be removed after upgading to anndata 0.10.0
@@ -2058,6 +2057,9 @@ class Validator:
 
         # Checks spatial
         self._check_spatial()
+
+        # Validate genetic ancestry
+        self._validate_genetic_ancestry()
 
         # Checks each component
         for component_name, component_def in self.schema_def["components"].items():

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -554,9 +554,10 @@ class Validator:
         invalid_rows = ~self.adata.obs.apply(is_valid_row, axis=1)
 
         if invalid_rows.any():
-            invalid_indices = self.adata.obs.index[invalid_rows].tolist()
+            donor_ids = self.adata.obs[donor_id_column].tolist()
+            unique_donor_ids = list(set(donor_ids))
             self.errors.append(
-                f"obs rows with indices {invalid_indices} have invalid genetic_ancestry_* values. All "
+                f"obs rows with donor ids {unique_donor_ids} have invalid genetic_ancestry_* values. All "
                 f"observations with the same donor_id must contain the same genetic_ancestry_* values. If "
                 f"organism_ontolology_term_id is NOT 'NCBITaxon:9606' for Homo sapiens, then all genetic"
                 f"ancestry values MUST be float('nan'). If organism_ontolology_term_id is 'NCBITaxon:9606' "

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1740,7 +1740,7 @@ class TestObs:
         validator.adata.obs["genetic_ancestry_South_Asian"] = [0.0, 0.0]
         validator.reset(None, 2)
         validator.validate_adata()
-        assert len(validator.errors) > 0
+        assert len(validator.errors) == 1
 
         # Change the donor id back to two different donor id's. Now, this should pass validation
         validator.adata.obs["donor_id"] = original_donor_id_column


### PR DESCRIPTION
## Reason for Change

- follow up based on QA feedback [from lattice](https://czi-sci.slack.com/archives/C07AV4NU9D2/p1732737017085079) to update logging to be based on donor id, instead of row indices

## Changes

- updates the error log to be based on donor id instead of row indices
- i also moved the `_validate_genetic_ancestry` check into `_deep_check` because i realized that embedding it into the component level validation was causing it to be run multiple times, resulting in multiple errors

## Testing
since this was mostly just a copy change, i updated `test_genetic_ancestry_same_donor_id` to print out the errors and to intentionally fail the test. here is the error message which shows the copy has been updated to show donor ids:
```
        print(validator.errors)
>       assert len(validator.errors) == 0
E       assert 1 == 0
E        +  where 1 = len(["ERROR: obs rows with donor ids ['donor_1'] have invalid genetic_ancestry_* values. All observations with the same do...value MUST be a float('nan') if unavailable; otherwise, the sum of all genetic_ancestry_* fields must be equal to 1.0"])
E        +    where ["ERROR: obs rows with donor ids ['donor_1'] have invalid genetic_ancestry_* values. All observations with the same do...value MUST be a float('nan') if unavailable; otherwise, the sum of all genetic_ancestry_* fields must be equal to 1.0"] = <cellxgene_schema.validate.Validator object at 0x152d942e0>.errors

tests/test_schema_compliance.py:1745: AssertionError
```

additionally, that test was updated to `assert len(validator.errors) == 1` rather than `assert len(validation.errors) > 0`

## Notes for Reviewer