### PR TITLE
fix: tissue_ontology_term_id and cell_type_ontology_term_id fields for 3 new species

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -108,85 +108,33 @@ components:
     columns:
       cell_type_ontology_term_id:
         type: curie
-        dependencies:
-          - # If organism is Zebrafish
-            rule:
-              column: organism_ontology_term_id
-              match_exact:
-                terms:
-                  - NCBITaxon:7955
-            error_message_suffix: >-
-              When 'organism_ontology_term_id' is 'NCBITaxon:7955' (Danio rerio),
-              'cell_type_ontology_term_id' MUST be a descendant term id of 'ZFA:0009000' (cell).
-            type: curie
-            curie_constraints:
-              ontologies:
-                - ZFA
-              allowed:
-                ancestors:
-                  ZFA:
-                    - ZFA:0009000
-              exceptions:
-                - unknown
-          - # If organism is fruit fly
-            rule:
-              column: organism_ontology_term_id
-              match_exact:
-                terms:
-                  - NCBITaxon:7227
-            error_message_suffix: >-
-              When 'organism_ontology_term_id' is 'NCBITaxon:7227' (Drosophila melanogaster),
-              'cell_type_ontology_term_id' MUST be a descendant term id of 'FBbt:00007002' (cell).
-            type: curie
-            curie_constraints:
-              ontologies:
-                - FBbt
-              allowed:
-                ancestors:
-                  FBbt:
-                    - FBbt:00007002
-              exceptions:
-                - unknown
-          - # If organism is c. elegans
-            rule:
-              column: organism_ontology_term_id
-              match_exact:
-                terms:
-                  - NCBITaxon:6239
-            error_message_suffix: >-
-              When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans),
-              'cell_type_ontology_term_id' MUST be a descendant term id of 'WBbt:0004017' (cell).
-            type: curie
-            curie_constraints:
-              ontologies:
-                - WBbt
-              allowed:
-                ancestors:
-                  WBbt:
-                    - WBbt:0004017
-              forbidden:
-                ancestors:
-                    WBbt:
-                        - WBbt:0006803
-                terms:
-                  - WBbt:0006803
-              exceptions:
-                - unknown
-        # else if column does not match any of the above
         curie_constraints:
           ontologies:
             - CL
+            - ZFA
+            - FBbt
+            - WBbt
           exceptions:
             - unknown
           allowed:
             ancestors:
+              ZFA:
+              - ZFA:0009000
+              FBbt:
+              - FBbt:00007002
+              WBbt:
+              - WBbt:0004017
               CL:
               - CL:0000000
           forbidden:
+            ancestors:
+              WBbt:
+              - WBbt:0006803
             terms:
               - CL:0000255
               - CL:0000257
               - CL:0000548
+              - WBbt:0006803
         add_labels:
           - type: curie
             to_column: cell_type
@@ -276,86 +224,50 @@ components:
       tissue_ontology_term_id:
         type: curie
         dependencies:
-          - # If organism is Zebrafish
+          - # If tissue_type is tissue OR organoid
             rule:
-              column: organism_ontology_term_id
+              column: tissue_type
               match_exact:
                 terms:
-                  - NCBITaxon:7955
+                  - tissue
+                  - organoid
             error_message_suffix: >-
-              When 'organism_ontology_term_id' is 'NCBITaxon:7955' (Danio rerio),
-              'tissue_ontology_term_id' MUST be the most accurate descendant
-              of ZFA:0100000 for zebrafish anatomical entity and MUST NOT be ZFA:0009000
-              for cell or any of its descendants.
+              When 'tissue_type' is 'tissue' or 'organoid', 'tissue_ontology_term_id' must be a valid UBERON, ZFA, FBbt, or WBbt term.
             type: curie
             curie_constraints:
               ontologies:
+                - UBERON
                 - ZFA
+                - FBbt
+                - WBbt
               allowed:
                 ancestors:
                   ZFA:
                     - ZFA:0100000
+                  FBbt:
+                    - FBbt:10000000
+                  WBbt:
+                    - WBbt:0005766
+                  UBERON:
+                    - UBERON:0001062
               forbidden:
                 terms:
                   - ZFA:0009000
                   - ZFA:0001093
