### PR TITLE
Optimize validation with duckdb

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -288,14 +288,14 @@ def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
 
 
 def validate_fragment_start_coordinate_greater_than_0(parquet_file: str) -> Optional[str]:
-    print("starting validate_fragment_start_coordinate_greater_than_0")
+    logger.info("starting validate_fragment_start_coordinate_greater_than_0")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     if not (df["start coordinate"] > 0).all().execute():
         return "Start coordinate must be greater than 0."
 
 
 def validate_fragment_barcode_in_adata_index(parquet_file: str, anndata_file: str) -> Optional[str]:
-    print("starting validate_fragment_barcode_in_adata_index")
+    logger.info("starting validate_fragment_barcode_in_adata_index")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     barcode = set(df.select("barcode").distinct().execute()["barcode"])
     with h5py.File(anndata_file) as f:
@@ -305,14 +305,14 @@ def validate_fragment_barcode_in_adata_index(parquet_file: str, anndata_file: st
 
 
 def validate_fragment_stop_greater_than_start_coordinate(parquet_file: str) -> Optional[str]:
-    print("starting validate_fragment_stop_greater_than_start_coordinate")
+    logger.info("starting validate_fragment_stop_greater_than_start_coordinate")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     if not (df["stop coordinate"] > df["start coordinate"]).all().execute():
         return "Stop coordinate must be greater than start coordinate."
 
 
 def validate_fragment_stop_coordinate_within_chromosome(parquet_file: str, anndata_file: str) -> Optional[str]:
-    print("starting validate_fragment_stop_coordinate_within_chromosome")
+    logger.info("starting validate_fragment_stop_coordinate_within_chromosome")
     with h5py.File(anndata_file) as f:
         organism_ontology_term_id = ad.io.read_elem(f["obs"])["organism_ontology_term_id"].unique().astype(str)[0]
     chromosome_length_table = organism_ontology_term_id_by_chromosome_length_table[organism_ontology_term_id]
@@ -331,7 +331,7 @@ def validate_fragment_stop_coordinate_within_chromosome(parquet_file: str, annda
 
 
 def validate_fragment_read_support(parquet_file: str) -> Optional[str]:
-    print("starting validate_fragment_read_support")
+    logger.info("starting validate_fragment_read_support")
     t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     if (t["read support"] <= 0).any().execute():
         return "Read support must be greater than 0."

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -290,8 +290,6 @@ def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
 def validate_fragment_start_coordinate_greater_than_0(parquet_file: str) -> Optional[str]:
     print("starting validate_fragment_start_coordinate_greater_than_0")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
-    # df = ddf.read_parquet(parquet_file, columns=["start coordinate"])
-    # series = (df["start coordinate"] > 0).all().execute()
     if not (df["start coordinate"] > 0).all().execute():
         return "Start coordinate must be greater than 0."
 
@@ -309,7 +307,6 @@ def validate_fragment_barcode_in_adata_index(parquet_file: str, anndata_file: st
 def validate_fragment_stop_greater_than_start_coordinate(parquet_file: str) -> Optional[str]:
     print("starting validate_fragment_stop_greater_than_start_coordinate")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
-    # df = ddf.read_parquet(parquet_file, columns=["start coordinate", "stop coordinate"])
     if not (df["stop coordinate"] > df["start coordinate"]).all().execute():
         return "Stop coordinate must be greater than start coordinate."
 
@@ -331,23 +328,6 @@ def validate_fragment_stop_coordinate_within_chromosome(parquet_file: str, annda
     df["chromosome_length"] = df["chromosome"].map(chromosome_length_table)
     if not (df["max_stop_coordinate"] <= df["chromosome_length"]).all():
         return "Stop coordinate must be less than the chromosome length."
-
-    # check that the stop coordinate is within the length of the chromosome
-    # with h5py.File(anndata_file) as f:
-    #     organism_ontology_term_id = ad.io.read_elem(f["obs"])["organism_ontology_term_id"].unique().astype(str)[0]
-    # df = ddf.read_parquet(parquet_file, columns=["chromosome", "stop coordinate"])
-
-    # # the chromosomes in the fragment must match the chromosomes for that organism
-    # chromosome_length_table = organism_ontology_term_id_by_chromosome_length_table[organism_ontology_term_id]
-    # mismatched_chromosomes = set(df["chromosome"].unique().compute()) - chromosome_length_table.keys()
-    # if mismatched_chromosomes:
-    #     return f"Chromosomes in the fragment do not match the organism({organism_ontology_term_id}).\n" + "\t\n".join(
-    #         mismatched_chromosomes
-    #     )
-    # df["chromosome_length"] = df["chromosome"].map(chromosome_length_table, meta=int).astype(int)
-    # df = df["stop coordinate"] <= df["chromosome_length"]
-    # if not df.all().compute():
-    #     return "Stop coordinate must be less than the chromosome length."
 
 
 def validate_fragment_read_support(parquet_file: str) -> Optional[str]:

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -288,9 +288,9 @@ def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
     for chromosome, count in rows_per_chromosome.itertuples(index=False):
         n_unique = t.filter(t["chromosome"] == chromosome).distinct().count().execute()
         if n_unique != count:
-            # TODO: See if we can improve error message
-            msg = "Fragment file has duplicate rows."
-            # msg += f"Chromosome {chromosome} has {count} rows but only {n_unique} are unique\n"
+            if not msg:
+                msg = "Fragment file has duplicate rows.\n"
+            msg += f"Chromosome {chromosome} has {count} rows but only {n_unique} are unique\n"
     if msg:
         return msg.strip()  # remove trailing newline
 

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -285,6 +285,7 @@ def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
     t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     rows_per_chromosome = t["chromosome"].value_counts().execute()
     msg = ""
+    # Checking number of unique rows per chromosome is more memory efficient than checking all rows at once
     for chromosome, count in rows_per_chromosome.itertuples(index=False):
         n_unique = t.filter(t["chromosome"] == chromosome).distinct().count().execute()
         if n_unique != count:

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -273,7 +273,7 @@ def validate_anndata_with_fragment(parquet_file: str, anndata_file: str) -> list
 
 
 def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
-    print("starting validate_fragment_no_duplicate_rows")
+    logger.info("starting validate_fragment_no_duplicate_rows")
     t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     rows_per_chromosome = t["chromosome"].value_counts().execute()
     msg = ""

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -354,9 +354,6 @@ def validate_anndata_is_primary_data(anndata_file: str) -> Optional[str]:
         return "Anndata.obs.is_primary_data must all be True."
 
 
-""
-
-
 @log_calls
 def validate_anndata_organism_ontology_term_id(anndata_file: str) -> Optional[str]:
     with h5py.File(anndata_file) as f:

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -3,6 +3,7 @@ cellxgene-ontology-guide==1.6.0 # update before a schema migration
 click<9
 Cython<4
 dask[array, dataframe]==2024.12.0
+ibis-framework[duckdb]>=10.3
 filelock<4
 numpy<3
 pandas>2,<3

--- a/cellxgene_schema_cli/tests/test_atac_seq.py
+++ b/cellxgene_schema_cli/tests/test_atac_seq.py
@@ -387,7 +387,9 @@ class TestValidateFragmentNoDuplicateRows:
         # Act
         result = atac_seq.validate_fragment_no_duplicate_rows(fragment_file)
         # Assert
-        assert result == "Fragment file has duplicate rows."
+        assert result.startswith("Fragment file has duplicate rows.")
+        for chrom in atac_fragment_dataframe["chromosome"].unique():
+            assert f"Chromosome {chrom} has 2 rows but only 1 are unique" in result
 
 
 class TestGetOutputFile:


### PR DESCRIPTION
## Reason for Change

We have been running out of memory while validating large atac seq fragment files. This PR address this by doing the validation with duckdb instead of dask-dataframe.

With these changes I was able to validate our largest dataset in ~5 minutes on a `m5ad.8xlarge` (125gb memory, 32 CPU) whereas I ran out of memory with the previous implementation.

## Changes

- 

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer