### PR TITLE
feat: resolve visium+multispecies testing conflicts

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1746,9 +1746,7 @@ class Validator:
         is_not_unknown = self.adata.obs["cell_type_ontology_term_id"] != "unknown"
         if (is_spatial & is_not_tissue & is_not_unknown).any():
             self.errors.append(
-                f"obs['cell_type_ontology_term_id'] must be 'unknown' and obs['organism_cell_type_ontology_term_id'] "
-                f"must be 'unknown' or 'na' depending on the value of 'organism_ontology_term_id' (see schema "
-                f"definition) when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}."
+                f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}."
             )
 
     def _validate_spatial_tissue_position(self, tissue_position_name: str, min: int, max: int):

--- a/cellxgene_schema_cli/tests/test_map_species.py
+++ b/cellxgene_schema_cli/tests/test_map_species.py
@@ -1,5 +1,6 @@
 from tempfile import TemporaryDirectory
 from unittest import mock
+import logging
 
 import numpy
 import pandas as pd
@@ -67,6 +68,7 @@ def test_map_species__valid_output(validator_with_adata):
 
 
 def test_map_species_log_ouput(validator_with_adata, caplog):
+    caplog.set_level(logging.INFO)
     obs = validator_with_adata.adata.obs
     # test single match, error match, multiple options
     obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "ZFA:0009384"

--- a/cellxgene_schema_cli/tests/test_map_species.py
+++ b/cellxgene_schema_cli/tests/test_map_species.py
@@ -1,6 +1,6 @@
+import logging
 from tempfile import TemporaryDirectory
 from unittest import mock
-import logging
 
 import numpy
 import pandas as pd

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -20,6 +20,7 @@ from cellxgene_schema.validate import (
     ERROR_SUFFIX_VISIUM,
     ERROR_SUFFIX_VISIUM_11M,
     ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE,
+    ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0,
     SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE,
     SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM,
     VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE,
@@ -2923,8 +2924,7 @@ class TestZebrafish:
         obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "ZFA:0000003"
         validator.validate_adata()
         assert (
-            "obs['cell_type_ontology_term_id'] must be 'unknown' and obs['cell_type_ontology_term_id'] must "
-            "be 'unknown' or 'na' depending on the value of 'organism_ontology_term_id' (see schema definition)"
+            f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}"
             in validator.errors[0]
         )
 
@@ -3112,8 +3112,7 @@ class TestFruitFly:
         validator.reset(None, 2)
         validator.validate_adata()
         assert (
-            "obs['cell_type_ontology_term_id'] must be 'unknown' and obs['cell_type_ontology_term_id'] must "
-            "be 'unknown' or 'na' depending on the value of 'organism_ontology_term_id' (see schema definition)"
+            f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}."
             in validator.errors[0]
         )
 
@@ -3305,7 +3304,7 @@ class TestRoundworm:
         validator: Validator = validator_with_visium_roundworm_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
-        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "unknown"
+        obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "unknown"
         validator.reset(None, 2)
         validator.validate_adata()
         assert not validator.errors
@@ -3320,8 +3319,7 @@ class TestRoundworm:
         validator.reset(None, 2)
         validator.validate_adata()
         assert (
-            "obs['cell_type_ontology_term_id'] must be 'unknown' and obs['cell_type_ontology_term_id'] must "
-            "be 'unknown' or 'na' depending on the value of 'organism_ontology_term_id' (see schema definition)"
+            f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}"
             in validator.errors[0]
         )
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2905,10 +2905,7 @@ class TestZebrafish:
         validator.validate_adata()
         assert len(validator.errors) > 0
 
-    @pytest.mark.skip(
-        reason="Skipping this test to unblock downstream multispecies work. TODO: fix before 5.3.0 release"
-    )
-    def test_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_zebrafish_adata):
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_zebrafish_adata):
         validator = validator_with_visium_zebrafish_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
@@ -2916,10 +2913,10 @@ class TestZebrafish:
         validator.validate_adata()
         assert not validator.errors
 
-    @pytest.mark.skip(
-        reason="Skipping this test to unblock downstream multispecies work. TODO: fix before 5.3.0 release"
-    )
-    def test_cell_type_ontology_term_id__visium_in_tissue_0_invalid(self, validator_with_visium_zebrafish_adata):
+
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0_invalid(
+        self, validator_with_visium_zebrafish_adata
+    ):
         validator = validator_with_visium_zebrafish_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
@@ -3096,10 +3093,7 @@ class TestFruitFly:
         validator.validate_adata()
         assert len(validator.errors) > 0
 
-    @pytest.mark.skip(
-        reason="Skipping this test to unblock downstream multispecies work. TODO: fix before 5.3.0 release"
-    )
-    def test_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_fruitfly_adata):
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_fruitfly_adata):
         validator = validator_with_visium_fruitfly_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
@@ -3107,10 +3101,9 @@ class TestFruitFly:
         validator.validate_adata()
         assert not validator.errors
 
-    @pytest.mark.skip(
-        reason="Skipping this test to unblock downstream multispecies work. TODO: fix before 5.3.0 release"
-    )
-    def test_cell_type_ontology_term_id__visium_in_tissue_0_invalid(self, validator_with_visium_fruitfly_adata):
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0_invalid(
+        self, validator_with_visium_fruitfly_adata
+    ):
         validator = validator_with_visium_fruitfly_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
@@ -3306,25 +3299,24 @@ class TestRoundworm:
         validator.validate_adata()
         assert len(validator.errors) > 0
 
