### PR TITLE
fix: remove dependency on Validator in AnnDataLabelAppender

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -55,6 +55,29 @@ def schema_validate(h5ad_file, add_labels_file, ignore_labels):
 
 
 @schema_cli.command(
+    name="add-labels",
+    short_help="Create a copy of an h5ad with portal-added labels",
+    help="Create a copy of an h5ad with portal-added labels. The labels are added based on the IDs in the "
+    "provided file.",
+)
+@click.argument("input_file", nargs=1, type=click.Path(exists=True, dir_okay=False))
+@click.argument("output_file", nargs=1, type=click.Path(exists=False, dir_okay=False))
+def add_labels(input_file, output_file):
+    from utils import read_h5ad
+
+    from .write_labels import AnnDataLabelAppender
+
+    logger.info(f"Loading h5ad from {input_file}")
+    adata = read_h5ad(input_file)
+    anndata_label_adder = AnnDataLabelAppender(adata)
+    logger.info("Adding labels")
+    if anndata_label_adder.write_labels(output_file):
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+@schema_cli.command(
     name="remove-labels",
     short_help="Create a copy of an h5ad without portal-added labels",
     help="Create a copy of an h5ad without portal-added labels.",

--- a/cellxgene_schema_cli/cellxgene_schema/gencode.py
+++ b/cellxgene_schema_cli/cellxgene_schema/gencode.py
@@ -123,3 +123,15 @@ class GeneChecker:
             return self.gene_dict[gene_id][2]
         else:
             raise ValueError(f"The id '{gene_id}' is not a valid ENSEMBL id for '{self.species}'")
+
+
+# cache the gene checkers
+_gene_checkers = {}
+
+
+def get_gene_checker(species: SupportedOrganisms) -> GeneChecker:
+    # Values will be instances of gencode.GeneChecker,
+    # keys will be one of gencode.SupportedOrganisms
+    if species not in _gene_checkers:
+        _gene_checkers[species] = GeneChecker(species)
+    return _gene_checkers[species]

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -14,10 +14,10 @@ import scipy
 from anndata.compat import DaskArray
 from cellxgene_ontology_guide.ontology_parser import OntologyParser
 from dask.array import map_blocks
-from gencode import get_gene_checker
 from scipy import sparse
 
 from . import gencode, schema
+from .gencode import get_gene_checker
 from .utils import (
     SPARSE_MATRIX_TYPES,
     SUPPORTED_SPARSE_MATRIX_TYPES,
@@ -2146,13 +2146,13 @@ def validate(
 
         if add_labels_file:
             label_start = datetime.now()
-            writer = AnnDataLabelAppender(h5ad_path)
-            writer.write_labels(add_labels_file)
+            writer = AnnDataLabelAppender(validator.adata)
+            was_writing_successful = writer.write_labels(add_labels_file)
             logger.info(
                 f"H5AD label writing complete in {datetime.now() - label_start}, was_writing_successful: "
-                f"{writer.was_writing_successful}"
+                f"{was_writing_successful}"
             )
 
-            return (validator.is_valid and writer.was_writing_successful, validator.errors + writer.errors, False)
+            return (validator.is_valid and was_writing_successful, validator.errors + writer.errors, False)
 
         return True, validator.errors, False

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -98,11 +98,11 @@ def validator_with_slide_seq_v2_assay(validator) -> Validator:
 
 
 @pytest.fixture
-def label_writer(validator_with_validated_adata) -> AnnDataLabelAppender:
+def label_writer() -> AnnDataLabelAppender:
     """
     Fixture that returns an AnnDataLabelAppender object
     """
-    label_writer = AnnDataLabelAppender(validator_with_validated_adata)
+    label_writer = AnnDataLabelAppender(examples.adata.copy())
     label_writer._add_labels()
     return label_writer
 
@@ -2329,7 +2329,8 @@ class TestUns:
         validator.adata.uns["suspension_type_colors"] = numpy.array(["", "green"])
         validator.validate_adata()
         assert validator.errors == [
-            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. Found: ['' 'green']"
+            "ERROR: Colors in uns[suspension_type_colors] must be either all hex colors or all CSS4 named colors. "
+            "Found: ['' 'green']"
         ]
 
     def test_invalid_named_color_option_integer(self, validator_with_adata):
@@ -2752,25 +2753,25 @@ class TestAddingLabels:
         for i, j in zip(expected_column.tolist(), obtained_column.tolist()):
             assert i == j
 
-    def test_obs_added_tissue_type_label__unknown(self, validator_with_adata):
-        obs = validator_with_adata.adata.obs
+    def test_obs_added_tissue_type_label__unknown(self):
+        adata = examples.adata.copy()
+        obs = adata.obs
 
         # Arrange
         obs.at["Y", "tissue_type"] = "cell culture"  # Already set in example data, just setting explicitly here
         obs.at["Y", "tissue_ontology_term_id"] = "unknown"  # Testing this term case
-        validator_with_adata.validate_adata()  # Validate
-        labeler = AnnDataLabelAppender(validator_with_adata)
+        labeler = AnnDataLabelAppender(adata)
         labeler._add_labels()  # Annotate
 
         assert labeler.adata.obs.at["Y", "tissue"] == "unknown"
 
-    def test_obs_added_cell_type_label__unknown(self, validator_with_adata):
-        obs = validator_with_adata.adata.obs
+    def test_obs_added_cell_type_label__unknown(self):
+        adata = examples.adata.copy()
+        obs = adata.obs
 
         # Arrange
         obs.at["Y", "cell_type_ontology_term_id"] = "unknown"  # Testing this term case
-        validator_with_adata.validate_adata()  # Validate
-        labeler = AnnDataLabelAppender(validator_with_adata)
+        labeler = AnnDataLabelAppender(adata)
         labeler._add_labels()  # Annotate
 
         assert labeler.adata.obs.at["Y", "cell_type"] == "unknown"

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -58,11 +58,8 @@ def validator_with_minimal_adata():
 
 
 @pytest.fixture
-def label_writer():
-    validator = Validator()
-    validator.adata = adata_valid.copy()
-    validator.validate_adata()
-    return AnnDataLabelAppender(validator)
+def label_writer(valid_adata):
+    return AnnDataLabelAppender(adata_valid)
 
 
 @pytest.fixture
@@ -149,7 +146,7 @@ class TestAddLabelFunctions:
 
         # Bad
         ids = ["NO_GENE"]
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             label_writer._get_mapping_dict_feature_id(ids)
 
     def test_get_dictionary_mapping_feature_reference(self, label_writer):
@@ -171,7 +168,7 @@ class TestAddLabelFunctions:
 
         # Bad
         ids = ["NO_GENE"]
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             label_writer._get_mapping_dict_feature_id(ids)
 
     def test_get_dictionary_mapping_feature_length(self, label_writer):
@@ -194,7 +191,7 @@ class TestAddLabelFunctions:
 
         # Bad
         ids = ["NO_GENE"]
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             label_writer._get_mapping_dict_feature_id(ids)
 
     def test_get_dictionary_mapping_feature_type(self, label_writer):
@@ -217,7 +214,7 @@ class TestAddLabelFunctions:
 
         # Bad
         ids = ["NO_GENE"]
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             label_writer._get_mapping_dict_feature_type(ids)
 
     @pytest.mark.parametrize(
@@ -256,16 +253,14 @@ class TestAddLabelFunctions:
     def test__write__Success(self, label_writer):
         with tempfile.TemporaryDirectory() as temp_dir:
             labels_path = "/".join([temp_dir, "labels.h5ad"])
-            label_writer.write_labels(labels_path)
-        assert label_writer.was_writing_successful
+            assert label_writer.write_labels(labels_path)
         assert not label_writer.errors
 
     def test__write__Fail(self, label_writer):
         label_writer.adata.write_h5ad = mock.Mock(side_effect=Exception("Test Fail"))
         with tempfile.TemporaryDirectory() as temp_dir:
             labels_path = "/".join([temp_dir, "labels.h5ad"])
-            label_writer.write_labels(labels_path)
-        assert not label_writer.was_writing_successful
+            assert not label_writer.write_labels(labels_path)
         assert label_writer.errors
 
 


### PR DESCRIPTION
## Reason for Change

This is part of the multiome work, where multiple validations steps will happen in parallel. If all steps pass then we will add labels. To accomplish this the Validator needed to be decoupled from the AnnDataLabelAppender. This allows the AnnDataLabelAppender to run independently of validation.

## Changes

- Cache gene_checker in gencode.
- Replace the `Validator` parameter in `AnnDataLabelAppender` with `AnnData`
- Replace uses of `Validator` in `AnnDataLabelAppender`
- add cli to add labels to h5ad
- fix relative imports
- remove AnnDataLabelAppender.was_writing_successful

## Testing
- Updates tests


## Notes for Reviewer