### PR TITLE
Go back to using the dask lock

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -8,7 +8,7 @@ from typing import Optional
 import anndata as ad
 import dask
 import dask.dataframe as ddf
-import filelock
+import dask.distributed as dd  # TODO: see if distributed mode can be avoided.
 import h5py
 import ibis
 import pyarrow as pa
@@ -178,7 +178,7 @@ def process_fragment(
     fragment_file: str,
     anndata_file: str,
     generate_index: bool = False,
-    dask_config: Optional[dict] = None,
+    dask_cluster_config: Optional[dict] = None,
     override_write_algorithm: Optional[str] = None,
     output_file: Optional[str] = None,
 ) -> list[str]:
@@ -188,18 +188,21 @@ def process_fragment(
     :param str fragment_file: The fragment file to process
     :param str anndata_file: The anndata file to validate against
     :param bool generate_index: Whether to generate the index for the fragment
-    :param dask_config: dask cluster configuration parameters passed to dask.config
+    :param dask_cluster_config: dask cluster configuration parameters passed to dask.distributed.LocalCluster
     :param override_write_algorithm: Override the write algorithm used to write the bgzip file. Options are "pysam"
     and "cli"
     :param output_file: The output file to write the bgzip file to. If not provided, the output file will be the same
 
     """
     with tempfile.TemporaryDirectory() as tempdir:
-        # configure the dask
-        dask_config = dask_config or {"scheduler": "threads"}
+        # configure the dask cluster
+        _dask_cluster_config = dict(dashboard_address=None)
+        logging.getLogger("distributed").setLevel(logging.ERROR)
+        if dask_cluster_config:
+            _dask_cluster_config.update(dask_cluster_config)
 
         # start the dask cluster and client
-        with dask.config.set(dask_config):
+        with dd.LocalCluster(**_dask_cluster_config) as cluster, dd.Client(cluster):
             # quick checks
             errors = validate_anndata(anndata_file)
             if errors:
@@ -398,8 +401,7 @@ def index_fragment(
     bgzip_output_path = Path(bgzip_output_file)
     bgzip_output_path.unlink(missing_ok=True)
     bgzip_output_path.touch()
-    # lock to preserver write order
-    bgzip_write_lock = filelock.FileLock(bgzip_output_path.with_suffix(".lock").name, thread_local=False)
+    bgzip_write_lock = dd.Lock()  # lock to preserver write order
 
     if override_write_algorithm:
         write_algorithm = write_algorithm_by_callable[override_write_algorithm]
@@ -438,14 +440,14 @@ def sort_fragment(parquet_file: str, write_path: str, chromosome: str) -> Path:
 
 
 @delayed
-def write_bgzip_pysam(input_file: str, bgzip_output_file: str, write_lock: filelock.FileLock):
+def write_bgzip_pysam(input_file: str, bgzip_output_file: str, write_lock: dd.Lock):
     with write_lock, pysam.libcbgzf.BGZFile(bgzip_output_file, mode="ab") as f_out, open(input_file, "rb") as f_in:
         while data := f_in.read(2**20):
             f_out.write(data)
 
 
 @delayed
-def write_bgzip_cli(input_file: str, bgzip_output_file: str, write_lock: filelock.FileLock):
+def write_bgzip_cli(input_file: str, bgzip_output_file: str, write_lock: dd.Lock):
     with write_lock, open(input_file, "rb") as fin, open(bgzip_output_file, "ab") as fout:
         subprocess.run(["bgzip", "--threads=8", "-c"], stdin=fin, stdout=fout, check=True)
 
@@ -458,7 +460,7 @@ def prepare_fragment(
     parquet_file: str,
     bgzip_output_file: str,
     tempdir: str,
-    write_lock: filelock.FileLock,
+    write_lock: dd.Lock,
     write_algorithm: callable,
 ) -> list[Delayed]:
     """

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -2,9 +2,8 @@ anndata==0.11.2
 cellxgene-ontology-guide==1.6.0 # update before a schema migration
 click<9
 Cython<4
-dask[array, dataframe]==2024.12.0
+dask[array, distributed, dataframe]==2024.12.0
 ibis-framework[duckdb]>=10.3
-filelock<4
 numpy<3
 pandas>2,<3
 pyarrow>=19

--- a/cellxgene_schema_cli/tests/test_atac_seq.py
+++ b/cellxgene_schema_cli/tests/test_atac_seq.py
@@ -88,7 +88,7 @@ class TestProcessFragment:
             fragments_file,
             anndata_file,
             generate_index=True,
-            dask_config={"scheduler": "threads"},
+            dask_cluster_config=dict(processes=False),
             override_write_algorithm=override_write_algorithm,
             output_file=str(atac_fragment_bgzip_file_path),
         )
@@ -132,7 +132,7 @@ class TestProcessFragment:
             fragments_file,
             anndata_file,
             generate_index=True,
-            dask_config={"scheduler": "threads"},
+            dask_cluster_config=dict(processes=False),
             output_file=str(atac_fragment_bgzip_file_path),
         )
         result = [r for r in result if "Error" in r]


### PR DESCRIPTION
## Reason for Change

While working on https://github.com/chanzuckerberg/single-cell-curation/pull/1315, I was seeing non-contiguity in the final fragments file which was causing tabix to error. It looked like the new locking approach was not working.

Reverting back to using dask for locking alleviates these issues. 

## Changes

- Revert f4a84d6
