### PR TITLE
New approach using pyarrow for IO

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 import shutil
 import subprocess
@@ -11,7 +10,6 @@ import dask
 import dask.dataframe as ddf
 import filelock
 import h5py
-import pandas as pd
 import pyarrow as pa
 import pyarrow.csv
 import pyarrow.dataset
@@ -121,9 +119,6 @@ organism_ontology_term_id_by_chromosome_length_table = {
     "NCBITaxon:10090": mouse_chromosome_by_length,
 }
 column_ordering = ["chromosome", "start coordinate", "stop coordinate", "barcode", "read support"]
-allowed_chromosomes = list(set(itertools.chain(human_chromosome_by_length.keys(), mouse_chromosome_by_length.keys())))
-allowed_chromosomes.sort()
-chromosome_categories = pd.CategoricalDtype(categories=allowed_chromosomes)
 schema = pa.schema(
     [
         pa.field("chromosome", pa.string()),

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -226,6 +226,12 @@ def process_fragment(
 
 
 def convert_to_parquet(fragment_file: str, tempdir: str) -> str:
+    """
+    Convert the fragment file to a parquet dataset for faster processing.
+
+    :param fragment_file: A gzipped compressed fragment file
+    :param tempdir: The temporary directory to write the parquet file to. Name of the written file is derived from the input.
+    """
     logger.info(f"Converting {fragment_file} to parquet")
     parquet_file_path = Path(tempdir) / Path(fragment_file).name.replace(".gz", ".parquet").replace(".bgz", ".parquet")
     pa.dataset.write_dataset(
@@ -237,6 +243,7 @@ def convert_to_parquet(fragment_file: str, tempdir: str) -> str:
         ),
         base_dir=parquet_file_path,
         format="parquet",
+        # Using hive partitioning for best compatibility with dask to_parquet and read_parquet functions
         partitioning=pa.dataset.partitioning(pa.schema([pa.field("chromosome", pa.string())]), flavor="hive"),
     )
 

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -237,12 +237,13 @@ def process_fragment(
 
 def convert_to_parquet(fragment_file: str, tempdir: str) -> str:
     logger.info(f"Unzipping {fragment_file}")
-    parquet_file_path = Path(tempdir) / Path(fragment_file).name.replace(".gz", ".parquet")
+    parquet_file_path = Path(tempdir) / Path(fragment_file).name.replace(".gz", ".parquet").replace(".bgz", ".parquet")
     pa.dataset.write_dataset(
         data=pa.csv.open_csv(
             pa.input_stream(fragment_file, compression="gzip"),
             read_options=pa.csv.ReadOptions(column_names=schema.names),
             parse_options=pa.csv.ParseOptions(delimiter="\t"),
+            convert_options=pa.csv.ConvertOptions(column_types=schema),
         ),
         base_dir=parquet_file_path,
         format="parquet",

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -124,13 +124,6 @@ column_ordering = ["chromosome", "start coordinate", "stop coordinate", "barcode
 allowed_chromosomes = list(set(itertools.chain(human_chromosome_by_length.keys(), mouse_chromosome_by_length.keys())))
 allowed_chromosomes.sort()
 chromosome_categories = pd.CategoricalDtype(categories=allowed_chromosomes)
-column_types = {
-    "chromosome": chromosome_categories,
-    "start coordinate": int,
-    "stop coordinate": int,
-    "barcode": str,
-    "read support": int,
-}
 schema = pa.schema(
     [
         pa.field("chromosome", pa.string()),

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -226,7 +226,7 @@ def process_fragment(
 
 
 def convert_to_parquet(fragment_file: str, tempdir: str) -> str:
-    logger.info(f"Unzipping {fragment_file}")
+    logger.info(f"Converting {fragment_file} to parquet")
     parquet_file_path = Path(tempdir) / Path(fragment_file).name.replace(".gz", ".parquet").replace(".bgz", ".parquet")
     pa.dataset.write_dataset(
         data=pa.csv.open_csv(

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -213,12 +213,12 @@ def process_fragment(
                 return errors
 
             # convert the fragment to a parquet file for faster processing
-            # try:
-            parquet_file = convert_to_parquet(fragment_file, tempdir)
-            # except Exception as e:
-            #     msg = "Error Parsing the fragment file. Check that columns match schema definition. Error: " + str(e)
-            #     logger.exception(msg)
-            #     return [msg]
+            try:
+                parquet_file = convert_to_parquet(fragment_file, tempdir)
+            except Exception as e:
+                msg = "Error Parsing the fragment file. Check that columns match schema definition. Error: " + str(e)
+                logger.exception(msg)
+                return [msg]
 
             # slow checks
             errors = validate_anndata_with_fragment(parquet_file, anndata_file)

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -6,6 +6,7 @@ dask[array, dataframe]==2024.12.0
 filelock<4
 numpy<3
 pandas>2,<3
+pyarrow>=19
 PyYAML<7
 scipy<1.15 # broken in 1.15.0 see https://github.com/chanzuckerberg/single-cell-curation/issues/1165
 semver<4

--- a/cellxgene_schema_cli/tests/test_atac_seq.py
+++ b/cellxgene_schema_cli/tests/test_atac_seq.py
@@ -161,7 +161,7 @@ class TestConvertToParquet:
 
     def test_invalid_column_dtype(self, tmpdir, atac_fragment_dataframe):
         atac_fragment_dataframe["start coordinate"] = "foo"
-        tsv_file = os.path.join(tmpdir, "fragment.tsv")
+        tsv_file = os.path.join(tmpdir, "fragment.tsv.gz")
         atac_fragment_dataframe.to_csv(
             tsv_file, sep="\t", index=False, compression="gzip", header=False, columns=atac_seq.column_ordering
         )


### PR DESCRIPTION
## Reason for Change

Speed up conversion to parquet by skipping intermediate decompressed tsp

## Changes

- This uses the iterative CSV reader and iterative parquet writer from pyarrow.

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer

[Here is a small notebook](https://gist.github.com/ivirshup/248a2931d6e78cf72dedd9520af0e8de) where I took some performance metrics. I'm seeing about a 3x speed up on conversion and 1/5th memory usage

I've also timed the test suite on my branch against main, where we also see some improvements:

#### this branch

```
5.53s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_write_algorithms[pysam]
5.27s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_source_file_compression[fragments.tsv.bgz]
5.26s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_source_file_compression[fragments_sorted.tsv.gz]
5.12s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_write_algorithms[None]
5.12s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_write_algorithms[cli]
```

#### main

```
7.40s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_write_algorithms[pysam]
7.07s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_source_file_compression[fragments_sorted.tsv.gz]
7.07s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_write_algorithms[None]
7.06s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_source_file_compression[fragments.tsv.bgz]
7.02s call     cellxgene_schema_cli/tests/test_atac_seq.py::TestProcessFragment::test_write_algorithms[cli]
```