### PR TITLE
Revert "Remove decompressed intermediate (#1308)"

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -224,12 +224,24 @@ def process_fragment(
 
 
 def convert_to_parquet(fragment_file: str, tempdir: str) -> str:
+    # unzip the fragment. Subprocess is used here because gzip on the cli uses less memory with comparable
+    # speed to the python gzip library.
+    unzipped_file = Path(tempdir) / Path(fragment_file).name.rsplit(".", 1)[0]
+    logger.info(f"Unzipping {fragment_file}")
+    with open(unzipped_file, "wb") as fp:
+        subprocess.run(["gunzip", "-c", fragment_file], stdout=fp, check=True)
+
     # convert the fragment to a parquet file
     logger.info(f"Converting {fragment_file} to parquet")
-    parquet_file_path = Path(tempdir) / Path(fragment_file).with_suffix(".parquet")
-    ddf.read_csv(
-        fragment_file, sep="\t", names=column_ordering, dtype=column_types, keep_default_na=False, compression="gzip"
-    ).to_parquet(parquet_file_path, partition_on=["chromosome"], compute=True)
+    parquet_file_path = Path(tempdir) / Path(fragment_file).name.replace(".gz", ".parquet")
+    try:
+        ddf.read_csv(
+            unzipped_file, sep="\t", names=column_ordering, dtype=column_types, keep_default_na=False
+        ).to_parquet(parquet_file_path, partition_on=["chromosome"], compute=True)
+    finally:
+        # remove the unzipped file
+        logger.debug(f"Removing {unzipped_file}")
+        unzipped_file.unlink()
     parquet_file = str(parquet_file_path)
     return parquet_file
 

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -226,6 +226,7 @@ def process_fragment(
 def convert_to_parquet(fragment_file: str, tempdir: str) -> str:
     # unzip the fragment. Subprocess is used here because gzip on the cli uses less memory with comparable
     # speed to the python gzip library.
+    # We need to unzip for dask to be able to read in chunks
     unzipped_file = Path(tempdir) / Path(fragment_file).name.rsplit(".", 1)[0]
     logger.info(f"Unzipping {fragment_file}")
     with open(unzipped_file, "wb") as fp:

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -226,7 +226,7 @@ def process_fragment(
 def convert_to_parquet(fragment_file: str, tempdir: str) -> str:
     # unzip the fragment. Subprocess is used here because gzip on the cli uses less memory with comparable
     # speed to the python gzip library.
-    # We need to unzip for dask to be able to read in chunks
+    # Dask is unable to read a gzip compressed csv in chunks, so we need to decompress first
     unzipped_file = Path(tempdir) / Path(fragment_file).name.rsplit(".", 1)[0]
     logger.info(f"Unzipping {fragment_file}")
     with open(unzipped_file, "wb") as fp:


### PR DESCRIPTION
This reverts commit 3250f5a7a90491b30cd395491d3abd6c4e744b4a.

It turns out that dask needs to read the entirety of a gzipped csv into memory