### PR TITLE
feat: refactor suspension type validation logic to be simpler and more performant

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -186,7 +186,12 @@ components:
         type: curie
         dependencies:
           - # If tissue_type is tissue OR organoid
-            rule: "tissue_type == 'tissue' | tissue_type == 'organoid'"
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - tissue
+                  - organoid
             error_message_suffix: >-
               When 'tissue_type' is 'tissue' or 'organoid',
               'tissue_ontology_term_id' MUST be a descendant term id of 'UBERON:0001062' (anatomical entity).
@@ -199,7 +204,11 @@ components:
                   UBERON:
                     - UBERON:0001062
           - # If tissue_type is cell culture
-            rule: "tissue_type == 'cell culture'"
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - cell culture
             error_message_suffix: >-
               When 'tissue_type' is 'cell culture', 'tissue_ontology_term_id' MUST be either a CL term
               (excluding 'CL:0000255' (eukaryotic cell), 'CL:0000257' (Eumycetozoan cell),
@@ -222,7 +231,11 @@ components:
         type: curie
         dependencies:
           - # If organism is Human
-            rule: "organism_ontology_term_id == 'NCBITaxon:9606'"
+            rule:
+              column: organism_ontology_term_id
+              match_exact:
+                terms:
+                  - NCBITaxon:9606
             error_message_suffix: >-
               When 'organism_ontology_term_id' is 'NCBITaxon:9606' (Homo sapiens),
               self_reported_ethnicity_ontology_term_id MUST be formatted as one
@@ -285,7 +298,11 @@ components:
         type: curie
         dependencies:
           - # If organism is Human
-            rule: "organism_ontology_term_id == 'NCBITaxon:9606'"
+            rule:
+              column: organism_ontology_term_id
+              match_exact:
+                terms:
+                  - NCBITaxon:9606
             error_message_suffix: >-
               When 'organism_ontology_term_id' is 'NCBITaxon:9606' (Homo sapiens),
               'development_stage_ontology_term_id' MUST be the most accurate descendant of 'HsapDv:0000001' or unknown.
@@ -300,7 +317,11 @@ components:
               exceptions:
                 - unknown
           - # If organism is Mouse
-            rule: "organism_ontology_term_id == 'NCBITaxon:10090'"
+            rule:
+              column: organism_ontology_term_id
+              match_exact:
+                terms:
+                  - NCBITaxon:10090
             error_message_suffix: >-
               When 'organism_ontology_term_id' is 'NCBITaxon:10090' (Mus musculus),
               'development_stage_ontology_term_id' MUST be the most accurate descendant of 'MmusDv:0000001' or unknown.
@@ -354,16 +375,15 @@ components:
           during submission so that the assay(s) can be added to the schema definition document.
         dependencies:
           - # 'suspension_type' MUST be 'cell' or 'nucleus'
-            complex_rule:
+            rule:
+              column: assay_ontology_term_id
               match_ancestors:
-                column: assay_ontology_term_id
                 ancestors:
                   EFO:
                     - EFO:0030080
                     - EFO:0010184
                 inclusive: True
               match_exact:
-                column: assay_ontology_term_id
                 terms:
                   - EFO:0010010
                   - EFO:0008722
@@ -376,22 +396,19 @@ components:
                   - EFO:0022490
                   - EFO:0030028
             type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030080 or its descendants
             enum:
               - "cell"
               - "nucleus"
           - # 'suspension_type' MUST be 'nucleus'
-            complex_rule:
+            rule:
+              column: assay_ontology_term_id
               match_ancestors:
-                column: assay_ontology_term_id
                 ancestors:
                   EFO:
                     - EFO:0007045
                     - EFO:0002761
                 inclusive: True
               match_exact:
-                column: assay_ontology_term_id
                 terms:
                   - EFO:0008720
                   - EFO:0030026
@@ -399,15 +416,14 @@ components:
             enum:
               - "nucleus"
           - #'suspension_type' MUST be 'cell'
-            complex_rule:
+            rule:
+              column: assay_ontology_term_id
               match_ancestors:
-                column: assay_ontology_term_id
                 ancestors:
                   EFO:
                     - EFO:0008919
                 inclusive: True
               match_exact:
-                column: assay_ontology_term_id
                 terms:
                   - EFO:0030002
                   - EFO:0008853
@@ -419,15 +435,14 @@ components:
             enum:
               - "cell"
           - # 'suspension_type' MUST be 'na'
-            complex_rule:
+            rule:
+              column: assay_ontology_term_id
               match_ancestors:
-                column: assay_ontology_term_id
                 ancestors:
                   EFO:
                     - EFO:0008994
                 inclusive: True
               match_exact:
-                column: assay_ontology_term_id
                 terms:
                   - EFO:0008992
             type: categorical

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -353,61 +353,52 @@ components:
           selected the most appropriate value for the assay(s) between 'cell', 'nucleus', and 'na'. Please contact cellxgene@chanzuckerberg.com
           during submission so that the assay(s) can be added to the schema definition document.
         dependencies:
-          - # If assay_ontology_term_id is EFO:0030080 or its descendants, 'suspension_type' MUST be 'cell' or 'nucleus'
+          - # 'suspension_type' MUST be 'cell' or 'nucleus'
             complex_rule:
               match_ancestors:
                 column: assay_ontology_term_id
                 ancestors:
                   EFO:
                     - EFO:0030080
+                    - EFO:0010184
                 inclusive: True
+              match_exact:
+                column: assay_ontology_term_id
+                terms:
+                  - EFO:0010010
+                  - EFO:0008722
+                  - EFO:0010550
+                  - EFO:0008780
+                  - EFO:0700010
+                  - EFO:0700011
+                  - EFO:0009919
+                  - EFO:0030060
+                  - EFO:0022490
+                  - EFO:0030028
             type: categorical
             error_message_suffix: >-
               when 'assay_ontology_term_id' is EFO:0030080 or its descendants
             enum:
               - "cell"
               - "nucleus"
-          - # If assay_ontology_term_id is EFO:0007045 or its descendants, 'suspension_type' MUST be 'nucleus'
+          - # 'suspension_type' MUST be 'nucleus'
             complex_rule:
               match_ancestors:
                 column: assay_ontology_term_id
                 ancestors:
                   EFO:
                     - EFO:0007045
+                    - EFO:0002761
                 inclusive: True
+              match_exact:
+                column: assay_ontology_term_id
+                terms:
+                  - EFO:0008720
+                  - EFO:0030026
             type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0007045 or its descendants
             enum:
               - "nucleus"
-          - # If assay_ontology_term_id is EFO:0010184 or its descendants, 'suspension_type' MUST be 'cell' or 'nucleus'
-            complex_rule:
-              match_ancestors:
-                column: assay_ontology_term_id
-                ancestors:
-                  EFO:
-                    - EFO:0010184
-                inclusive: True
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0010184 or its descendants
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008994 or its descendants, 'suspension_type' MUST be 'na'
-            complex_rule:
-              match_ancestors:
-                column: assay_ontology_term_id
-                ancestors:
-                  EFO:
-                    - EFO:0008994
-                inclusive: True
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008994 or its descendants
-            enum:
-              - "na"
-          - # If assay_ontology_term_id is EFO:0008919 or its descendants, 'suspension_type' MUST be 'cell'
+          - #'suspension_type' MUST be 'cell'
             complex_rule:
               match_ancestors:
                 column: assay_ontology_term_id
@@ -415,165 +406,31 @@ components:
                   EFO:
                     - EFO:0008919
                 inclusive: True
+              match_exact:
+                column: assay_ontology_term_id
+                terms:
+                  - EFO:0030002
+                  - EFO:0008853
+                  - EFO:0008796
+                  - EFO:0700003
+                  - EFO:0700004
+                  - EFO:0008953
             type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008919 or its descendants
             enum:
               - "cell"
-          - # If assay_ontology_term_id is EFO:0002761 or its descendants, 'suspension_type' MUST be 'nucleus'
+          - # 'suspension_type' MUST be 'na'
             complex_rule:
               match_ancestors:
                 column: assay_ontology_term_id
                 ancestors:
                   EFO:
-                    - EFO:0002761
+                    - EFO:0008994
                 inclusive: True
+              match_exact:
+                column: assay_ontology_term_id
+                terms:
+                  - EFO:0008992
             type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0002761 or its descendants
-            enum:
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0010010, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0010010'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0010010
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008720, 'suspension_type' MUST be 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0008720'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008720
-            enum:
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008722, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0008722'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008722
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0030002, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0030002'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030002
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0008853, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0008853'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008853
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0030026, 'suspension_type' MUST be 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0030026'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030026
-            enum:
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0010550, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0010550'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0010550
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008796, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0008796'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008796
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0700003, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0700003'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0700003
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0700004, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0700004'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0700004
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0008780, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0008780'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008780
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008953, 'suspension_type' MUST be 'cell'
-            rule: "assay_ontology_term_id == 'EFO:0008953'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008953
-            enum:
-              - "cell"
-          - # If assay_ontology_term_id is EFO:0700010, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0700010'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0700010
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0700011, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0700011'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0700011
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0009919, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0009919'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0009919
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0030060, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0030060'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030060
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0022490, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0022490'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0022490
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0030028, 'suspension_type' MUST be 'cell' or 'nucleus'
-            rule: "assay_ontology_term_id == 'EFO:0030028'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0030028
-            enum:
-              - "cell"
-              - "nucleus"
-          - # If assay_ontology_term_id is EFO:0008992, 'suspension_type' MUST be 'na'
-            rule: "assay_ontology_term_id == 'EFO:0008992'"
-            type: categorical
-            error_message_suffix: >-
-              when 'assay_ontology_term_id' is EFO:0008992
             enum:
               - "na"
       tissue_type:

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -377,11 +377,10 @@ components:
           - # 'suspension_type' MUST be 'cell' or 'nucleus'
             rule:
               column: assay_ontology_term_id
-              match_ancestors:
+              match_ancestors_inclusive:
                 ancestors:
                   - EFO:0030080
                   - EFO:0010184
-                inclusive: True
               match_exact:
                 terms:
                   - EFO:0010010
@@ -401,11 +400,10 @@ components:
           - # 'suspension_type' MUST be 'nucleus'
             rule:
               column: assay_ontology_term_id
-              match_ancestors:
+              match_ancestors_inclusive:
                 ancestors:
                   - EFO:0007045
                   - EFO:0002761
-                inclusive: True
               match_exact:
                 terms:
                   - EFO:0008720
@@ -416,10 +414,9 @@ components:
           - #'suspension_type' MUST be 'cell'
             rule:
               column: assay_ontology_term_id
-              match_ancestors:
+              match_ancestors_inclusive:
                 ancestors:
                   - EFO:0008919
-                inclusive: True
               match_exact:
                 terms:
                   - EFO:0030002
@@ -434,10 +431,9 @@ components:
           - # 'suspension_type' MUST be 'na'
             rule:
               column: assay_ontology_term_id
-              match_ancestors:
+              match_ancestors_inclusive:
                 ancestors:
                   - EFO:0008994
-                inclusive: True
               match_exact:
                 terms:
                   - EFO:0008992

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -379,9 +379,8 @@ components:
               column: assay_ontology_term_id
               match_ancestors:
                 ancestors:
-                  EFO:
-                    - EFO:0030080
-                    - EFO:0010184
+                  - EFO:0030080
+                  - EFO:0010184
                 inclusive: True
               match_exact:
                 terms:
@@ -404,9 +403,8 @@ components:
               column: assay_ontology_term_id
               match_ancestors:
                 ancestors:
-                  EFO:
-                    - EFO:0007045
-                    - EFO:0002761
+                  - EFO:0007045
+                  - EFO:0002761
                 inclusive: True
               match_exact:
                 terms:
@@ -420,8 +418,7 @@ components:
               column: assay_ontology_term_id
               match_ancestors:
                 ancestors:
-                  EFO:
-                    - EFO:0008919
+                  - EFO:0008919
                 inclusive: True
               match_exact:
                 terms:
@@ -439,8 +436,7 @@ components:
               column: assay_ontology_term_id
               match_ancestors:
                 ancestors:
-                  EFO:
-                    - EFO:0008994
+                  - EFO:0008994
                 inclusive: True
               match_exact:
                 terms:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -658,15 +658,22 @@ class Validator:
         """
 
         all_rules = []
-
         for dependency_def in dependencies:
             if "complex_rule" in dependency_def:
+                query_exp = ""
                 if "match_ancestors" in dependency_def["complex_rule"]:
                     query_fn, args = self._generate_match_ancestors_query_fn(
                         dependency_def["complex_rule"]["match_ancestors"]
                     )
                     term_id, ontologies, ancestors, ancestor_inclusive = args
                     query_exp = f"@query_fn({term_id}, {ontologies}, {ancestors}, {ancestor_inclusive})"
+                if "match_exact" in dependency_def["complex_rule"]:
+                    column_to_match = dependency_def["complex_rule"]["match_exact"]["column"]
+                    terms_to_match = dependency_def["complex_rule"]["match_exact"]["terms"]
+                    for term in terms_to_match:
+                        if query_exp:
+                            query_exp += " | "
+                        query_exp += f"{column_to_match} == '{term}'"
             elif "rule" in dependency_def:
                 query_exp = dependency_def["rule"]
             else:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -737,8 +737,8 @@ class Validator:
         for dependency_def in dependencies:
             terms_to_match = set()
             column_to_match = dependency_def["rule"]["column"]
-            if "match_ancestors" in dependency_def["rule"]:
-                ancestors = dependency_def["rule"]["match_ancestors"]["ancestors"]
+            if "match_ancestors_inclusive" in dependency_def["rule"]:
+                ancestors = dependency_def["rule"]["match_ancestors_inclusive"]["ancestors"]
                 for ancestor in ancestors:
                     terms_to_match.update(ONTOLOGY_PARSER.get_term_descendants(ancestor, include_self=True))
             if "match_exact" in dependency_def["rule"]:

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1367,13 +1367,15 @@ class TestObs:
         if "na" in suspension_types:
             invalid_suspension_type = "nucleus" if "nucleus" not in suspension_types else "cell"
         obs = validator.adata.obs
-        obs.loc[obs.index[1], "suspension_type"] = invalid_suspension_type
-        obs.loc[obs.index[1], "assay_ontology_term_id"] = assay
+        obs["suspension_type"] = invalid_suspension_type
+        obs["assay_ontology_term_id"] = assay
+        obs["suspension_type"] = obs["suspension_type"].astype("category")
+        obs["assay_ontology_term_id"] = obs["assay_ontology_term_id"].astype("category")
         validator.validate_adata()
         assert validator.errors == [
             f"ERROR: Column 'suspension_type' in dataframe 'obs' contains invalid values "
             f"'['{invalid_suspension_type}']'. Values must be one of {suspension_types} when "
-            f"'assay_ontology_term_id' is {assay}"
+            f"'assay_ontology_term_id' is in ['{assay}']"
         ]
 
     @pytest.mark.parametrize(
@@ -1400,13 +1402,15 @@ class TestObs:
         if "na" in suspension_types:
             invalid_suspension_type = "nucleus" if "nucleus" not in suspension_types else "cell"
             obs["suspension_type"] = obs["suspension_type"].cat.remove_unused_categories()
-        obs.loc[obs.index[1], "assay_ontology_term_id"] = assay
-        obs.loc[obs.index[1], "suspension_type"] = invalid_suspension_type
+        obs["suspension_type"] = invalid_suspension_type
+        obs["assay_ontology_term_id"] = assay
+        obs["suspension_type"] = obs["suspension_type"].astype("category")
+        obs["assay_ontology_term_id"] = obs["assay_ontology_term_id"].astype("category")
         validator.validate_adata()
         assert validator.errors == [
             f"ERROR: Column 'suspension_type' in dataframe 'obs' contains invalid values "
             f"'['{invalid_suspension_type}']'. Values must be one of {suspension_types} when "
-            f"'assay_ontology_term_id' is {assay} or its descendants"
+            f"'assay_ontology_term_id' is in ['{assay}']"
         ]
 
     def test_suspension_type_with_descendant_term_id_failure(self, validator_with_adata):
@@ -1416,14 +1420,15 @@ class TestObs:
         """
         validator = validator_with_adata
         obs = validator.adata.obs
-        obs.loc[obs.index[0], "assay_ontology_term_id"] = "EFO:0022615"  # descendant of EFO:0008994
-        obs.loc[obs.index[0], "suspension_type"] = "nucleus"
-
+        obs["suspension_type"] = "nucleus"
+        obs["assay_ontology_term_id"] = "EFO:0022615"  # descendant of EFO:0008994
+        obs["suspension_type"] = obs["suspension_type"].astype("category")
+        obs["assay_ontology_term_id"] = obs["assay_ontology_term_id"].astype("category")
         validator.validate_adata()
         assert validator.errors == [
             "ERROR: Column 'suspension_type' in dataframe 'obs' contains invalid values "
             "'['nucleus']'. Values must be one of ['na'] when "
-            "'assay_ontology_term_id' is EFO:0008994 or its descendants"
+            "'assay_ontology_term_id' is in ['EFO:0022615']"
         ]
 
     def test_suspension_type_with_descendant_term_id_success(self, validator_with_adata):


### PR DESCRIPTION
## Reason for Change

- Anecdotally, during testing for other tickets, suspension_type was taking unreasonably long for validate (>1 hr for dataset with 4M obs rows x 31 columns). 
     - This is likely due to executing 1 query per rule in the schema definition rather than batching together queries that evaluate to the same suspension_type value. 
- The code for defining + evaluating dependency rules is quite complex and can be simplified given our use cases
- The trade-off for this complexity is slightly more specific error messages; I believe we can achieve similarly helpful error messages with slightly less specificity traded off for more performant, simpler code.

## Changes

- refactor `schema_definition.yaml` to always use the (formerly known as) "complex_rule" format of defining your pandas queries in YAML rather than directly writing pandas queries as part of the definition. 
          - therefore, rename "complex_rule" --> "rule" and rewrite existing "rule" entries to use this format
- refactor `assay_ontology_term_id.dependencies` definition to group together assays that are validating for the same suspension_type (i.e. instead of 3 separate entries for "EFO:1", "EFO:2", and "descendants of EFO:3" must evaluate to suspension_type "cell", group them all into one dependency entry). 
          - the groups are: suspension_type should be "cell" vs. "nucleus" vs. "na" vs. "cell or nucleus". 
- refactor `_validate_column_dependencies` to simplify the query builder--build set of terms to check (including descendants, if applicable), and run a single "isin" query per rule in `schema_definition.yaml ` rather than a custom vectorized function. This is more performant for our use cases. 
- deleted `_generate_match_ancestors_query_fn`, no longer used
- add logic to build an error_message_suffix for dependencies in cases where we do not define one in the `schema_definition.yaml`. This will log which column values were matched and did not fit the rule definition (i.e. which assays in the df contain a suspension_type value validation error)

## Testing

- unit tests all pass
- locally, ran tests, and suspension_type validation is much faster (in 4M row case, it took 3 min rather than 1 hr) 

## Notes for Reviewer