### PR TITLE
Remove decompressed intermediate

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -226,7 +226,7 @@ def process_fragment(
 def convert_to_parquet(fragment_file: str, tempdir: str) -> str:
     # convert the fragment to a parquet file
     logger.info(f"Converting {fragment_file} to parquet")
-    parquet_file_path = Path(tempdir) / Path(fragment_file).name.replace(".gz", ".parquet")
+    parquet_file_path = Path(tempdir) / Path(fragment_file).with_suffix(".parquet")
     ddf.read_csv(
         fragment_file, sep="\t", names=column_ordering, dtype=column_types, keep_default_na=False, compression="gzip"
     ).to_parquet(parquet_file_path, partition_on=["chromosome"], compute=True)


### PR DESCRIPTION
## Reason for Change

Found a possible performance issue while investigating some failures. Will reduce disk usage,

## Changes

- Read from compressed fragment file instead of decompressing first

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer