### PR TITLE
feat: exclude generic visium (EFO:0010961) from allowed assay_ontology_term

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -103,7 +103,7 @@ class Validator:
             # Visium 11M's raw matrix size is distinct from other visium assays
             if bool(
                 self.adata.obs["assay_ontology_term_id"]
-                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
+                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, False))
                 .astype(bool)
                 .any()
             ):
@@ -123,7 +123,7 @@ class Validator:
             # Visium 11M's max dimension size is distinct from other visium assays
             if bool(
                 self.adata.obs["assay_ontology_term_id"]
-                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
+                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, False))
                 .astype(bool)
                 .any()
             ):
@@ -140,7 +140,7 @@ class Validator:
             # visium 11 has different requirements than other visium
             if (
                 self.adata.obs["assay_ontology_term_id"]
-                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
+                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, False))
                 .astype(bool)
                 .any()
             ):
@@ -1648,7 +1648,7 @@ class Validator:
         # Validate all out of tissue (in_tissue==0) spatial spots have unknown cell ontology term
         is_spatial = (
             self.adata.obs["assay_ontology_term_id"]
-            .apply(lambda assay: is_ontological_descendant_of(ONTOLOGY_PARSER, assay, ASSAY_VISIUM, True))
+            .apply(lambda assay: is_ontological_descendant_of(ONTOLOGY_PARSER, assay, ASSAY_VISIUM, False))
             .astype(bool)
         )
         is_not_tissue = self.adata.obs["in_tissue"] == 0
@@ -1677,7 +1677,7 @@ class Validator:
             or (
                 ~(
                     self.adata.obs["assay_ontology_term_id"]
-                    .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM, True))
+                    .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM, False))
                     .astype(bool)
                 )
                 & (self.adata.obs[tissue_position_name].notnull())
@@ -1698,7 +1698,7 @@ class Validator:
             or (
                 (
                     self.adata.obs["assay_ontology_term_id"]
-                    .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM, True))
+                    .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM, False))
                     .astype(bool)
                 )
                 & (self.adata.obs[tissue_position_name].isnull())
@@ -1955,7 +1955,7 @@ class Validator:
             self.is_visium = bool(
                 self.adata.obs[_assay_key]
                 .astype("string")
-                .apply(lambda assay: is_ontological_descendant_of(ONTOLOGY_PARSER, assay, ASSAY_VISIUM, True))
+                .apply(lambda assay: is_ontological_descendant_of(ONTOLOGY_PARSER, assay, ASSAY_VISIUM, False))
                 .astype(bool)
                 .any()
             )

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -103,7 +103,7 @@ class Validator:
             # Visium 11M's raw matrix size is distinct from other visium assays
             if bool(
                 self.adata.obs["assay_ontology_term_id"]
-                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, False))
+                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
                 .astype(bool)
                 .any()
             ):
@@ -123,7 +123,7 @@ class Validator:
             # Visium 11M's max dimension size is distinct from other visium assays
             if bool(
                 self.adata.obs["assay_ontology_term_id"]
-                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, False))
+                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
                 .astype(bool)
                 .any()
             ):
@@ -140,7 +140,7 @@ class Validator:
             # visium 11 has different requirements than other visium
             if (
                 self.adata.obs["assay_ontology_term_id"]
-                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, False))
+                .apply(lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_VISIUM_11M, True))
                 .astype(bool)
                 .any()
             ):

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 ONTOLOGY_PARSER = OntologyParser(schema_version="v5.3.0")
 
-ASSAY_VISIUM = "EFO:0010961" #generic term
-ASSAY_VISIUM_11M = "EFO:0022860" #specific visium assay
+ASSAY_VISIUM = "EFO:0010961"  # generic term
+ASSAY_VISIUM_11M = "EFO:0022860"  # specific visium assay
 ASSAY_SLIDE_SEQV2 = "EFO:0030062"
 
 VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE = 4992
@@ -1959,6 +1959,15 @@ class Validator:
                 .astype(bool)
                 .any()
             )
+
+            # explicitly forbid EFO:0010961
+            _contains_generic_visium = (
+                self.adata.obs["assay_ontology_term_id"].apply(lambda assay: assay == ASSAY_VISIUM).astype(bool).any()
+            )
+            if _contains_generic_visium:
+                self.errors.append(
+                    f"Invalid spatial assay. obs['assay_ontology_term_id'] must be a descendant of {ASSAY_VISIUM} but NOT {ASSAY_VISIUM} itself. "
+                )
 
         return self.is_visium
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 ONTOLOGY_PARSER = OntologyParser(schema_version="v5.3.0")
 
-ASSAY_VISIUM = "EFO:0010961"
-ASSAY_VISIUM_11M = "EFO:0022860"
+ASSAY_VISIUM = "EFO:0010961" #generic term
+ASSAY_VISIUM_11M = "EFO:0022860" #specific visium assay
 ASSAY_SLIDE_SEQV2 = "EFO:0030062"
 
 VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE = 4992

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -151,7 +151,7 @@ good_obs_visium = pd.DataFrame(
             1,
             1,
             "unknown",
-            "EFO:0010961",
+            "EFO:0022859",
             "MONDO:0100096",
             "NCBITaxon:9606",
             "PATO:0000383",
@@ -174,7 +174,7 @@ good_obs_visium = pd.DataFrame(
             2,
             2,
             "CL:0000192",
-            "EFO:0010961",
+            "EFO:0022859",
             "PATO:0000461",
             "NCBITaxon:10090",
             "unknown",
@@ -299,7 +299,7 @@ good_obs_visium_is_single_false = pd.DataFrame(
     [
         [
             "CL:0000066",
-            "EFO:0010961",
+            "EFO:0022859",
             "MONDO:0100096",
             "NCBITaxon:9606",
             "PATO:0000383",
@@ -319,7 +319,7 @@ good_obs_visium_is_single_false = pd.DataFrame(
         ],
         [
             "CL:0000192",
-            "EFO:0010961",
+            "EFO:0022859",
             "PATO:0000461",
             "NCBITaxon:10090",
             "unknown",

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -549,7 +549,7 @@ class TestObs:
 
     @pytest.mark.parametrize(
         "assay_ontology_term_id, is_descendant",
-        [("EFO:0010961", True), ("EFO:0022858", True), ("EFO:0030029", False), ("EFO:0002697", False)],
+        [("EFO:0022859", True), ("EFO:0022858", True), ("EFO:0030029", False), ("EFO:0002697", False)],
     )
     def test_column_presence_in_tissue(self, validator_with_visium_assay, assay_ontology_term_id, is_descendant):
         """
@@ -652,7 +652,7 @@ class TestObs:
 
     @pytest.mark.parametrize(
         "assay_ontology_term_id, all_same",
-        [("EFO:0010961", True), ("EFO:0030062", True), ("EFO:0022860", True), ("EFO:0008995", False)],
+        [("EFO:0022859", True), ("EFO:0030062", True), ("EFO:0022860", True), ("EFO:0008995", False)],
     )
     def test_assay_ontology_term_id__all_same(self, validator_with_visium_assay, assay_ontology_term_id, all_same):
         """
@@ -2459,7 +2459,7 @@ class TestObsm:
             "WARNING: Validation of raw layer was not performed due to current errors, try again after fixing current errors.",
         ]
 
-    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0010961", "EFO:0030062", "EFO:0022860"])
+    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0022859", "EFO:0030062", "EFO:0022860"])
     def test_obsm_values_no_X_embedding__visium_dataset(self, validator_with_visium_assay, assay_ontology_term_id):
         """
         X_{suffix} embeddings MAY exist for spatial datasets

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -337,7 +337,7 @@ class TestCheckSpatial:
         "assay_ontology_term_id, expected_is_visium",
         [
             # Parent term for Visium Spatial Gene Expression. This term and all its descendants are Visium
-            ("EFO:0010961", True),
+            ("EFO:0022858", True),
             # Visium Spatial Gene Expression V1
             ("EFO:0022857", True),
             # Visium CytAssist Spatial Gene Expression V2
@@ -461,7 +461,7 @@ class TestCheckSpatial:
 
     @pytest.mark.parametrize(
         "assay_ontology_term_id, is_descendant",
-        [("EFO:0010961", True), ("EFO:0022858", True), ("EFO:0030029", False), ("EFO:0002697", False)],
+        [("EFO:0022859", True), ("EFO:0022858", True), ("EFO:0030029", False), ("EFO:0002697", False)],
     )
     def test__validate_spatial_required_if_visium(self, assay_ontology_term_id, is_descendant):
         validator: Validator = Validator()
@@ -519,7 +519,7 @@ class TestCheckSpatial:
 
     @pytest.mark.parametrize(
         "assay_ontology_term_id, is_descendant",
-        [("EFO:0010961", True), ("EFO:0022858", True), ("EFO:0030029", False), ("EFO:0002697", False)],
+        [("EFO:0022859", True), ("EFO:0022858", True), ("EFO:0030029", False), ("EFO:0002697", False)],
     )
     def test__validate_is_single_required_visium_error(self, assay_ontology_term_id, is_descendant):
         validator: Validator = Validator()
@@ -593,7 +593,7 @@ class TestCheckSpatial:
 
     @pytest.mark.parametrize(
         "assay_ontology_term_id, is_descendant",
-        [("EFO:0010961", True), ("EFO:0022858", True), ("EFO:0030029", False), ("EFO:0002697", False)],
+        [("EFO:0022859", True), ("EFO:0022858", True), ("EFO:0030029", False), ("EFO:0002697", False)],
     )
     def test__validate_library_id_required_if_visium(self, assay_ontology_term_id, is_descendant):
         validator: Validator = Validator()
@@ -1017,7 +1017,7 @@ class TestCheckSpatial:
         validator.adata.obs.pop(tissue_position_name)
 
         # check visium
-        validator.adata.obs["assay_ontology_term_id"] = "EFO:0010961"
+        validator.adata.obs["assay_ontology_term_id"] = "EFO:0022858"
         validator._check_spatial_obs()
         assert validator.errors
         assert (
@@ -1057,7 +1057,7 @@ class TestCheckSpatial:
         assert validator.errors
         assert f"obs['{tissue_position_name}'] must be of int type" in validator.errors[0]
 
-    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0010961", "EFO:0022860", "EFO:0022859"])
+    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0022857", "EFO:0022860", "EFO:0022859"])
     @pytest.mark.parametrize("tissue_position_name, min", [("array_col", 0), ("array_row", 0), ("in_tissue", 0)])
     def test__validate_tissue_position_int_min_error(self, assay_ontology_term_id, tissue_position_name, min):
         validator: Validator = Validator()
@@ -1076,8 +1076,8 @@ class TestCheckSpatial:
     @pytest.mark.parametrize(
         "assay_ontology_term_id, tissue_position_name, tissue_position_max",
         [
-            ("EFO:0010961", "array_col", 127),
-            ("EFO:0010961", "array_row", 77),
+            ("EFO:0022857", "array_col", 127),
+            ("EFO:0022857", "array_row", 77),
             ("EFO:0022860", "array_col", 223),
             ("EFO:0022860", "array_row", 127),
             ("EFO:0022859", "array_col", 127),
@@ -1136,8 +1136,8 @@ class TestCheckSpatial:
         "cell_type_ontology_term_id, in_tissue, assay_ontology_term_id",
         [
             # MUST be unknown when in_tissue = 0 and assay_ontology_term_id = Visium Spatial Gene Expression
-            ("CL:0000066", 0, "EFO:0010961"),
-            (["CL:0000066", "unknown"], [0, 1], ["EFO:0010961", "EFO:0010961"]),
+            ("CL:0000066", 0, "EFO:0022858"),
+            (["CL:0000066", "unknown"], [0, 1], ["EFO:0022858", "EFO:0022858"]),
             # MUST be unknown when in_tissue = 0 and assay_ontology_term_id = Visium CytAssist Spatial Gene Expression, 11mm
             ("CL:0000066", 0, "EFO:0022860"),
             # MUST be unknown when in_tissue = 0 and assay_ontology_term_id = Visium Spatial Gene Expression V1

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -367,6 +367,21 @@ class TestCheckSpatial:
         validator.validate_adata()
         assert not validator.errors
 
+    def test__forbid_generic_visium(self):
+        validator: Validator = Validator()
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        validator._visium_and_is_single_true_matrix_size = 2
+
+        # set assay to the generic visium term
+        validator.adata.obs["assay_ontology_term_id"] = "EFO:0010961"
+
+        # Confirm this triggers FORBIDDIN ERROR and downstream errors due to invalid spatial term.
+        validator.validate_adata()
+        EXPECTED_FORBIDDEN_ERROR = "ERROR: Invalid spatial assay. obs['assay_ontology_term_id'] must be a descendant of EFO:0010961 but NOT EFO:0010961 itself. "
+        assert len(validator.errors) == 5
+        assert EXPECTED_FORBIDDEN_ERROR in validator.errors
+
     @mock.patch("cellxgene_schema.validate.VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE", 2)
     def test__validate_from_file(self):
         """Testing compatibility with SparseDataset types in Anndata"""
@@ -957,7 +972,7 @@ class TestCheckSpatial:
         validator: Validator = Validator()
         validator._set_schema_def()
         validator.adata = adata_visium.copy()
-        validator.adata.obs.assay_ontology_term_id = ["EFO:0010961", "EFO:0030062"]
+        validator.adata.obs.assay_ontology_term_id = ["EFO:0022858", "EFO:0030062"]
 
         # Confirm assay ontology term id is identified as invalid.
         validator._validate_spatial_assay_ontology_term_id()
@@ -979,9 +994,9 @@ class TestCheckSpatial:
     @pytest.mark.parametrize(
         "assay_ontology_term_id, is_single",
         [
-            (["EFO:0010961", "EFO:0030062"], True),
-            (["EFO:0010961", "EFO:0030062"], False),
-            ("EFO:0010961", False),
+            (["EFO:0022858", "EFO:0030062"], True),
+            (["EFO:0022858", "EFO:0030062"], False),
+            ("EFO:0022858", False),
             ("EFO:0030062", True),
             ("EFO:0030062", False),
             ("EFO:0030062", False),
@@ -1034,7 +1049,7 @@ class TestCheckSpatial:
         )
         validator.reset()
 
-    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0010961", "EFO:0030062", "EFO:0022860"])
+    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0022858", "EFO:0030062", "EFO:0022860"])
     def test__validate_tissue_position_not_required(self, assay_ontology_term_id):
         validator: Validator = Validator()
         validator._set_schema_def()
@@ -1107,8 +1122,8 @@ class TestCheckSpatial:
     @pytest.mark.parametrize(
         "cell_type_ontology_term_id, in_tissue, assay_ontology_term_id",
         [
-            # MUST be unknown when in_tissue = 0 and assay_ontology_term_id = Visium Spatial Gene Expression
-            ("unknown", 0, "EFO:0010961"),
+            # MUST be unknown when in_tissue = 0 and assay_ontology_term_id = Visium Spatial Gene Expression v2
+            ("unknown", 0, "EFO:0022858"),
             # MUST be unknown when in_tissue = 0 and assay_ontology_term_id = Visium CytAssist Spatial Gene Expression, 11mm
             ("unknown", 0, "EFO:0022860"),
             # MUST be unknown when in_tissue = 0 and assay_ontology_term_id = Visium Spatial Gene Expression V1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ types-requests
 types-setuptools
 typing_extensions
 types-PyYAML
+pre-commit


### PR DESCRIPTION
## Reason for Change
- #1189 
- 
## Changes
- exclude self when checking if assay is a descendant of EFO:0010961
- remove use of EFO:0010961 from tests where it is expected to yield a successful validation
- add explicit test for EFO:0010961 and append a custom error message for this error.

## Testing

- Most of the test updates were to replace EFO:0010961 with a lower, valid term e.g. EFO:0022857 (v1) or EFO:0022858 (v2) or EFO:0022859 (6.5mm)

```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer
- Lattice confirmed that the existing error messages related to valid spatial assays is sufficient. 
- it would be nice to extend the schema validator to include visium checks - perhaps this is a maintenance task.