-                ancestors:
-                  ZFA:
-                    - ZFA:0009000
-          - # If organism is fruit fly
-            rule:
-              column: organism_ontology_term_id
-              match_exact:
-                terms:
-                  - NCBITaxon:7227
-            error_message_suffix: >-
-              When 'organism_ontology_term_id' is 'NCBITaxon:7227' (Drosophila melanogaster),
-              'tissue_ontology_term_id' MUST be the most accurate descendant
-              of FBbt:10000000 for fruit fly anatomical entity and MUST NOT be FBbt:00007002
-              for cell or any of its descendants.
-            type: curie
-            curie_constraints:
-              ontologies:
-                - FBbt
-              allowed:
-                ancestors:
-                  FBbt:
-                    - FBbt:10000000
-              forbidden:
-                terms:
                   - FBbt:00007002
-                ancestors:
-                  FBbt:
-                    - FBbt:00007002
-          - # If organism is c. elegans
-            rule:
-              column: organism_ontology_term_id
-              match_exact:
-                terms:
-                  - NCBITaxon:6239
-            error_message_suffix: >-
-              When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans),
-              'tissue_ontology_term_id' MUST be the most accurate descendant
-              of WBbt:0005766 for Anatomy
-            type: curie
-            curie_constraints:
-              ontologies:
-                - WBbt
-              allowed:
-                ancestors:
-                  WBbt:
-                    - WBbt:0005766
-              forbidden:
-                ancestors:
-                  WBbt:
-                    - WBbt:0004017
-                    - WBbt:0006803
-                terms:
                   - WBbt:0007849
                   - WBbt:0007850
                   - WBbt:0008595
                   - WBbt:0004017
                   - WBbt:0006803
+                ancestors:
+                  ZFA:
+                    - ZFA:0009000
+                  WBbt:
+                    - WBbt:0004017
+                    - WBbt:0006803
+                  FBbt:
+                    - FBbt:00007002
           - # If tissue_type is cell culture
             rule:
               column: tissue_type
@@ -377,14 +289,6 @@ components:
                   - CL:0000255
                   - CL:0000257
                   - CL:0000548
-        # else if column does not match any of the above
-        curie_constraints:
-          ontologies:
-            - UBERON
-          allowed:
-            ancestors:
-              UBERON:
-                - UBERON:0001062
         add_labels:
           - type: curie
             to_column: tissue

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -465,6 +465,91 @@ class Validator:
             nonzeros = count_nonzeros(matrix.compute(), is_sparse_matrix)[0]
         return nonzeros
 
+    def _validate_tissue_ontology_term_id(self):
+        """
+        For `tissue_ontology_term_id`, the schema_definition.yaml allows all possible terms regardless of what
+        the organism is. This block of code does further validation to make sure that if zebrafish, fruit fly,
+        or roundworm is specified, only the correct ontologies are used.
+        This is quite a bit easier to understand than fully overhauling the schema definition to allow for these
+        very specific cases. Note that we only check for prefixes, since validation that these are proper ontology
+        terms / descendants is done within the curie constraints
+        """
+        organism_column = "organism_ontology_term_id"
+        tissue_column = "tissue_ontology_term_id"
+        tissue_type_column = "tissue_type"
+
+        required_columns = [tissue_column, organism_column, tissue_type_column]
+        for column in required_columns:
+            if column not in self.adata.obs.columns:
+                return
+
+        allowed_prefixes = {
+            "NCBITaxon:6239": ("WBbt", "UBERON"),
+            "NCBITaxon:7955": ("ZFA", "UBERON"),
+            "NCBITaxon:7227": ("FBbt", "UBERON"),
+        }
+
+        def is_valid_row(row):
+            if row[tissue_type_column] == "cell culture":
+                return True
+            allowed = allowed_prefixes.get(row[organism_column], ("UBERON",))
+            return row[tissue_column].startswith(allowed)
+
+        try:
+            invalid_rows = ~self.adata.obs.apply(is_valid_row, axis=1)
+
+            if invalid_rows.any():
+                self.errors.append(
+                    "When tissue_type is tissue or organoid, tissue_ontology_term_id must be a valid UBERON term. "
+                    "If organism is NCBITaxon:6239, it can be a valid UBERON term or a valid WBbt term. "
+                    "If organism is NCBITaxon:7955, it can be a valid UBERON term or a valid ZFA term. "
+                    "If organism is NCBITaxon:7227, it can be a valid UBERON term or a valid FBbt term."
+                )
+        except Exception as e:
+            self.errors.append(f"Unexpected error validating tissue_ontology_term_id: {e}")
+
+    def _validate_cell_type_ontology_term_id(self):
+        """
+        For `cell_type_ontology_term_id`, the schema_definition.yaml allows all possible terms regardless of what
+        the organism is. This block of code does further validation to make sure that if zebrafish, fruit fly,
+        or roundworm is specified, only the correct ontologies are used.
+        This is quite a bit easier to understand than fully overhauling the schema definition to allow for these
+        very specific cases. Note that we only check for prefixes, since validation that these are proper ontology
+        terms / descendants is done within the curie constraints
+        """
+        organism_column = "organism_ontology_term_id"
+        cell_type_column = "cell_type_ontology_term_id"
+
+        required_columns = [cell_type_column, organism_column]
+        for column in required_columns:
+            if column not in self.adata.obs.columns:
+                return
+
+        allowed_prefixes = {
+            "NCBITaxon:6239": ("WBbt", "CL"),
+            "NCBITaxon:7955": ("ZFA", "CL"),
+            "NCBITaxon:7227": ("FBbt", "CL"),
+        }
+
+        def is_valid_row(row):
+            if row[cell_type_column] == "unknown":
+                return True
+            allowed = allowed_prefixes.get(row[organism_column], ("CL",))
+            return row[cell_type_column].startswith(allowed)
+
+        try:
+            invalid_rows = ~self.adata.obs.apply(is_valid_row, axis=1)
+
+            if invalid_rows.any():
+                self.errors.append(
+                    "cell_type_ontology_term_id must be a valid CL term. "
+                    "If organism is NCBITaxon:6239, it can be a valid CL term or a valid WBbt term. "
+                    "If organism is NCBITaxon:7955, it can be a valid CL term or a valid ZFA term. "
+                    "If organism is NCBITaxon:7227, it can be a valid CL term or a valid FBbt term."
+                )
+        except Exception as e:
+            self.errors.append(f"Unexpected error validating cell_type_ontology_term_id: {e}")
+
     def _validate_genetic_ancestry(self):
         """
         Performs row-based validation of the genetic_ancestry_X fields. This ensures that a valid row must be:
@@ -2047,6 +2132,10 @@ class Validator:
 
         # Validate genetic ancestry
         self._validate_genetic_ancestry()
+
+        # Organism-specific prefix validation
+        self._validate_tissue_ontology_term_id()
+        self._validate_cell_type_ontology_term_id()
 
         # Checks each component
         for component_name, component_def in self.schema_def["components"].items():

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2862,7 +2862,7 @@ class TestZebrafish:
 
     @pytest.mark.parametrize(
         "cell_type_ontology_term_id",
-        ["ZFA:0000003", "unknown"],
+        ["ZFA:0000003", "CL:0007021", "unknown"],
     )
     def test_cell_type_ontology_term_id(self, validator_with_zebrafish_adata, cell_type_ontology_term_id):
         """