-    @pytest.mark.skip(
-        reason="Skipping this test to unblock downstream multispecies work. TODO: fix before 5.3.0 release"
-    )
-    def test_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_roundworm_adata):
-        validator = validator_with_visium_roundworm_adata
+    
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_roundworm_adata):
+        validator: Validator = validator_with_visium_roundworm_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
-        obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "unknown"
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "unknown"
+        validator.reset(None, 2)
         validator.validate_adata()
         assert not validator.errors
 
-    @pytest.mark.skip(
-        reason="Skipping this test to unblock downstream multispecies work. TODO: fix before 5.3.0 release"
-    )
-    def test_cell_type_ontology_term_id__visium_in_tissue_0_invalid(self, validator_with_visium_roundworm_adata):
-        validator = validator_with_visium_roundworm_adata
+    def test_organism_cell_type_ontology_term_id__visium_in_tissue_0_invalid(
+        self, validator_with_visium_roundworm_adata
+    ):
+        validator: Validator = validator_with_visium_roundworm_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
-        obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "WBbt:0005739"
+        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "WBbt:0005739"
+        validator.reset(None, 2)
         validator.validate_adata()
         assert (
             "obs['cell_type_ontology_term_id'] must be 'unknown' and obs['cell_type_ontology_term_id'] must "

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2910,7 +2910,7 @@ class TestZebrafish:
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
         obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "unknown"
-        validator.reset(None,2)
+        validator.reset(None, 2)
         validator.validate_adata()
         assert not validator.errors
 
@@ -3301,7 +3301,6 @@ class TestRoundworm:
         validator.validate_adata()
         assert len(validator.errors) > 0
 
-    
     def test_organism_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_roundworm_adata):
         validator: Validator = validator_with_visium_roundworm_adata
         obs = validator.adata.obs

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2906,13 +2906,13 @@ class TestZebrafish:
         assert len(validator.errors) > 0
 
     def test_organism_cell_type_ontology_term_id__visium_in_tissue_0(self, validator_with_visium_zebrafish_adata):
-        validator = validator_with_visium_zebrafish_adata
+        validator: Validator = validator_with_visium_zebrafish_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
         obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "unknown"
+        validator.reset(None,2)
         validator.validate_adata()
         assert not validator.errors
-
 
     def test_organism_cell_type_ontology_term_id__visium_in_tissue_0_invalid(
         self, validator_with_visium_zebrafish_adata
@@ -3098,16 +3098,18 @@ class TestFruitFly:
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
         obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "unknown"
+        validator.reset(None, 2)
         validator.validate_adata()
         assert not validator.errors
 
     def test_organism_cell_type_ontology_term_id__visium_in_tissue_0_invalid(
         self, validator_with_visium_fruitfly_adata
     ):
-        validator = validator_with_visium_fruitfly_adata
+        validator: Validator = validator_with_visium_fruitfly_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
         obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "FBbt:00049192"
+        validator.reset(None, 2)
         validator.validate_adata()
         assert (
             "obs['cell_type_ontology_term_id'] must be 'unknown' and obs['cell_type_ontology_term_id'] must "
@@ -3315,7 +3317,7 @@ class TestRoundworm:
         validator: Validator = validator_with_visium_roundworm_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "in_tissue"] = 0
-        obs.loc[obs.index[0], "organism_cell_type_ontology_term_id"] = "WBbt:0005739"
+        obs.loc[obs.index[0], "cell_type_ontology_term_id"] = "WBbt:0005739"
         validator.reset(None, 2)
         validator.validate_adata()
         assert (

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1205,7 +1205,8 @@ class TestCheckSpatial:
         validator._validate_spatial_cell_type_ontology_term_id()
         assert validator.errors
         assert (
-            f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}." in validator.errors[0]
+            f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}."
+            in validator.errors[0]
         )
 
     def test__validate_embeddings_non_nans(self):

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1205,9 +1205,7 @@ class TestCheckSpatial:
         validator._validate_spatial_cell_type_ontology_term_id()
         assert validator.errors
         assert (
-            f"obs['cell_type_ontology_term_id'] must be 'unknown' and obs['organism_cell_type_ontology_term_id'] must "
-            f"be 'unknown' or 'na' depending on the value of 'organism_ontology_term_id' (see schema definition) "
-            f"when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}." in validator.errors[0]
+            f"obs['cell_type_ontology_term_id'] must be 'unknown' when {ERROR_SUFFIX_VISIUM_AND_IS_SINGLE_TRUE_IN_TISSUE_0}." in validator.errors[0]
         )
 
     def test__validate_embeddings_non_nans(self):


### PR DESCRIPTION
## Reason for Change
- #1225 

## Changes
- purely changes to testing functions

## Testing
- no additional  tests

## Notes for Reviewer
There were two issues here

### Fixtures with small matrices
The validator hardcodes the expected matrix size. Our test fixtures, however, use much smaller test matrices. To nudge the validator to accept this simply reset with the expected size e.g. `validator.reset(None, 2)`


### Incongruous edits to `organism_<column>` columns
The source of the problem is that the test updated the organism-specific column e.g. `obs["organism_cell_type_ontology_term_id"]` but the validator is only checking the organism-agnostic column e.g. `obs["cell_type_ontology_term_id"]`.  Quick fix is to update the tests to change the organism-agnostic column.

I think this should be fine given that we are deprecating the organism-specific column in the official 5.3. 

> [!IMPORTANT] remove `organism_<column>`
> all of the `organism_<column>` columns in `obs` should be removed. This includes the tests and the error messages.

