### PR TITLE
fix: fruit fly RR genes

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/gencode.py
+++ b/cellxgene_schema_cli/cellxgene_schema/gencode.py
@@ -46,7 +46,7 @@ def get_organism_from_feature_id(
         return SupportedOrganisms.SARS_COV_2
     elif feature_id.startswith("ERCC-"):
         return SupportedOrganisms.ERCC
-    elif feature_id.startswith("FB"):
+    elif feature_id.startswith("FB") or feature_id.startswith("RR"):
         return SupportedOrganisms.DROSOPHILA_MELANOGASTER
     elif feature_id.startswith("ENSDARG"):
         return SupportedOrganisms.DANIO_RERIO

--- a/cellxgene_schema_cli/tests/fixtures/examples_ontology_test.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_ontology_test.py
@@ -6,6 +6,8 @@ invalid_species = ["Caenorhabditis elegans"]
 valid_genes = {
     gencode.SupportedOrganisms.HOMO_SAPIENS: {"ENSG00000141510": ("TP53_ENSG00000141510", 2404)},
     gencode.SupportedOrganisms.MUS_MUSCULUS: {"ENSMUSG00000059552": ("Trp53", 1797)},
+    gencode.SupportedOrganisms.DROSOPHILA_MELANOGASTER: {"RR45003_transposable_element": ("S{}RR4500", 1234)},
+    gencode.SupportedOrganisms.DROSOPHILA_MELANOGASTER: {"FBgn0037293": ("RabGGTa", 1853)},
     gencode.SupportedOrganisms.CAENORHABDITIS_ELEGANS: {"WBGene00000003": ("aat-2", 1738)},
     gencode.SupportedOrganisms.CALLITHRIX_JACCHUS: {"ENSCJAG00000071296": ("U4_ENSCJAG00000071296", 141)},
     gencode.SupportedOrganisms.DANIO_RERIO: {"ENSDARG00000009657": ("fgfr1op2", 1088)},


### PR DESCRIPTION
## Reason for Change

- we received feedback from lattice [here](https://czi-sci.slack.com/archives/C07AV4NU9D2/p1738878739392169?thread_ts=1738345846.792719&cid=C07AV4NU9D2) that some fruit fly genes start with `RR`

## Changes

- updated the gencode mapper to account for this

## Testing

- added fruit fly genes to `valid_genes` in `test_gencode`

## Notes for Reviewer