### PR TITLE
feat: use dask threads schedule with default values.

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -36,8 +36,7 @@ def schema_cli(verbose):
     type=click.Path(exists=False, dir_okay=False, writable=True),
 )
 @click.option("-i", "--ignore-labels", help="Ignore ontology labels when validating", is_flag=True)
-@click.option("-n", "--num-workers", help="Number of workers to use for parallel processing", default=1, type=int)
-def schema_validate(h5ad_file, add_labels_file, ignore_labels, num_workers):
+def schema_validate(h5ad_file, add_labels_file, ignore_labels):
     # Imports are very slow so we defer loading until Click arg validation has passed
     logger.info("Loading dependencies")
     try:
@@ -48,7 +47,7 @@ def schema_validate(h5ad_file, add_labels_file, ignore_labels, num_workers):
     logger.info("Loading validator modules")
     from .validate import validate
 
-    is_valid, _, _ = validate(h5ad_file, add_labels_file, ignore_labels=ignore_labels, n_workers=num_workers)
+    is_valid, _, _ = validate(h5ad_file, add_labels_file, ignore_labels=ignore_labels)
     if is_valid:
         sys.exit(0)
     else:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -2110,7 +2110,6 @@ def validate(
     h5ad_path: Union[str, bytes, os.PathLike],
     add_labels_file: str = None,
     ignore_labels: bool = False,
-    n_workers: int = 1,
 ) -> (bool, list, bool):
     from .write_labels import AnnDataLabelAppender
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -2130,14 +2130,8 @@ def validate(
     validator = Validator(
         ignore_labels=ignore_labels,
     )
-    with dask.config.set(
-        {
-            "num_workers": n_workers,
-            "threads_per_worker": 1,
-            "distributed.worker.memory.limit": "6GB",
-            "scheduler": "threads",
-        }
-    ):
+
+    with dask.config.set({"scheduler": "threads"}):
         validator.validate_adata(h5ad_path)
         logger.info(f"Validation complete in {datetime.now() - start} with status is_valid={validator.is_valid}")
 

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -2,7 +2,7 @@ anndata==0.11.2
 cellxgene-ontology-guide==1.3.0 # update before a schema migration
 click<9
 Cython<4
-dask==2024.12.0
+dask[array]==2024.12.0
 numpy<3
 pandas>2,<3
 PyYAML<7


### PR DESCRIPTION
## Reason for Change

This is faster an reduces the over head of maintaining the dask configuration. 

Using processes instead of threads was also tried, but processes used a lot more memory and disk, and didn't provide a significant speed boost.

## Changes

- removed ``` num_workers, threads_per_worker, distributed.worker.memory.limit``` from `dask.config`. Using the default values improves speed and maintains constant memory.  ```threads_per_worker, distributed.worker.memory.limit``` are removed because they only work when using a distributed dask client.
- add `dask[array]`, this is to make sure we install a compatible numpy version.
- remove `n_workers` from the validate cli command. It is no longer used.

## Testing
1. `pip install "dask[diagnostics]"
2.  Modify `cellxgene_schema.validate` to accept `scheduler` as a parameter.
3.  Run this script
```python
from cellxgene_schema.validate import validate
import dask
from dask.diagnostics import Profiler, ResourceProfiler


dask.config.set({"visualization.engine": "graphviz"})
schedulers = ["threads", "processes"]
runs = [0,6,4,2,1]

file_name = "" # TODO insert anndata file to test.
for i in runs:
    for scheduler in schedulers:
        with Profiler() as prof, ResourceProfiler(dt=0.25) as rprof:
            start = time.time()
            validate(file_name, n_workers=i, ignore_labels=True)
            print(f"dask-profiler-{i}-{scheduler}. Elapsed time: {time.time() - start}")
    
        rprof.visualize(filename=f"dask-profiler-{i}-{scheduler}-resources.html")
        prof.visualize(filename=f"dask-profiler-{i}-{scheduler}-tasks.html")
```
## Results

From the table bellow we learn two things: increasing the number of works increases the speed of validation, and using processes is faster than threads. 

### 3 GB Dataset
#### Old Config
| Type      | Number of Workers | Elapsed Time (seconds) |
|-----------|-------------------|------------------------|
| threads   | 6                 | 61.18    |
| threads   | 4                 | 60.42   |
| threads   | 2                 | 62.00    |
| threads   | 1                 | 78.63      |

### New Config
| Type      | Number of Workers | Elapsed Time (seconds) |
|-----------|-------------------|------------------------|
| threads   | 6                 | 56.88    |
| processes | 6                 | 45.81     |
| threads   | 4                 | 57.582   |
| processes | 4                 | 39.94     |
| threads   | 2                 | 58.93     |
| processes | 2                 | 59.67      |
| threads   | 1                 | 76.291      |
| processes | 1                 | 97.63      |

#### 1 Workers  Processes VS Threads
![Screenshot 2025-01-14 at 4 54 27 PM](https://github.com/user-attachments/assets/57377434-7739-4bb6-9705-3bb3838a7e38)
#### 2 Workers  Processes VS Threads
![Screenshot 2025-01-14 at 4 54 33 PM](https://github.com/user-attachments/assets/f314c1f2-6dbf-4a0c-9835-7038418a97cb)
#### 4 Workers  Processes VS Threads
![Screenshot 2025-01-14 at 4 54 43 PM](https://github.com/user-attachments/assets/7301f591-3216-4ba1-8eac-a7e4b8048daf)
#### 6 Workers Processes VS Threads
![Screenshot 2025-01-14 at 4 54 50 PM](https://github.com/user-attachments/assets/fc0a417d-d248-4f07-a4c2-a13e17512f85)

### 20 GB Dataset
From the table bellow we learn that: increasing the number of works does speed up validation, and processes are not faster than threads for large datasets.

#### Old Config
| Type      | Number of Workers | Elapsed Time (seconds) |
|-----------|-------------------|------------------------|
| threads   | 6                 | 251.41    |
| threads   | 4                 | 253.52   |
| threads   | 2                 |   262.35 |
| threads   | 1                 |   311.92   |

#### New Config
| Type      | Number of Workers | Elapsed Time (seconds) |
|-----------|-------------------|------------------------|
| threads   | 6                 | 244.49     |
| processes | 6                 | 393.55     |
| threads   | 4                 |   244.12    |
| processes | 4                 |   374.15  |
| threads   | 2                 |    255.17  |
| processes | 2                 |    448.45  |
| threads   | 1                 |    305.99   |
| processes | 1                 |    911.90   |

#### 1 Workers  Processes VS Threads
![Screenshot 2025-01-14 at 4 32 00 PM](https://github.com/user-attachments/assets/5430ede5-77e5-485a-bda7-49d4bc58a235)

#### 2 Workers  Processes VS Threads
![Screenshot 2025-01-14 at 5 30 19 PM](https://github.com/user-attachments/assets/1f7fa32d-a7ea-4f8f-bee6-4af38ce32319)

#### 4 Workers  Processes VS Threads
![Screenshot 2025-01-14 at 4 01 47 PM](https://github.com/user-attachments/assets/f172ce5a-5d0e-462a-9d59-cb8515db14c8)

#### 6 Workers Processes VS Threads
![Screenshot 2025-01-14 at 4 01 54 PM](https://github.com/user-attachments/assets/c161504b-c447-4a2a-8ed1-61d038570d86)

## Notes for Reviewer
- The diagnostic tools for Dask are bit wonky. Sometimes they would not output a graph or would output the same graph twice.