### PR TITLE
fix: more efficient way of checking for duplicates

### DIFF
--- a/scripts/memtest/run_atac.py
+++ b/scripts/memtest/run_atac.py
@@ -1,0 +1,11 @@
+import tempfile
+
+from cellxgene_schema.atac_seq import process_fragment
+
+H5AD_FILE = "./data/revised.h5ad"
+FRAGMENT_FILE = "./data/fragments.tsv.gz"
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_file = "/".join([tmpdirname, "fragment.tsv.bgz"])
+        process_fragment(FRAGMENT_FILE, H5AD_FILE, True, output_file=tmp_file)


### PR DESCRIPTION
## Reason for Change

- This will reduce the amount of memory passed around to detect duplicate rows

## Changes

- using groupby to detect duplicate rows instead of drop duplicate. This results in small chunks being passed between dask workers.

## Testing

- verified unit tests pass.


## Notes for Reviewer