### PR TITLE
Improve sort step

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -288,14 +288,14 @@ def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
 
 
 def validate_fragment_start_coordinate_greater_than_0(parquet_file: str) -> Optional[str]:
-    print("starting validate_fragment_start_coordinate_greater_than_0")
+    logger.info("starting validate_fragment_start_coordinate_greater_than_0")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     if not (df["start coordinate"] > 0).all().execute():
         return "Start coordinate must be greater than 0."
 
 
 def validate_fragment_barcode_in_adata_index(parquet_file: str, anndata_file: str) -> Optional[str]:
-    print("starting validate_fragment_barcode_in_adata_index")
+    logger.info("starting validate_fragment_barcode_in_adata_index")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     barcode = set(df.select("barcode").distinct().execute()["barcode"])
     with h5py.File(anndata_file) as f:
@@ -305,14 +305,14 @@ def validate_fragment_barcode_in_adata_index(parquet_file: str, anndata_file: st
 
 
 def validate_fragment_stop_greater_than_start_coordinate(parquet_file: str) -> Optional[str]:
-    print("starting validate_fragment_stop_greater_than_start_coordinate")
+    logger.info("starting validate_fragment_stop_greater_than_start_coordinate")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     if not (df["stop coordinate"] > df["start coordinate"]).all().execute():
         return "Stop coordinate must be greater than start coordinate."
 
 
 def validate_fragment_stop_coordinate_within_chromosome(parquet_file: str, anndata_file: str) -> Optional[str]:
-    print("starting validate_fragment_stop_coordinate_within_chromosome")
+    logger.info("starting validate_fragment_stop_coordinate_within_chromosome")
     with h5py.File(anndata_file) as f:
         organism_ontology_term_id = ad.io.read_elem(f["obs"])["organism_ontology_term_id"].unique().astype(str)[0]
     chromosome_length_table = organism_ontology_term_id_by_chromosome_length_table[organism_ontology_term_id]
@@ -331,7 +331,7 @@ def validate_fragment_stop_coordinate_within_chromosome(parquet_file: str, annda
 
 
 def validate_fragment_read_support(parquet_file: str) -> Optional[str]:
-    print("starting validate_fragment_read_support")
+    logger.info("starting validate_fragment_read_support")
     t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     if (t["read support"] <= 0).any().execute():
         return "Read support must be greater than 0."

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -290,8 +290,6 @@ def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
 def validate_fragment_start_coordinate_greater_than_0(parquet_file: str) -> Optional[str]:
     print("starting validate_fragment_start_coordinate_greater_than_0")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
-    # df = ddf.read_parquet(parquet_file, columns=["start coordinate"])
-    # series = (df["start coordinate"] > 0).all().execute()
     if not (df["start coordinate"] > 0).all().execute():
         return "Start coordinate must be greater than 0."
 
@@ -309,7 +307,6 @@ def validate_fragment_barcode_in_adata_index(parquet_file: str, anndata_file: st
 def validate_fragment_stop_greater_than_start_coordinate(parquet_file: str) -> Optional[str]:
     print("starting validate_fragment_stop_greater_than_start_coordinate")
     df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
-    # df = ddf.read_parquet(parquet_file, columns=["start coordinate", "stop coordinate"])
     if not (df["stop coordinate"] > df["start coordinate"]).all().execute():
         return "Stop coordinate must be greater than start coordinate."
 
@@ -331,23 +328,6 @@ def validate_fragment_stop_coordinate_within_chromosome(parquet_file: str, annda
     df["chromosome_length"] = df["chromosome"].map(chromosome_length_table)
     if not (df["max_stop_coordinate"] <= df["chromosome_length"]).all():
         return "Stop coordinate must be less than the chromosome length."
-
-    # check that the stop coordinate is within the length of the chromosome
-    # with h5py.File(anndata_file) as f:
-    #     organism_ontology_term_id = ad.io.read_elem(f["obs"])["organism_ontology_term_id"].unique().astype(str)[0]
-    # df = ddf.read_parquet(parquet_file, columns=["chromosome", "stop coordinate"])
-
-    # # the chromosomes in the fragment must match the chromosomes for that organism
-    # chromosome_length_table = organism_ontology_term_id_by_chromosome_length_table[organism_ontology_term_id]
-    # mismatched_chromosomes = set(df["chromosome"].unique().compute()) - chromosome_length_table.keys()
-    # if mismatched_chromosomes:
-    #     return f"Chromosomes in the fragment do not match the organism({organism_ontology_term_id}).\n" + "\t\n".join(
-    #         mismatched_chromosomes
-    #     )
-    # df["chromosome_length"] = df["chromosome"].map(chromosome_length_table, meta=int).astype(int)
-    # df = df["stop coordinate"] <= df["chromosome_length"]
-    # if not df.all().compute():
-    #     return "Stop coordinate must be less than the chromosome length."
 
 
 def validate_fragment_read_support(parquet_file: str) -> Optional[str]:

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -273,7 +273,7 @@ def validate_anndata_with_fragment(parquet_file: str, anndata_file: str) -> list
 
 
 def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
-    print("starting validate_fragment_no_duplicate_rows")
+    logger.info("starting validate_fragment_no_duplicate_rows")
     t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
     rows_per_chromosome = t["chromosome"].value_counts().execute()
     msg = ""

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -3,6 +3,7 @@ cellxgene-ontology-guide==1.6.0 # update before a schema migration
 click<9
 Cython<4
 dask[array, dataframe]==2024.12.0
+ibis-framework[duckdb]>=10.3
 filelock<4
 numpy<3
 pandas>2,<3


### PR DESCRIPTION
VERY IN PROGRESS

## Reason for Change

I would like to see if we can improve the resource use of the sort step. Key points are:

* Reduce size of intermediate files needed (e.g. the currently uncompressed intermediate sorted CSVs)
* Duckdb has broadly been more efficient that dask.dataframe, see if we can get some wins from that

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- 

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer