### PR TITLE
feat: schema 5.3.0 gene bumps

### DIFF
--- a/.github/workflows/gencode-bump-dry-run.yml
+++ b/.github/workflows/gencode-bump-dry-run.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
-          role-duration-seconds: 2700
+          role-duration-seconds: 7200
       - name: Pull AWS Secrets
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:

--- a/.github/workflows/gencode-bump-dry-run.yml
+++ b/.github/workflows/gencode-bump-dry-run.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
-          role-duration-seconds: 5400
+          role-duration-seconds: 2700
       - name: Pull AWS Secrets
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:

--- a/cellxgene_schema_cli/cellxgene_schema/gencode_files/gene_info.yml
+++ b/cellxgene_schema_cli/cellxgene_schema/gencode_files/gene_info.yml
@@ -50,3 +50,4 @@ rat:
   description: rattus_norvegicus
   url: https://ftp.ensembl.org/pub/release-113/gtf/rattus_norvegicus/Rattus_norvegicus.mRatBN7.2.113.gtf.gz
   
+  

--- a/cellxgene_schema_cli/cellxgene_schema/gencode_files/gene_info.yml
+++ b/cellxgene_schema_cli/cellxgene_schema/gencode_files/gene_info.yml
@@ -49,3 +49,4 @@ lemur:
 rat: 
   description: rattus_norvegicus
   url: https://ftp.ensembl.org/pub/release-113/gtf/rattus_norvegicus/Rattus_norvegicus.mRatBN7.2.113.gtf.gz
+  

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata==0.11.2
-cellxgene-ontology-guide==1.4.2 # update before a schema migration
+cellxgene-ontology-guide==1.6.0 # update before a schema migration
 click<9
 Cython<4
 dask[array, distributed, dataframe]==2024.12.0

--- a/cellxgene_schema_cli/scripts/readme.md
+++ b/cellxgene_schema_cli/scripts/readme.md
@@ -11,7 +11,7 @@ To update ontologies, update the `cellxgene-ontology-guide` version in `cellxgen
 make update-gene-references
 ```
 
-The gene reference files are used internally by the class `cellxgene-schema.ontology.GeneChecker`
+The gene reference files are used internally by the class `cellxgene-schema.gencode:GeneChecker`
 
 ## Updating ontologies
 
@@ -21,31 +21,11 @@ and then generate a new release with the subsequently generated ontology files. 
 `cellxgene_schema_cli/requirements.txt` to this latest release.
 
 ## Updating gene references
+Per-species gene information is managed and stored in the  `cellxgene_schema_cli/cellxgene_schema/gencode_files/` directory. The source of truth for per-species gene versions is in the `gene_info.yml` file, therein. 
 
-Gene references are stored under  `cellxgene_schema_cli/cellxgene_schema/gencode_files/`
-
-The following gene references are currently stored (to see specific versions refer to schema definition):
-
-1. Human `genes_homo_sapines.csv.gz`
-2. Mouse `genes_mus_musculus_sapines.csv.gz`
-3. sars‑CoV‑2 `genes_sars_cov_2.csv.gz`
-4. ERCC Spike-Ins `genes_ercc.csv.gz`
-
-To update these gene references, a developer has to do run the following:
-
+To update these gene references, a developer must update the `gene_info.yml` file and run the following:
 ```bash
 make update-gene-references
 ```
 
-This will:
-
-1. Download the gene reference files.
-2. For 10X data: decompress it, get the GTF files and remove the rest.
-3. At the end the following files will be in the folder:
-
-    - `mus_musculus.gtf.gz`
-    - `homo_sapiens.gtf.gz`
-    - `sars_cov_2.gtf.gz`
-    - `ercc.txt`
-
-The GTF files for mouse and human are obtained from the 10X reference data. The GTF file for sars‑CoV‑2 is obtained from ENSEMBL. The ERCC IDs are obtained from ThermoFisher.
+This will managed the downloading, unpacking, and extraction of per-species gene level information and write the results for each species seperately e.g. `genes_ercc.csv.gz` and `genes_homo_sapiens.csv.gz`.

--- a/cellxgene_schema_cli/scripts/readme.md
+++ b/cellxgene_schema_cli/scripts/readme.md
@@ -1,31 +1,22 @@
 # Updating reference files
 
-## Quick start 
-To update the gene references, update `cellxgene_schema_cli/cellxgene_schema/gencode_files/gene_info.yml` with new references.
-
-To update ontologies, update the `cellxgene-ontology-guide` version in `cellxgene_schema_cli/requirements.txt`.
-
-- Then the following command will download and process the gene references and update the respective package files under `cellxgene_schema_cli/cellxgene_schema/gencode_files/`
-
-```bash
-make update-gene-references
-```
-
-The gene reference files are used internally by the class `cellxgene-schema.gencode:GeneChecker`
-
 ## Updating ontologies
 
 Ontology information for cellxgene-schema is derived from `cellxgene-ontology-guide`. To update the ontologies in 
 conjunction with a schema release, update [ontology_info.json in cellxgene-ontology-guide](https://github.com/chanzuckerberg/cellxgene-ontology-guide/blob/main/ontology-assets/ontology_info.json),
-and then generate a new release with the subsequently generated ontology files. Bump the version of `cellxgene-ontology-guide` in 
-`cellxgene_schema_cli/requirements.txt` to this latest release.
+and then generate a new release with the subsequently generated ontology files. Manually bump the version of `cellxgene-ontology-guide` in 
+`cellxgene_schema_cli/requirements.txt` to match the version of this latest release.
+
+```
+cellxgene-ontology-guide==1.4.2 # if pointing to
+```
 
 ## Updating gene references
-Per-species gene information is managed and stored in the  `cellxgene_schema_cli/cellxgene_schema/gencode_files/` directory. The source of truth for per-species gene versions is in the `gene_info.yml` file, therein. 
+Per-species gene information is managed and stored in the  `cellxgene_schema_cli/cellxgene_schema/gencode_files/` directory. The source of truth for per-species gene versions is in the `gene_info.yml` file. The targeted versions should match those specified in the `schema/<cxg-schema-version>/schema.md` file.
 
 To update these gene references, a developer must update the `gene_info.yml` file and run the following:
 ```bash
 make update-gene-references
 ```
 
-This will managed the downloading, unpacking, and extraction of per-species gene level information and write the results for each species seperately e.g. `genes_ercc.csv.gz` and `genes_homo_sapiens.csv.gz`.
+This will manage the downloading, unpacking, and extraction of per-species gene level information and write the results for each species seperately e.g. `genes_ercc.csv.gz` and `genes_homo_sapiens.csv.gz`.

--- a/scripts/schema_bump_dry_run_genes/gene_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_genes/gene_bump_dry_run.py
@@ -205,7 +205,6 @@ def generate_deprecated_public(base_url: str, diff_map: Dict) -> Dict:  # type: 
             run_reporter.public_errored_datasets += 1
             logger.error(
                 f"Error processing public dataset {dataset['dataset_id']}, in collection {dataset['collection_id']}: "
-                f"{e}"
             )
     for collection in public_deprecated.values():
         # convert dataset_groups from a dictionary to a list of its values.
@@ -239,7 +238,7 @@ def generate_deprecated_private(base_url: str, diff_map: Dict) -> Tuple[Dict, Li
                     private_deprecated[dataset["collection_id"]]["revision_of"] = revision_of
         except Exception as e:
             run_reporter.private_errored_datasets += 1
-            logger.error(f"Error processing private dataset: {e}")
+            logger.error(f"Error processing private dataset")
     for collection in private_deprecated.values():
         collection["dataset_groups"] = list(collection["dataset_groups"].values())
     return private_deprecated, non_auto_migrated  # type: ignore

--- a/scripts/schema_bump_dry_run_genes/gene_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_genes/gene_bump_dry_run.py
@@ -201,7 +201,7 @@ def generate_deprecated_public(base_url: str, diff_map: Dict) -> Dict:  # type: 
             public_deprecated, is_deprecated_genes_found = compare_genes(dataset, diff_map, public_deprecated)
             if is_deprecated_genes_found:
                 run_reporter.public_deprecated_datasets += 1
-        except Exception as e:
+        except Exception:
             run_reporter.public_errored_datasets += 1
             logger.error(
                 f"Error processing public dataset {dataset['dataset_id']}, in collection {dataset['collection_id']}: "
@@ -236,9 +236,9 @@ def generate_deprecated_private(base_url: str, diff_map: Dict) -> Tuple[Dict, Li
                 if revision_of and revision_of not in non_auto_migrated:
                     non_auto_migrated.add(revision_of)
                     private_deprecated[dataset["collection_id"]]["revision_of"] = revision_of
-        except Exception as e:
+        except Exception:
             run_reporter.private_errored_datasets += 1
-            logger.error(f"Error processing private dataset")
+            logger.error("Error processing private dataset")
     for collection in private_deprecated.values():
         collection["dataset_groups"] = list(collection["dataset_groups"].values())
     return private_deprecated, non_auto_migrated  # type: ignore

--- a/scripts/schema_bump_dry_run_genes/requirements.txt
+++ b/scripts/schema_bump_dry_run_genes/requirements.txt
@@ -3,3 +3,4 @@ tiledb==0.30.2 # Should match version pinned in single-cell-data-portal
 pandas==2.2.2
 pyarrow>=1.0.0
 jinja2<4
+packaging==24.2

--- a/scripts/schema_bump_dry_run_ontologies/requirements.txt
+++ b/scripts/schema_bump_dry_run_ontologies/requirements.txt
@@ -1,2 +1,2 @@
 requests<3
-cellxgene-ontology-guide==1.4.1
+cellxgene-ontology-guide==1.6.0


### PR DESCRIPTION
## Reason for Change
Update (a) gene info files and (b) COG version to comply with cxg schema 5.3.0.

## Changes
- update COG version in requirements
- update to gene info.

## Testing
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer