### PR TITLE
fix: upgrade setuptools before building

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,6 +19,7 @@ jobs:
         id: build
         run: |
           pip install wheel
+          pip install -U setuptools
           make pydist
           cd cellxgene_schema_cli
           echo "version=`python setup.py --version`" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Reason for Change

- fix a deprecation warning from pypi by upgrading setuptools

## Changes

- upgrade setuptools before building python distribution of cellxgene-schema.

## Testing

- verified that building works with the latest setuptools and pypi doesn't complain about it's naming

## Notes for Reviewer