@@ -3053,7 +3053,7 @@ class TestFruitFly:
 
     @pytest.mark.parametrize(
         "cell_type_ontology_term_id",
-        ["FBbt:00049192", "unknown"],
+        ["FBbt:00049192", "CL:0007021", "unknown"],
     )
     def test_cell_type_ontology_term_id(self, validator_with_fruitfly_adata, cell_type_ontology_term_id):
         """
@@ -3251,7 +3251,7 @@ class TestRoundworm:
 
     @pytest.mark.parametrize(
         "cell_type_ontology_term_id",
-        ["WBbt:0005762", "unknown"],
+        ["WBbt:0005762", "CL:0007021", "unknown"],
     )
     def test_cell_type_ontology_term_id(self, validator_with_roundworm_adata, cell_type_ontology_term_id):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1306,9 +1306,10 @@ class TestObs:
         obs.tissue_type = obs.tissue_type.cat.add_categories(["organoid"])
         obs.loc[obs.index[0], "tissue_type"] = "organoid"
         validator.validate_adata()
-        assert validator.errors == [
-            "ERROR: 'UBERON:0000057 (organoid)' in 'tissue_ontology_term_id' is not a valid ontology term id of 'UBERON'."
-        ]
+        assert (
+            "ERROR: 'UBERON:0000057 (organoid)' in 'tissue_ontology_term_id' is not a valid ontology term id"
+            in validator.errors[0]
+        )
 
     def test_tissue_ontology_term_id_descendant_of_anatomical_entity__tissue(self, validator_with_adata):
         """
@@ -1320,7 +1321,7 @@ class TestObs:
         obs.loc[obs.index[0], "tissue_ontology_term_id"] = "UBERON:0001062"
         obs.loc[obs.index[0], "tissue_type"] = "tissue"
         validator.validate_adata()
-        assert validator.errors == ["ERROR: 'UBERON:0001062' in 'tissue_ontology_term_id' is not an allowed term id."]
+        assert "ERROR: 'UBERON:0001062' in 'tissue_ontology_term_id' is not an allowed term id." in validator.errors[0]
 
     def test_tissue_ontology_term_id_descendant_of_anatomical_entity__organoid(self, validator_with_adata):
         """
@@ -1333,7 +1334,7 @@ class TestObs:
         obs.tissue_type = obs.tissue_type.cat.add_categories(["organoid"])
         obs.loc[obs.index[0], "tissue_type"] = "organoid"
         validator.validate_adata()
-        assert validator.errors == ["ERROR: 'UBERON:0001062' in 'tissue_ontology_term_id' is not an allowed term id."]
+        assert "ERROR: 'UBERON:0001062' in 'tissue_ontology_term_id' is not an allowed term id." in validator.errors[0]
 
     def test_tissue_type(self, validator_with_adata):
         """
@@ -2929,10 +2930,17 @@ class TestZebrafish:
         # Passes visium check but fails cell_type_ontology_term_id check
         assert validator.errors == [error_message]
 
-    def test_organism_tissue_type_ontology_term_id(self, validator_with_zebrafish_adata):
+    @pytest.mark.parametrize(
+        "tissue_ontology_term_id",
+        [
+            "ZFA:0001262",  # valid descendant of ZFA:0100000
+            "UBERON:0002048",  # valid UBERON term
+        ],
+    )
+    def test_organism_tissue_type_ontology_term_id(self, validator_with_zebrafish_adata, tissue_ontology_term_id):
         validator = validator_with_zebrafish_adata
         obs = validator.adata.obs
-        obs.loc[obs.index[0], "tissue_ontology_term_id"] = "ZFA:0001262"  # valid descendant of ZFA:0100000
+        obs.loc[obs.index[0], "tissue_ontology_term_id"] = tissue_ontology_term_id
         validator.validate_adata()
         assert not validator.errors
 
@@ -2964,6 +2972,14 @@ class TestZebrafish:
         obs = validator.adata.obs
         obs.tissue_type = obs.tissue_type.cat.add_categories(["organoid"])
         obs.loc[obs.index[0], "tissue_type"] = tissue_type
+        assert not validator.errors
+
+    def test_cell_culture_tissue_ontology_term_id(self, validator_with_zebrafish_adata):
+        validator = validator_with_zebrafish_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "tissue_type"] = "cell culture"
+        obs.loc[obs.index[0], "tissue_ontology_term_id"] = "CL:0007021"  # valid CL term for cell culture
+        validator.validate_adata()
         assert not validator.errors
 
 
@@ -3149,6 +3165,14 @@ class TestFruitFly:
         obs.loc[obs.index[0], "tissue_type"] = tissue_type
         assert not validator.errors
 
+    def test_cell_culture_tissue_ontology_term_id(self, validator_with_fruitfly_adata):
+        validator = validator_with_fruitfly_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "tissue_type"] = "cell culture"
+        obs.loc[obs.index[0], "tissue_ontology_term_id"] = "CL:0007021"  # valid CL term for cell culture
+        validator.validate_adata()
+        assert not validator.errors
+
 
 class TestRoundworm:
     """
@@ -3296,7 +3320,14 @@ class TestRoundworm:
         # Passes visium check but fails organism_cell_type_ontology_term_id check
         assert validator.errors == [error_message]
 
-    def test_organism_tissue_type_ontology_term_id(self, validator_with_roundworm_adata):
+    @pytest.mark.parametrize(
+        "tissue_ontology_term_id",
+        [
+            "WBbt:0006750",  # valid descendant of WBbt:0005766
+            "UBERON:0002048",  # valid UBERON term
+        ],
+    )
+    def test_organism_tissue_type_ontology_term_id(self, validator_with_roundworm_adata, tissue_ontology_term_id):
         validator = validator_with_roundworm_adata
         obs = validator.adata.obs
         obs.loc[obs.index[0], "tissue_ontology_term_id"] = "WBbt:0006750"  # valid descendant of WBbt:0005766
@@ -3402,7 +3433,6 @@ class TestMultiSpecies:
             "unknown",
         ],
     )
-
     def test_tissue_ontology_term_id__invalid(self, validator_with_adata, tissue_ontology_term_id):
         validator = validator_with_adata
         obs = validator.adata.obs

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -3106,10 +3106,17 @@ class TestFruitFly:
         # Passes visium check but fails cell_type_ontology_term_id check
         assert validator.errors == [error_message]
 
-    def test_organism_tissue_type_ontology_term_id(self, validator_with_fruitfly_adata):
+    @pytest.mark.parametrize(
+        "tissue_ontology_term_id",
+        [
+            "FBbt:00007337",  # valid descendant of FBbt:10000000
+            "UBERON:0002048",  # valid UBERON term
+        ],
+    )
+    def test_organism_tissue_type_ontology_term_id(self, validator_with_fruitfly_adata, tissue_ontology_term_id):
         validator = validator_with_fruitfly_adata
         obs = validator.adata.obs
-        obs.loc[obs.index[0], "tissue_ontology_term_id"] = "FBbt:00007337"  # valid descendant of FBbt:10000000
+        obs.loc[obs.index[0], "tissue_ontology_term_id"] = tissue_ontology_term_id
         validator.validate_adata()
         assert not validator.errors
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -3353,6 +3353,14 @@ class TestRoundworm:
         )
         assert error_message in validator.errors
 
+    def test_cell_culture_tissue_ontology_term_id(self, validator_with_roundworm_adata):
+        validator = validator_with_roundworm_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[0], "tissue_type"] = "cell culture"
+        obs.loc[obs.index[0], "tissue_ontology_term_id"] = "CL:0007021"  # valid CL term for cell culture
+        validator.validate_adata()
+        assert not validator.errors
+
 
 class TestMultiSpecies:
     """
@@ -3387,6 +3395,7 @@ class TestMultiSpecies:
             "unknown",
         ],
     )
+
     def test_tissue_ontology_term_id__invalid(self, validator_with_adata, tissue_ontology_term_id):
         validator = validator_with_adata
         obs = validator.adata.obs


### PR DESCRIPTION
## Reason for Change

there's a few issues here that this PR addresses:
- we need to make sure that zebrafish / fruit fly / roundworm still accepts valid CL terms for `tissue_ontology_term_id`, but _only_ when `tissue_type == cell culture`
- also, UBERON terms should be supported for `tissue_ontology_term_id` even if species is zebrafish / fruit fly / roundworm
- and CL terms should be supported for `cell_type_ontology_term_id`  even if species is zebrafish / fruit fly / roundworm

this PR: https://github.com/chanzuckerberg/single-cell-curation/pull/1231/files introduced some issues with these 3 cases weren't being properly handled with moving the logic to the schema def. so i've moved the organism-specific logic back into the validate script directly.

we will revisit an approach to writing out the validation rules here sometime next week.

## Testing

- adds test coverage for these 3 cases, which was missing earlier

## Notes for Reviewer