### PR TITLE
revert to pre-bump versions in codebase

### DIFF
--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="5.3.0",
+    version="5.2.3",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",


### PR DESCRIPTION
## Reason for Change
- keep versioning in sync. The versions should all be set to their pre-bumped versions.

## Changes
- The version in the CLI `setup.py` was set to its post-bump version, and is now reverted to its pre-bump version i.e. `5.2.3`


## Testing
