### PR TITLE
fix: reduce disk usage for conversion steps.

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 SPARSE_MATRIX_TYPES = {"csr", "csc", "coo"}
 SUPPORTED_SPARSE_MATRIX_TYPES = {"csr"}
 
+KB = 1024
+MB = 1024 * KB
+GB = 1024 * MB
+
 
 def replace_ontology_term(dataframe, ontology_name, update_map):
     column_name = f"{ontology_name}_ontology_term_id"


### PR DESCRIPTION

## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- Buffer disk reads when convert to parquet. This improves the conversion speed by reducing the number of disk calls.
- only run one sort job at time to reduce overloading the dask scheduler
- compress sorted intermediate files.
- update write function to read compressed sorted files.

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer