### PR TITLE
feat: schema 5.3 migration

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -121,6 +121,9 @@ components:
           exceptions:
             - unknown
           allowed:
+            terms:
+              CL:
+                - CL:0000000
             ancestors:
               ZFA:
               - ZFA:0009000

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -13,7 +13,6 @@ import pandas as pd
 from anndata.compat import DaskArray
 from dask.array import map_blocks
 from scipy import sparse
-import scipy.sparse
 
 from . import gencode, schema
 from .gencode import get_gene_checker
@@ -415,7 +414,7 @@ class Validator:
                         allow_list == ["all"] or term_id in set(allow_list)
                     ):
                         is_allowed = True
-                        #break
+                        # break
             if (
                 not is_allowed
                 and "ancestors" in curie_constraints["allowed"]

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -14,6 +14,7 @@ import scipy
 from anndata.compat import DaskArray
 from dask.array import map_blocks
 from scipy import sparse
+import scipy.sparse
 
 from . import gencode, schema
 from .gencode import get_gene_checker
@@ -933,7 +934,7 @@ class Validator:
                 category_mapping[column_name] = column.nunique()
 
         for key, value in uns_dict.items():
-            if isinstance(value, scipy.sparse.csr_matrix):
+            if isinstance(value, scipy.sparse.spmatrix):
                 if value.nnz == 0:
                     self.errors.append(f"uns['{key}'] cannot be an empty value.")
             elif value is not None and not isinstance(value, (np.bool_, bool, numbers.Number)) and len(value) == 0:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -415,7 +415,7 @@ class Validator:
                         allow_list == ["all"] or term_id in set(allow_list)
                     ):
                         is_allowed = True
-                        break
+                        #break
             if (
                 not is_allowed
                 and "ancestors" in curie_constraints["allowed"]

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -677,13 +677,21 @@ class TestObs:
         validator.validate_adata()
         assert len(validator.errors) > 0
 
+    @pytest.mark.parametrize("term",["CL:0000000"])
+    def test_cell_type_ontology_term_id(self, validator_with_adata, term):
+        validator = validator_with_adata
+        validator.adata.obs["cell_type_ontology_term_id"] = term
+        validator.validate_adata()
+        assert len(validator.errors)==0
+
+    
     @pytest.mark.parametrize(
         "term",
         schema_def["components"]["obs"]["columns"]["cell_type_ontology_term_id"]["curie_constraints"]["forbidden"][
             "terms"
         ],
     )
-    def test_cell_type_ontology_term_id(self, validator_with_adata, term):
+    def test_cell_type_ontology_term_id__forbidden(self, validator_with_adata, term):
         """
         cell_type_ontology_term_id categorical with str categories. This MUST be a CL term, and must NOT match forbidden
         columns defined in schema

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -2095,14 +2095,17 @@ class TestUns:
         validator.validate_adata()
         assert validator.errors == []
 
-    def test_uns_scipy_matrices_cannot_be_empty(self, validator_with_adata):
+    @pytest.mark.parametrize("matrix_factory",[scipy.sparse.csr_matrix, scipy.sparse.csc_matrix])
+    def test_uns_scipy_matrices_cannot_be_empty(self, validator_with_adata, matrix_factory):
         validator: Validator = validator_with_adata
 
-        validator.adata.uns["test"] = scipy.sparse.csr_matrix([[1]], dtype=int)
+        validator.adata.uns["test"] = matrix_factory([[1]], dtype=int)
+        
         validator.validate_adata()
         assert validator.errors == []
+        validator.reset()
 
-        validator.adata.uns["test"] = scipy.sparse.csr_matrix([[]], dtype=int)
+        validator.adata.uns["test"] = matrix_factory([[]], dtype=int)
         validator.validate_adata()
         assert validator.errors == ["ERROR: uns['test'] cannot be an empty value."]
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -677,14 +677,13 @@ class TestObs:
         validator.validate_adata()
         assert len(validator.errors) > 0
 
-    @pytest.mark.parametrize("term",["CL:0000000"])
+    @pytest.mark.parametrize("term", ["CL:0000000"])
     def test_cell_type_ontology_term_id(self, validator_with_adata, term):
         validator = validator_with_adata
         validator.adata.obs["cell_type_ontology_term_id"] = term
         validator.validate_adata()
-        assert len(validator.errors)==0
+        assert len(validator.errors) == 0
 
-    
     @pytest.mark.parametrize(
         "term",
         schema_def["components"]["obs"]["columns"]["cell_type_ontology_term_id"]["curie_constraints"]["forbidden"][
@@ -2095,7 +2094,7 @@ class TestUns:
         validator.validate_adata()
         assert validator.errors == []
 
-    @pytest.mark.parametrize("matrix_factory",[scipy.sparse.csr_matrix, scipy.sparse.csc_matrix])
+    @pytest.mark.parametrize("matrix_factory", [scipy.sparse.csr_matrix, scipy.sparse.csc_matrix])
     def test_uns_scipy_matrices_cannot_be_empty(self, validator_with_adata, matrix_factory):
         validator: Validator = validator_with_adata
 


### PR DESCRIPTION
## Reason for Change
These fixes address issues that emerged as part of the schema migration. 
- ERROR: 'CL:0000000' in 'cell_type_ontology_term_id' is not an allowed term id.
- sparse array length is ambiguous; use getnnz() or shape[0]  - this error occurs as a result of a sparse matrix in `anndata.uns`


## Changes
- allow specific terms in schema_definition e.g. CL:0000000
- support reading `csc` sparse matrices in `uns` element
- support for validating dask arrays in `uns` element


## Testing
- added tests for validating empty/non-empty `anndata.uns` sparse matrices, regardless of sparse format.

## Notes for Reviewer