### PR TITLE
feat: add support for mus musculus descendant organisms

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -392,11 +392,11 @@ components:
           - # If organism is Mouse
             rule:
               column: organism_ontology_term_id
-              match_exact:
-                terms:
+              match_ancestors_inclusive:
+                ancestors:
                   - NCBITaxon:10090
             error_message_suffix: >-
-              When 'organism_ontology_term_id' is 'NCBITaxon:10090' (Mus musculus), 'development_stage_ontology_term_id' MUST be the most accurate descendant of 'MmusDv:0000001' or unknown.
+              When 'organism_ontology_term_id' is 'NCBITaxon:10090' (Mus musculus) or one of its descendants, 'development_stage_ontology_term_id' MUST be the most accurate descendant of 'MmusDv:0000001' or unknown.
             type: curie
             curie_constraints:
               ontologies:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -802,9 +802,16 @@ class Validator:
             terms_to_match = set()
             column_to_match = dependency_def["rule"]["column"]
             if "match_ancestors_inclusive" in dependency_def["rule"]:
+                print("rule", dependency_def["rule"])
                 ancestors = dependency_def["rule"]["match_ancestors_inclusive"]["ancestors"]
                 for ancestor in ancestors:
+                    print("ancestor", ancestor)
+                    term_descendants = ONTOLOGY_PARSER.get_term_descendants(ancestor, include_self=True)
+                    print("term_descendants", term_descendants)
+                    print("len(terms to match) before", len(terms_to_match))
                     terms_to_match.update(ONTOLOGY_PARSER.get_term_descendants(ancestor, include_self=True))
+                    print("len(terms to match) after", len(terms_to_match))
+                print("terms to match", terms_to_match)
             if "match_exact" in dependency_def["rule"]:
                 terms_to_match.update(dependency_def["rule"]["match_exact"]["terms"])
             try:

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata==0.11.2
-cellxgene-ontology-guide==1.4.1 # update before a schema migration
+cellxgene-ontology-guide==1.4.2 # update before a schema migration
 click<9
 Cython<4
 dask[array]==2024.12.0

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -697,6 +697,25 @@ class TestObs:
         assert not_allowed_error_message in validator.errors or deprecated_error_message in validator.errors
 
     @pytest.mark.parametrize(
+        "organism_ontology_term_id",
+        [
+            "NCBITaxon:10090",  # Mus musculus (ancestor term, always allowed)
+            "NCBITaxon:947985",  # Mus musculus albula
+            "NCBITaxon:35531",  # Mus musculus bactrianus
+        ],
+    )
+    def test_development_stage_ontology_term_id_mouse_descendant(self, validator_with_adata, organism_ontology_term_id):
+        """
+        If organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus OR its descendants,
+        this MUST be the most accurate MmusDv:0000001 descendant.
+        """
+        validator = validator_with_adata
+        obs = validator.adata.obs
+        obs.loc[obs.index[1], "organism_ontology_term_id"] = organism_ontology_term_id
+        validator.validate_adata()
+        assert not validator.errors
+
+    @pytest.mark.parametrize(
         "development_stage_ontology_term_id,error",
         [
             (


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/1243

## Changes

- updates schema definition to add support for mus musculus descendants
- upon further inspection it appears as if the print output for `ONTOLOGY_PARSER.get_term_descendants("NCBITaxon:10090", include_self=True)` is simply `term_descendants ['NCBITaxon:10090']`

## Testing

added unit tests to ensure mouse descendant terms are accepted

## Notes for Reviewer