### PR TITLE
feat(multiome): Update the upload_local_datafile_to_dataset.ipynb to use a manifest.

### DIFF
--- a/notebooks/curation_api/python/upload_local_datafile_to_dataset.ipynb
+++ b/notebooks/curation_api/python/upload_local_datafile_to_dataset.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from src.dataset import upload_local_datafile\n",
+    "from src.dataset import upload_datafiles_from_manifest, upload_local_datafile\n",
     "from src.utils.config import set_api_access_config"
    ]
   },
@@ -85,7 +85,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datafile_path = \"/absolute/path/to-datafile.h5ad\""
+    "anndata_file_path = \"/absolute/path/to-datafile.h5ad\"\n",
+    "atac_fragment_file_path = \"/absolute/path/to-datafile.tsv.bgz\"\n",
+    "manifest = {}"
    ]
   },
   {
@@ -151,9 +153,7 @@
    "cell_type": "markdown",
    "id": "f648e0b2",
    "metadata": {},
-   "source": [
-    "### Upload file using temporary s3 credentials"
-   ]
+   "source": "### Upload Anndata file using temporary s3 credentials"
   },
   {
    "cell_type": "code",
@@ -162,8 +162,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "upload_local_datafile(datafile_path, collection_id, dataset_id)"
+    "manifest[\"anndata\"] = upload_local_datafile(anndata_file_path, collection_id, dataset_id)"
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### Upload ATAC Fragment file using temporary s3 credentials (optional)",
+   "id": "5c8bdcae9cd3b2ef"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "manifest[\"atac_fragment\"] = upload_local_datafile(atac_fragment_file_path, collection_id, dataset_id)"
+   ],
+   "id": "6b6c50bb8d8ee05e"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### Submit the manifest to the dataset",
+   "id": "9bdbb52d9c93b73f"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "upload_datafiles_from_manifest(manifest, collection_id, dataset_id)"
+   ],
+   "id": "11cf466851ff1949"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Reason for Change

- Now that the manifest endpoint is used to upload datasets from the submission bucket, the notebook `upload_local_datafile_to_dataset` must be updated to use the new work flow. Now local files are uploaded to s3, and the resulting `s3_uri` will populate the manifest. The manifest submission endpoint will be called with the newly uploaded files and ingestion will start. 

## Changes

- update the upload_local_datafile to return an s3_uri 
- Use the local file name i the s3 object key.
- update `upload_local_datafile_to_dataset` to use the manifest endpoint and build the manifest.

## Testing

- 

## Notes for Reviewer