### PR TITLE
fix: donor id error logging + obsm typo

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1118,7 +1118,7 @@ class Validator:
 
                 # spatial embeddings can't have any NaN; other embeddings can't be all NaNs
                 if key_is_spatial and np.any(np.isnan(value)):
-                    issue_list.append("adata.obsm['spatial] contains at least one NaN value.")
+                    issue_list.append("adata.obsm['spatial'] contains at least one NaN value.")
                 elif np.all(np.isnan(value)):
                     issue_list.append(f"adata.obsm['{key}'] contains all NaN values.")
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1118,7 +1118,7 @@ class Validator:
 
                 # spatial embeddings can't have any NaN; other embeddings can't be all NaNs
                 if key_is_spatial and np.any(np.isnan(value)):
-                    issue_list.append("adata.obs['spatial] contains at least one NaN value.")
+                    issue_list.append("adata.obsm['spatial] contains at least one NaN value.")
                 elif np.all(np.isnan(value)):
                     issue_list.append(f"adata.obsm['{key}'] contains all NaN values.")
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -525,8 +525,8 @@ class Validator:
         invalid_rows = ~self.adata.obs.apply(is_valid_row, axis=1)
 
         if invalid_rows.any():
-            donor_ids = self.adata.obs[donor_id_column].tolist()
-            unique_donor_ids = list(set(donor_ids))
+            invalid_donor_ids = self.adata.obs.loc[invalid_rows, "donor_id"]
+            unique_donor_ids = list(set(invalid_donor_ids))
             self.errors.append(
                 f"obs rows with donor ids {unique_donor_ids} have invalid genetic_ancestry_* values. All "
                 f"observations with the same donor_id must contain the same genetic_ancestry_* values. If "

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2416,7 +2416,7 @@ class TestObsm:
         if key != "spatial":
             assert validator.errors == []
         else:
-            assert validator.errors == ["ERROR: adata.obsm['spatial] contains at least one NaN value."]
+            assert validator.errors == ["ERROR: adata.obsm['spatial'] contains at least one NaN value."]
 
         # Check embedding has all NaNs
         all_nan = numpy.full(obsm[key].shape, numpy.nan)
@@ -2426,7 +2426,7 @@ class TestObsm:
         if key != "spatial":
             assert validator.errors == [f"ERROR: adata.obsm['{key}'] contains all NaN values."]
         else:
-            assert validator.errors == ["ERROR: adata.obsm['spatial] contains at least one NaN value."]
+            assert validator.errors == ["ERROR: adata.obsm['spatial'] contains at least one NaN value."]
 
     def test_obsm_values_no_X_embedding__non_spatial_dataset(self, validator_with_adata):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2416,7 +2416,7 @@ class TestObsm:
         if key != "spatial":
             assert validator.errors == []
         else:
-            assert validator.errors == ["ERROR: adata.obs['spatial] contains at least one NaN value."]
+            assert validator.errors == ["ERROR: adata.obsm['spatial] contains at least one NaN value."]
 
         # Check embedding has all NaNs
         all_nan = numpy.full(obsm[key].shape, numpy.nan)
@@ -2426,7 +2426,7 @@ class TestObsm:
         if key != "spatial":
             assert validator.errors == [f"ERROR: adata.obsm['{key}'] contains all NaN values."]
         else:
-            assert validator.errors == ["ERROR: adata.obs['spatial] contains at least one NaN value."]
+            assert validator.errors == ["ERROR: adata.obsm['spatial] contains at least one NaN value."]
 
     def test_obsm_values_no_X_embedding__non_spatial_dataset(self, validator_with_adata):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1721,7 +1721,6 @@ class TestObs:
 
         # Second row should have identical donor id + genetic ancestry values, so this should pass validation
         validator.adata.obs.iloc[1] = validator.adata.obs.iloc[0].values
-
         validator.validate_adata()
         assert validator.errors == []
 

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1171,7 +1171,7 @@ class TestCheckSpatial:
         validator.adata.obsm["spatial"][0, 1] = np.nan
         # Confirm spatial is valid.
         validator.validate_adata()
-        assert validator.errors == ["ERROR: adata.obsm['spatial] contains at least one NaN value."]
+        assert validator.errors == ["ERROR: adata.obsm['spatial'] contains at least one NaN value."]
 
 
 class TestValidatorValidateDataFrame:

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1171,7 +1171,7 @@ class TestCheckSpatial:
         validator.adata.obsm["spatial"][0, 1] = np.nan
         # Confirm spatial is valid.
         validator.validate_adata()
-        assert validator.errors == ["ERROR: adata.obs['spatial] contains at least one NaN value."]
+        assert validator.errors == ["ERROR: adata.obsm['spatial] contains at least one NaN value."]
 
 
 class TestValidatorValidateDataFrame:


### PR DESCRIPTION
## Reason for Change

- the previous error logging was printing out all of the possible categorical values for `donor_id`, which would print out all possible donor id values. not just the donor id values for the invalid rows.

## Changes

- `self.adata.obs.loc[invalid_rows, "donor_id"]` will only fetch the donor_id fields when `invalid_rows` for that index is true. so this will only print out the donor ids that are actually invalid
- i also added in a typo fix for this [line](https://github.com/chanzuckerberg/single-cell-curation/blob/60673117145bb27edd83cde3fa7fb62052e3a5b7/cellxgene_schema_cli/cellxgene_schema/validate.py#L1121) which should say `adata.obsm['spatial']` instead of `adata.obs['spatial]`

## Testing

i tested this by just printing out the error log in `test_genetic_ancestry_same_donor_id`. previously, this error message would say `ERROR: obs rows with donor ids ['donor_1', 'donor_2']`. however, this should be `ERROR: obs rows with donor ids ['donor_1']` because the way that this test is set up, only `donor_1` has invalid values

```
ERROR    cellxgene_schema.validate:validate.py:2138 ERROR: obs rows with donor ids ['donor_1'] have invalid genetic_ancestry_* values. All observations with the same donor_id must contain the same genetic_ancestry_* values. If organism_ontolology_term_id is NOT 'NCBITaxon:9606' for Homo sapiens, then all geneticancestry values MUST be float('nan'). If organism_ontolology_term_id is 'NCBITaxon:9606' for Homo sapiens, then the value MUST be a float('nan') if unavailable; otherwise, the sum of all genetic_ancestry_* fields must be equal to 1.0
```

## Notes for Reviewer