### PR TITLE
fix: properly validate + read sparse matrices in uns into dask

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -10,6 +10,7 @@ import dask
 import dask.dataframe as ddf
 import filelock
 import h5py
+import ibis
 import pyarrow as pa
 import pyarrow.csv
 import pyarrow.dataset
@@ -130,6 +131,14 @@ schema = pa.schema(
 )
 
 
+def log_calls(func):
+    def wrapper(*args, **kwargs):
+        logging.info("starting: %s", func.__name__)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 def is_atac(x: str) -> str:
     if is_ontological_descendant_of(ONTOLOGY_PARSER, x, "EFO:0010891"):
         if is_ontological_descendant_of(ONTOLOGY_PARSER, x, "EFO:0008913"):
@@ -186,7 +195,6 @@ def process_fragment(
 
     """
     with tempfile.TemporaryDirectory() as tempdir:
-
         # configure the dask
         dask_config = dask_config or {"scheduler": "threads"}
 
@@ -272,61 +280,73 @@ def validate_anndata_with_fragment(parquet_file: str, anndata_file: str) -> list
     return report_errors("Errors found in Fragment and/or Anndata file", errors)
 
 
+@log_calls
 def validate_fragment_no_duplicate_rows(parquet_file: str) -> Optional[str]:
-    df = ddf.read_parquet(parquet_file)
-    if len(df.drop_duplicates()) != len(df):
-        return "Fragment file has duplicate rows."
+    t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
+    rows_per_chromosome = t["chromosome"].value_counts().execute()
+    msg = ""
+    # Checking number of unique rows per chromosome is more memory efficient than checking all rows at once
+    for chromosome, count in rows_per_chromosome.itertuples(index=False):
+        n_unique = t.filter(t["chromosome"] == chromosome).distinct().count().execute()
+        if n_unique != count:
+            if not msg:
+                msg = "Fragment file has duplicate rows.\n"
+            msg += f"Chromosome {chromosome} has {count} rows but only {n_unique} are unique\n"
+    if msg:
+        return msg.strip()  # remove trailing newline
 
 
+@log_calls
 def validate_fragment_start_coordinate_greater_than_0(parquet_file: str) -> Optional[str]:
-    df = ddf.read_parquet(parquet_file, columns=["start coordinate"])
-    series = df["start coordinate"] > 0
-    if not series.all().compute():
+    df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
+    if not (df["start coordinate"] > 0).all().execute():
         return "Start coordinate must be greater than 0."
 
 
+@log_calls
 def validate_fragment_barcode_in_adata_index(parquet_file: str, anndata_file: str) -> Optional[str]:
-    df = ddf.read_parquet(parquet_file, columns=["barcode"])
+    df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
+    barcode = set(df.select("barcode").distinct().execute()["barcode"])
     with h5py.File(anndata_file) as f:
         obs = ad.io.read_elem(f["obs"])
-    barcode = set(df.groupby(by="barcode").count().compute().index)
     if set(obs.index) != barcode:
         return "Barcodes don't match anndata.obs.index"
 
 
+@log_calls
 def validate_fragment_stop_greater_than_start_coordinate(parquet_file: str) -> Optional[str]:
-    df = ddf.read_parquet(parquet_file, columns=["start coordinate", "stop coordinate"])
-    series = df["stop coordinate"] > df["start coordinate"]
-    if not series.all().compute():
+    df = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
+    if not (df["stop coordinate"] > df["start coordinate"]).all().execute():
         return "Stop coordinate must be greater than start coordinate."
 
 
+@log_calls
 def validate_fragment_stop_coordinate_within_chromosome(parquet_file: str, anndata_file: str) -> Optional[str]:
-    # check that the stop coordinate is within the length of the chromosome
     with h5py.File(anndata_file) as f:
         organism_ontology_term_id = ad.io.read_elem(f["obs"])["organism_ontology_term_id"].unique().astype(str)[0]
-    df = ddf.read_parquet(parquet_file, columns=["chromosome", "stop coordinate"])
-
-    # the chromosomes in the fragment must match the chromosomes for that organism
     chromosome_length_table = organism_ontology_term_id_by_chromosome_length_table[organism_ontology_term_id]
-    mismatched_chromosomes = set(df["chromosome"].unique().compute()) - chromosome_length_table.keys()
+    t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
+    df = t.group_by("chromosome").aggregate(max_stop_coordinate=t["stop coordinate"].max()).execute()
+
+    mismatched_chromosomes = set(df["chromosome"].unique()) - chromosome_length_table.keys()
     if mismatched_chromosomes:
         return f"Chromosomes in the fragment do not match the organism({organism_ontology_term_id}).\n" + "\t\n".join(
             mismatched_chromosomes
         )
-    df["chromosome_length"] = df["chromosome"].map(chromosome_length_table, meta=int).astype(int)
-    df = df["stop coordinate"] <= df["chromosome_length"]
-    if not df.all().compute():
+
+    df["chromosome_length"] = df["chromosome"].map(chromosome_length_table)
+    if not (df["max_stop_coordinate"] <= df["chromosome_length"]).all():
         return "Stop coordinate must be less than the chromosome length."
 
 
+@log_calls
 def validate_fragment_read_support(parquet_file: str) -> Optional[str]:
-    # check that the read support is greater than 0
-    df = ddf.read_parquet(parquet_file, columns=["read support"], filters=[("read support", "<=", 0)])
-    if len(df.compute()) != 0:
+    t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
+    if (t["read support"] <= 0).any().execute():
         return "Read support must be greater than 0."
 
 
+@log_calls
 def validate_anndata_is_primary_data(anndata_file: str) -> Optional[str]:
     with h5py.File(anndata_file) as f:
         is_primary_data = ad.io.read_elem(f["obs"])["is_primary_data"]
@@ -334,6 +354,7 @@ def validate_anndata_is_primary_data(anndata_file: str) -> Optional[str]:
         return "Anndata.obs.is_primary_data must all be True."
 
 
+@log_calls
 def validate_anndata_organism_ontology_term_id(anndata_file: str) -> Optional[str]:
     with h5py.File(anndata_file) as f:
         organism_ontology_term_ids = ad.io.read_elem(f["obs"])["organism_ontology_term_id"].unique().astype(str)
@@ -348,11 +369,11 @@ def validate_anndata_organism_ontology_term_id(anndata_file: str) -> Optional[st
         return f"Anndata.obs.organism_ontology_term_id must be one of {allowed_terms}. Got {organism_ontology_term_id}."
 
 
+@log_calls
 def detect_chromosomes(parquet_file: str) -> list[str]:
-    logger.info("detecting chromosomes")
-    df = ddf.read_parquet(parquet_file, columns=["chromosome"]).drop_duplicates()
-    df = df["chromosome"].compute()
-    return df.tolist()
+    t = ibis.read_parquet(f"{parquet_file}/**", hive_partitioning=True)
+    chromosomes = list(t.select(["chromosome"]).distinct().execute()["chromosome"])
+    return chromosomes
 
 
 def get_output_file(fragment_file: str, output_file: Optional[str]) -> str:

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -127,13 +127,13 @@ def read_backed(f: h5py.File, chunk_size: int) -> ad.AnnData:
     """
 
     def callback(func, elem_name: str, elem, iospec):
-        if "/layers" in elem_name or elem_name == "/X" or elem_name == "/raw/X":
-            if iospec.encoding_type in (
-                "csr_matrix",
-                "csc_matrix",
-            ):
+        if "/layers" in elem_name or "/uns" in elem_name or elem_name == "/X" or elem_name == "/raw/X":
+            if iospec.encoding_type == "csr_matrix":
                 n_vars = elem.attrs.get("shape")[1]
                 return read_elem_as_dask(elem, chunks=(chunk_size, n_vars))
+            elif iospec.encoding_type == "csc_matrix":
+                n_obs = elem.attrs.get("shape")[0]
+                return read_elem_as_dask(elem, chunks=(n_obs, chunk_size))
             elif iospec.encoding_type == "array" and len(elem.shape) == 2:
                 n_vars = elem.shape[1]
                 return read_elem_as_dask(elem, chunks=(chunk_size, n_vars))
@@ -157,15 +157,6 @@ def read_h5ad(h5ad_path: Union[str, bytes, os.PathLike], chunk_size: int = 5000)
     try:
         f = h5py.File(h5ad_path)
         adata = read_backed(f, chunk_size)
-
-        # This code, and AnnData in general, is optimized for row access.
-        # Running backed, with CSC, is prohibitively slow. Read the entire
-        # AnnData into memory if it is CSC.
-        if (get_matrix_format(adata.X) == "csc") or (
-            (adata.raw is not None) and (get_matrix_format(adata.raw.X) == "csc")
-        ):
-            logger.warning("Matrices are in CSC format; loading entire dataset into memory.")
-            adata = adata.to_memory()
 
     except (OSError, TypeError):
         logger.info(f"Unable to open '{h5ad_path}' with AnnData")

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -10,7 +10,6 @@ import dask
 import matplotlib.colors as mcolors
 import numpy as np
 import pandas as pd
-import scipy
 from anndata.compat import DaskArray
 from dask.array import map_blocks
 from scipy import sparse
@@ -933,11 +932,12 @@ class Validator:
                 category_mapping[column_name] = column.nunique()
 
         for key, value in uns_dict.items():
-            if isinstance(value, scipy.sparse.csr_matrix):
-                if value.nnz == 0:
+            if isinstance(value, DaskArray):
+                if value.size == 0 or value.shape[0] == 0 or value.shape[1] == 0:
                     self.errors.append(f"uns['{key}'] cannot be an empty value.")
             elif value is not None and not isinstance(value, (np.bool_, bool, numbers.Number)) and len(value) == 0:
                 self.errors.append(f"uns['{key}'] cannot be an empty value.")
+
             if key.endswith("_colors"):
                 # 1. Verify that the corresponding categorical field exists in obs
                 column_name = key.replace("_colors", "")

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -3,6 +3,7 @@ cellxgene-ontology-guide==1.6.0 # update before a schema migration
 click<9
 Cython<4
 dask[array, dataframe]==2024.12.0
+ibis-framework[duckdb]>=10.3
 filelock<4
 numpy<3
 pandas>2,<3

--- a/cellxgene_schema_cli/tests/test_atac_seq.py
+++ b/cellxgene_schema_cli/tests/test_atac_seq.py
@@ -387,7 +387,9 @@ class TestValidateFragmentNoDuplicateRows:
         # Act
         result = atac_seq.validate_fragment_no_duplicate_rows(fragment_file)
         # Assert
-        assert result == "Fragment file has duplicate rows."
+        assert result.startswith("Fragment file has duplicate rows.")
+        for chrom in atac_fragment_dataframe["chromosome"].unique():
+            assert f"Chromosome {chrom} has 2 rows but only 1 are unique" in result
 
 
 class TestGetOutputFile:

--- a/cellxgene_schema_cli/tests/test_atac_seq.py
+++ b/cellxgene_schema_cli/tests/test_atac_seq.py
@@ -117,11 +117,61 @@ class TestProcessFragment:
                 previous_start = start
                 previous_chomosome = chromosome
 
+        expected_chromosome_row_count = {
+            "chr1": 1002,
+            "chr2": 1002,
+            "chr3": 1002,
+            "chr4": 1002,
+            "chr5": 1002,
+            "chr6": 1002,
+            "chr7": 1002,
+            "chr8": 1002,
+            "chr9": 1002,
+            "chr10": 1002,
+            "chr11": 1002,
+            "chr12": 1002,
+            "chr13": 1002,
+            "chr14": 1002,
+            "chr15": 1002,
+            "chr16": 1002,
+            "chr17": 1002,
+            "chr18": 1002,
+            "chr19": 1002,
+            "chr20": 1002,
+            "chr21": 1002,
+            "chr22": 1002,
+            "chrX": 1002,
+            "chrY": 1002,
+            "chrM": 16569,
+            "GL000009.2": 1002,
+            "GL000194.1": 1002,
+            "GL000195.1": 1002,
+            "GL000205.2": 1002,
+            "GL000213.1": 336,
+            "GL000216.2": 176608,
+            "GL000218.1": 1002,
+            "GL000219.1": 1002,
+            "GL000220.1": 161802,
+            "GL000225.1": 211173,
+            "KI270442.1": 392061,
+            "KI270711.1": 1002,
+            "KI270713.1": 1002,
+            "KI270721.1": 748,
+            "KI270726.1": 534,
+            "KI270727.1": 1002,
+            "KI270728.1": 1002,
+            "KI270731.1": 561,
+            "KI270733.1": 179772,
+            "KI270734.1": 1002,
+            "KI270744.1": 168472,
+            "KI270750.1": 148850,
+        }
         # Testing index access
         assert atac_fragment_index_file_path.exists()
         with pysam.TabixFile(str(atac_fragment_bgzip_file_path)) as tabix:
             for chromosome in tabix.contigs:
                 assert chromosome in atac_seq.human_chromosome_by_length
+                assert expected_chromosome_row_count[chromosome] == len(list(tabix.fetch(chromosome)))
 
     def test_fail(self, atac_fragment_bgzip_file_path, atac_fragment_index_file_path):
         # Arrange

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2090,11 +2090,11 @@ class TestUns:
     def test_uns_scipy_matrices_cannot_be_empty(self, validator_with_adata):
         validator: Validator = validator_with_adata
 
-        validator.adata.uns["test"] = scipy.sparse.csr_matrix([[1]], dtype=int)
+        validator.adata.uns["test"] = from_array(scipy.sparse.csr_matrix([[1]], dtype=int))
         validator.validate_adata()
         assert validator.errors == []
 
-        validator.adata.uns["test"] = scipy.sparse.csr_matrix([[]], dtype=int)
+        validator.adata.uns["test"] = from_array(scipy.sparse.csc_matrix([[]], dtype=int))
         validator.validate_adata()
         assert validator.errors == ["ERROR: uns['test'] cannot be an empty value."]
 


### PR DESCRIPTION
## Reason for Change

- During 5.3.0 schema dev migration, found an instance of CSC matrix in dataset's UNS that was being incorrectly marked as invalid (and read into memory)


## Changes

- read matrices in uns lazily as dask arrays in `utils.read_backed`. validation does not require reading any uns matrices into memory. 
- csc matrices were being incorrectly handled; they cannot be chunked alongside the row axis. handle csc vs csr matrix chunking in separate clauses.
- update uns validation to properly check that these dask arrays representing matrices are not of size 0
- remove obviated step to read CSC X matrices into memory; we no longer allow CSC X matrices.