### PR TITLE
feat: validate that no two rows in obs are identical by row counts

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -13,6 +13,7 @@ import pandas as pd
 from anndata.compat import DaskArray
 from dask.array import map_blocks
 from scipy import sparse
+from validation_internals.check_duplicates import check_duplicate_obs
 
 from . import gencode, schema
 from .gencode import get_gene_checker
@@ -26,8 +27,6 @@ from .utils import (
     is_ontological_descendant_of,
     read_h5ad,
 )
-
-from validation_internals.check_duplicates import check_duplicate_obs
 
 logger = logging.getLogger(__name__)
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -2056,7 +2056,7 @@ class Validator:
         self._validate_cell_type_ontology_term_id()
 
         # Verifies there are no duplicate obs rows, by raw counts
-        self.errors.extend(check_duplicate_obs())
+        self.errors.extend(check_duplicate_obs(self.adata))
 
         # Checks each component
         for component_name, component_def in self.schema_def["components"].items():

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -27,6 +27,8 @@ from .utils import (
     read_h5ad,
 )
 
+from validation_internals.check_duplicates import check_duplicate_obs
+
 logger = logging.getLogger(__name__)
 
 ASSAY_VISIUM = "EFO:0010961"  # generic term
@@ -2053,6 +2055,9 @@ class Validator:
         # Organism-specific prefix validation
         self._validate_tissue_ontology_term_id()
         self._validate_cell_type_ontology_term_id()
+
+        # Verifies there are no duplicate obs rows, by raw counts
+        self.errors.extend(check_duplicate_obs())
 
         # Checks each component
         for component_name, component_def in self.schema_def["components"].items():

--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -1,47 +1,54 @@
 import hashlib
 
+import anndata
 import dask.array as da
 import numpy as np
 from scipy import sparse
 from utils import get_matrix_format
 
 
-def check_duplicate_obs(adata) -> list[str]:
+def check_duplicate_obs(adata: anndata.AnnData) -> list[str]:
     """
     Checks for duplicate rows in obs by raw count.
 
-    The logic is split by whether it's a sparse or dense matrix.
-
     :rtype List of errors that were seen. If no errors, validation is good.
     """
+
+    errors = []
 
     if "in_tissue" in adata.obs.columns:
         obs_to_keep = adata.obs[adata.obs["in_tissue"] != 0].index
         adata = adata[obs_to_keep, :]
 
-    to_validate = [adata.X]
+    to_validate = [(adata.X, "adata.X")]
 
     if adata.raw:
-        to_validate.append(adata.raw.X)
+        to_validate.append((adata.raw.X, "adata.raw.X"))
 
-    for matrix in to_validate:
+    for matrix, matrix_name in to_validate:
         matrix_format = get_matrix_format(matrix)
         if matrix_format == "csr" or matrix_format == "dense":
-            return _check_duplicate_obs_dask(adata, matrix)
+            errors.extend(_check_duplicate_obs_dask(adata, matrix, matrix_name))
         else:
-            return [
+            errors.append(
                 f"Unsupported matrix format: {matrix_format} Sparse matrices must be encoded as scipy.sparse.csr_matrix. Dense matrices can be np.ndarray"
-            ]
+            )
+
+    return errors
 
 
-def _check_duplicate_obs_dask(adata, matrix: da.Array) -> list[str]:
+def _check_duplicate_obs_dask(adata: anndata.AnnData, matrix: da.Array, matrix_name: str) -> list[str]:
+    """
+    For each row in the matrix, we compute a hash of the row and store it in row_hashes.
+    We then check for duplicates in the row_hashes.
+    """
     errors = []
 
     if matrix.ndim != 2:
-        return [f"Dask matrix must be 2D, but got shape {matrix.shape}"]
+        return [f"Dask matrix {matrix_name} must be 2D, but got shape {matrix.shape}"]
 
     def rowwise_hash_block(block):
-        # If it's sparse, convert each block to dense array
+        # If it's sparse, convert each block to dense array so that we can run tobytes()
         if sparse.issparse(block):
             block = block.toarray()
 
@@ -64,6 +71,11 @@ def _check_duplicate_obs_dask(adata, matrix: da.Array) -> list[str]:
     dup_df = hash_df[hash_df.duplicated(subset="row_hash", keep=False)].copy()
 
     if not dup_df.empty:
-        errors.append(f"Found {len(dup_df)} duplicated raw counts in obs")
+        duplicate_rows_to_print = []
+        for i, idx in enumerate(hash_df.index[:10]):
+            duplicate_rows_to_print.append(f"row {i}: index = {idx}")
+        errors.append(
+            f"Found {len(dup_df)} duplicated raw counts in obs {matrix_name}. First {len(duplicate_rows_to_print)} duplicate rows found at: {duplicate_rows_to_print}. {hash_df}"
+        )
 
     return errors

--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -71,12 +71,6 @@ def _check_duplicate_obs_dask(adata: anndata.AnnData, matrix: da.Array, matrix_n
     dup_df = hash_df[hash_df.duplicated(subset="row_hash", keep=False)].copy()
 
     if not dup_df.empty:
-        duplicate_rows_to_print = []
-        max_rows_to_print = 10
-        for i, idx in enumerate(dup_df.index[:max_rows_to_print]):
-            duplicate_rows_to_print.append(f"row {i}: index = {idx}")
-        errors.append(
-            f"Found {len(dup_df)} duplicated raw counts in obs {matrix_name}. First {len(duplicate_rows_to_print)} duplicate rows found at: {duplicate_rows_to_print}."
-        )
+        errors.append(f"Found {len(dup_df)} duplicated raw counts in obs {matrix_name}.")
 
     return errors

--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -30,9 +30,9 @@ def check_duplicate_obs(adata: anndata.AnnData) -> list[str]:
         if matrix_format == "csr" or matrix_format == "dense":
             errors.extend(_check_duplicate_obs_dask(adata, matrix, matrix_name))
         else:
-            errors.append(
-                f"Unsupported matrix format: {matrix_format} Sparse matrices must be encoded as scipy.sparse.csr_matrix. Dense matrices can be np.ndarray"
-            )
+            # We already raise an error for unsupported formats in _validate_sparsity, so no need to
+            # check again here.
+            continue
 
     return errors
 
@@ -75,7 +75,7 @@ def _check_duplicate_obs_dask(adata: anndata.AnnData, matrix: da.Array, matrix_n
         for i, idx in enumerate(hash_df.index[:10]):
             duplicate_rows_to_print.append(f"row {i}: index = {idx}")
         errors.append(
-            f"Found {len(dup_df)} duplicated raw counts in obs {matrix_name}. First {len(duplicate_rows_to_print)} duplicate rows found at: {duplicate_rows_to_print}. {hash_df}"
+            f"Found {len(dup_df)} duplicated raw counts in obs {matrix_name}. First {len(duplicate_rows_to_print)} duplicate rows found at: {duplicate_rows_to_print}."
         )
 
     return errors

--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -1,0 +1,116 @@
+import hashlib
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+from utils import (
+    SPARSE_MATRIX_TYPES,
+    get_matrix_format,
+)
+
+def check_duplicate_obs(adata) -> list[str]:
+    """
+    Checks for duplicate rows in obs by raw count.
+
+    :rtype List of errors that were seen. If no errors, validation is good.
+    """
+    matrix = adata.X[:, column]
+    is_sparse_matrix = get_matrix_format(matrix) in SPARSE_MATRIX_TYPES
+    if is_sparse_matrix:
+        return _check_duplicate_obs_sparse(adata)
+    else:
+        return _check_duplicate_obs_dense(adata)
+
+def _check_duplicate_obs_dense(adata) -> list[str]:
+    errors = []
+
+    if 'in_tissue' in adata.obs.columns:
+      obs_to_keep = adata.obs[adata.obs['in_tissue'] != 0].index
+      adata = adata[obs_to_keep, :]
+
+    matrix = adata.raw.X if adata.raw else adata.X
+
+    if hasattr(matrix, 'toarray'):
+        matrix = matrix.toarray()
+    elif not isinstance(matrix, np.ndarray):
+        matrix = np.array(matrix)
+
+    def row_hash(row):
+        return hashlib.sha1(row.tobytes()).hexdigest()
+
+    row_hashes = [row_hash(row) for row in matrix]
+
+    hash_df = adata.obs.copy()
+    hash_df['row_hash'] = row_hashes
+
+    dup_df = hash_df[hash_df.duplicated(subset='row_hash', keep=False)].copy()
+
+    if not dup_df.empty:
+        errors.append('duplicated raw counts', 'ERROR')
+
+    return errors
+
+def _check_duplicate_obs_sparse(adata) -> list[str]:
+    """
+    Hash sparse csr matrix using np.ndarrays that represent sparse matrix data.
+    First pass will hash all rows via slicing the data array and append to copy of obs df
+    Second pass will hash only duplicate rows in obs copy via the indices array.
+    This will keep only true duplicated matrix rows and not rows with an indicental same
+    ordering of their data arrays
+    """
+    errors = []
+
+    if 'in_tissue' in adata.obs.columns:
+        obs_to_keep = adata.obs[adata.obs['in_tissue'] != 0].index
+        adata = adata[obs_to_keep, : ]
+
+    matrix = adata.raw.X if adata.raw else adata.X
+
+    if not isinstance(matrix, sparse.csr_matrix):
+        errors.append("Matrix not in sparse csr format, please convert before hashing")
+        return
+
+    nnz = matrix.nnz
+
+    if not matrix.has_canonical_format:
+        if adata.raw:
+            adata.raw.X.sort_indices()
+            adata.raw.X.sum_duplicates()
+        else:
+            adata.X.sort_indices()
+            adata.X.sum_duplicates()
+
+    assert matrix.has_canonical_format, "Matrix still in non-canonical format"
+
+    if nnz != matrix.nnz:
+        errors.append(f"{nnz - matrix.nnz} duplicates found during canonical conversion")
+
+    data_array = matrix.data
+    index_array = matrix.indices
+    indptr_array = matrix.indptr
+
+    start, end = 0, matrix.shape[0]
+    hashes = []
+    while start < end:
+        val = hash(data_array[indptr_array[start]:indptr_array[start + 1]].tobytes())
+        hashes.append(val)
+        start += 1
+
+    def index_hash(index):
+        obs_loc = adata.obs.index.get_loc(index)
+        val = hash(index_array[indptr_array[obs_loc]:indptr_array[obs_loc + 1]].tobytes())
+
+        return val
+    
+    hash_df = adata.obs.copy()
+    hash_df['data_array_hash'] = hashes
+    hash_df = hash_df[hash_df.duplicated(subset='data_array_hash',keep=False) == True]
+    hash_df.sort_values('data_array_hash', inplace=True)
+
+    hash_df['index_array_hash'] = [index_hash(row) for row in hash_df.index.to_list()]
+    hash_df = hash_df[hash_df.duplicated(subset=['data_array_hash', 'index_array_hash'], keep=False) == True]
+
+    if not hash_df.empty:
+        errors.append('duplicated raw counts')
+    
+    return errors

--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -72,7 +72,8 @@ def _check_duplicate_obs_dask(adata: anndata.AnnData, matrix: da.Array, matrix_n
 
     if not dup_df.empty:
         duplicate_rows_to_print = []
-        for i, idx in enumerate(hash_df.index[:10]):
+        max_rows_to_print = 10
+        for i, idx in enumerate(dup_df.index[:max_rows_to_print]):
             duplicate_rows_to_print.append(f"row {i}: index = {idx}")
         errors.append(
             f"Found {len(dup_df)} duplicated raw counts in obs {matrix_name}. First {len(duplicate_rows_to_print)} duplicate rows found at: {duplicate_rows_to_print}."

--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -1,11 +1,9 @@
 import hashlib
 
+import dask.array as da
 import numpy as np
 from scipy import sparse
-from utils import (
-    SPARSE_MATRIX_TYPES,
-    get_matrix_format,
-)
+from utils import get_matrix_format
 
 
 def check_duplicate_obs(adata) -> list[str]:
@@ -16,86 +14,50 @@ def check_duplicate_obs(adata) -> list[str]:
 
     :rtype List of errors that were seen. If no errors, validation is good.
     """
-    matrix = adata.raw.X if adata.raw else adata.X
-    is_sparse_matrix = get_matrix_format(matrix) in SPARSE_MATRIX_TYPES
-    if is_sparse_matrix:
-        return _check_duplicate_obs_sparse(adata)
-    else:
-        return _check_duplicate_obs_dense(adata)
-
-
-def _check_duplicate_obs_dense(adata) -> list[str]:
-    errors = []
 
     if "in_tissue" in adata.obs.columns:
         obs_to_keep = adata.obs[adata.obs["in_tissue"] != 0].index
         adata = adata[obs_to_keep, :]
 
-    matrix = adata.raw.X if adata.raw else adata.X
+    to_validate = [adata.X]
 
-    if hasattr(matrix, "toarray"):
-        matrix = matrix.toarray()
-    elif not isinstance(matrix, np.ndarray):
-        matrix = np.array(matrix)
+    if adata.raw:
+        to_validate.append(adata.raw.X)
+    
+    for matrix in to_validate:
+        matrix_format = get_matrix_format(matrix)
+        if matrix_format == "csr" or matrix_format == "dense":
+            return _check_duplicate_obs_dask(adata, matrix)
+        else:
+            return [
+                f"Unsupported matrix format: {matrix_format} Sparse matrices must be encoded as scipy.sparse.csr_matrix. Dense matrices can be np.ndarray"
+            ]
 
-    def row_hash(row):
-        return hashlib.sha224(row.tobytes()).hexdigest()
+def _check_duplicate_obs_dask(adata, matrix: da.Array) -> list[str]:
+    errors = []
 
-    row_hashes = [row_hash(row) for row in matrix]
+    if matrix.ndim != 2:
+        return [f"Dask matrix must be 2D, but got shape {matrix.shape}"]
+
+    def rowwise_hash_block(block):
+        # If it's sparse, convert each block to dense array
+        if sparse.issparse(block):
+            block = block.toarray()
+
+        return np.array([
+            hashlib.sha224(row.tobytes()).hexdigest()
+            for row in block
+        ], dtype=object).reshape(-1, 1)  # shape (rows, 1) for map_blocks
+
+    row_hashes = matrix.map_blocks(
+        rowwise_hash_block,
+        dtype=object,
+        chunks=(matrix.chunks[0], (1,)),  # one hash per row
+    ).compute().ravel()
 
     hash_df = adata.obs.copy()
     hash_df["row_hash"] = row_hashes
-
     dup_df = hash_df[hash_df.duplicated(subset="row_hash", keep=False)].copy()
-
-    if not dup_df.empty:
-        errors.append(f"Found {len(dup_df)} duplicated raw counts in obs")
-
-    return errors
-
-
-def _check_duplicate_obs_sparse(adata) -> list[str]:
-    """
-    Hash sparse csr matrix using np.ndarrays that represent sparse matrix data.
-    First pass will hash all rows via slicing the data array and append to copy of obs df
-    Second pass will hash only duplicate rows in obs copy via the indices array.
-    This will keep only true duplicated matrix rows and not rows with an indicental same
-    ordering of their data arrays
-    """
-    errors = []
-
-    if "in_tissue" in adata.obs.columns:
-        obs_to_keep = adata.obs[adata.obs["in_tissue"] != 0].index
-        adata = adata[obs_to_keep, :]
-
-    matrix = adata.raw.X if adata.raw else adata.X
-
-    if not isinstance(matrix, sparse.csr_matrix):
-        errors.append("Matrix not in sparse csr format, please convert before hashing")
-        return errors
-
-    if not matrix.has_canonical_format:
-        matrix.sort_indices()
-        matrix.sum_duplicates()
-
-    assert matrix.has_canonical_format, "Matrix still in non-canonical format"
-
-    indptr = matrix.indptr
-    data = matrix.data
-    indices = matrix.indices
-
-    def row_hash(data_slice):
-        return hashlib.sha224(data_slice.tobytes()).hexdigest()
-
-    data_hashes = [row_hash(data[indptr[i] : indptr[i + 1]]) for i in range(matrix.shape[0])]
-    index_hashes = [row_hash(indices[indptr[i] : indptr[i + 1]]) for i in range(matrix.shape[0])]
-
-    hash_df = adata.obs.copy()
-    hash_df["data_hash"] = data_hashes
-    hash_df["index_hash"] = index_hashes
-
-    dup_mask = hash_df.duplicated(subset=["data_hash", "index_hash"], keep=False)
-    dup_df = hash_df[dup_mask].copy()
 
     if not dup_df.empty:
         errors.append(f"Found {len(dup_df)} duplicated raw counts in obs")

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -432,10 +432,9 @@ good_uns_with_slide_seqV2_spatial = {
 # 4. Creating expression matrix,
 # X has integer values and non_raw_X has real values
 X = from_array(sparse.csr_matrix((good_obs.shape[0], good_var.shape[0]), dtype=numpy.float32))
-X[0, 0] = 1
-X[1, 0] = 2
-X[0, 1] = 3
-X[1, 1] = 4
+for i in range(good_obs.shape[0]):
+    for j in range(good_var.shape[0]):
+        X[i, j] = i + j
 non_raw_X = X.copy()
 non_raw_X[0, 0] = 1.5
 

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -433,7 +433,9 @@ good_uns_with_slide_seqV2_spatial = {
 # X has integer values and non_raw_X has real values
 X = from_array(sparse.csr_matrix((good_obs.shape[0], good_var.shape[0]), dtype=numpy.float32))
 X[0, 0] = 1
-X[1, 0] = 1
+X[1, 0] = 2
+X[0, 1] = 3
+X[1, 1] = 4
 non_raw_X = X.copy()
 non_raw_X[0, 0] = 1.5
 

--- a/cellxgene_schema_cli/tests/test_check_duplicates.py
+++ b/cellxgene_schema_cli/tests/test_check_duplicates.py
@@ -1,6 +1,9 @@
+import numpy
 import pytest
 from cellxgene_schema.validation_internals.check_duplicates import check_duplicate_obs
+from dask.array import from_array
 from fixtures.examples_validate import adata
+from scipy import sparse
 
 
 @pytest.fixture
@@ -9,5 +12,14 @@ def valid_adata():
 
 
 class TestCheckDuplicates:
-    def test__check_duplicate_obs(self, valid_adata):
+    def test__check_duplicate_obs_ok(self, valid_adata):
         assert check_duplicate_obs(valid_adata) == []
+
+    def test__obs_has_duplicate_rows(self, valid_adata):
+        # zeros out the X matrix, resulting in duplicate rows of all 0's
+        valid_adata.X = from_array(
+            sparse.csr_matrix((valid_adata.obs.shape[0], valid_adata.var.shape[0]), dtype=numpy.float32)
+        )
+        assert check_duplicate_obs(valid_adata) == [
+            "Found 2 duplicated raw counts in obs adata.X. First 2 duplicate rows found at: ['row 0: index = X', 'row 1: index = Y']."
+        ]

--- a/cellxgene_schema_cli/tests/test_check_duplicates.py
+++ b/cellxgene_schema_cli/tests/test_check_duplicates.py
@@ -1,0 +1,13 @@
+
+import pytest
+
+from fixtures.examples_validate import adata as adata_valid
+from cellxgene_schema.validation_internals.check_duplicates import check_duplicate_obs
+
+@pytest.fixture
+def valid_adata():
+    return adata_valid.copy()
+
+class TestCheckDuplicates:
+    def test__check_duplicate_obs(self, valid_adata):
+        assert check_duplicate_obs(valid_adata) == []

--- a/cellxgene_schema_cli/tests/test_check_duplicates.py
+++ b/cellxgene_schema_cli/tests/test_check_duplicates.py
@@ -1,12 +1,12 @@
-
 import pytest
-
-from fixtures.examples_validate import adata as adata_valid
 from cellxgene_schema.validation_internals.check_duplicates import check_duplicate_obs
+from fixtures.examples_validate import adata_minimal, adata
+
 
 @pytest.fixture
 def valid_adata():
-    return adata_valid.copy()
+    return adata.copy()
+
 
 class TestCheckDuplicates:
     def test__check_duplicate_obs(self, valid_adata):

--- a/cellxgene_schema_cli/tests/test_check_duplicates.py
+++ b/cellxgene_schema_cli/tests/test_check_duplicates.py
@@ -1,6 +1,6 @@
 import pytest
 from cellxgene_schema.validation_internals.check_duplicates import check_duplicate_obs
-from fixtures.examples_validate import adata_minimal, adata
+from fixtures.examples_validate import adata
 
 
 @pytest.fixture

--- a/cellxgene_schema_cli/tests/test_check_duplicates.py
+++ b/cellxgene_schema_cli/tests/test_check_duplicates.py
@@ -20,6 +20,4 @@ class TestCheckDuplicates:
         valid_adata.X = from_array(
             sparse.csr_matrix((valid_adata.obs.shape[0], valid_adata.var.shape[0]), dtype=numpy.float32)
         )
-        assert check_duplicate_obs(valid_adata) == [
-            "Found 2 duplicated raw counts in obs adata.X. First 2 duplicate rows found at: ['row 0: index = X', 'row 1: index = Y']."
-        ]
+        assert check_duplicate_obs(valid_adata) == ["Found 2 duplicated raw counts in obs adata.X."]

--- a/cellxgene_schema_cli/tests/test_map_species.py
+++ b/cellxgene_schema_cli/tests/test_map_species.py
@@ -44,7 +44,11 @@ def zebrafish_adata():
         ],
         columns=["feature_is_filtered"],
     )
-    zebrafish_adata.X = numpy.ones([zebrafish_adata.obs.shape[0], zebrafish_adata.var.shape[0]], dtype=numpy.float32)
+    X = numpy.ones([zebrafish_adata.obs.shape[0], zebrafish_adata.var.shape[0]], dtype=numpy.float32)
+    for i in range(zebrafish_adata.obs.shape[0]):
+        for j in range(zebrafish_adata.var.shape[0]):
+            X[i, j] = i + j
+    zebrafish_adata.X = X
     zebrafish_adata.raw = zebrafish_adata.copy()
     zebrafish_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
     return zebrafish_adata

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -161,6 +161,20 @@ class TestExpressionMatrix:
             f"ERROR: Number of genes in X ({NUMBER_OF_GENES - 1}) is different than raw.X ({NUMBER_OF_GENES})."
             in validator.errors
         )
+    
+    def test_csc_matrix_invalid(self, validator_with_adata):
+        is_valid_before = validator_with_adata.validate_adata()
+        assert is_valid_before
+
+        # Update X to be a CSC matrix
+        X = from_array(scipy.sparse.csc_matrix([[1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6]], dtype=numpy.float32))
+        validator_with_adata.adata.X = X
+        is_valid_after = validator_with_adata.validate_adata()
+        assert not is_valid_after
+
+        assert validator_with_adata.errors == [
+            "ERROR: Invalid sparse encoding for X with encoding csc. Only csr sparse encodings are supported.",
+        ]
 
     def test_sparsity(self, validator_with_adata):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -161,7 +161,7 @@ class TestExpressionMatrix:
             f"ERROR: Number of genes in X ({NUMBER_OF_GENES - 1}) is different than raw.X ({NUMBER_OF_GENES})."
             in validator.errors
         )
-    
+
     def test_csc_matrix_invalid(self, validator_with_adata):
         is_valid_before = validator_with_adata.validate_adata()
         assert is_valid_before


### PR DESCRIPTION
## Reason for Change

https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/1317

## Changes

- after spending ~30 mins writing my own hash algorithm that all seemed to break my local machine, i pivoted and based this PR off of this code snippet lattice provided for evaluating duplicate obs rows: https://github.com/Lattice-Data/lattice-tools/blob/a9f7129f43e5cc1e910e513d0efd3ca1412e59cb/cellxgene_resources/cellxgene_mods.py#L450-L513
- i made some changes to this, notably:
  - switched from `sha1` to `sha224`, which is faster
  - updated it to support reading in a dask array instead of a csr matrix
  - some basic code clean up like changing variable names, using list comprehension, etc

note that i also put all of this logic in a separate file, `check_duplicates.py` instead of throwing everything into `validate.py`, and putting all relevant tests into `test_check_duplicates.py`. personally i would prefer moving some of our validation logic out of `validate.py` and into separate files / modules, so if this structure makes sense, maybe we can do this moving forward and potentially refactor our existing code.

## Testing

i wrote some tests to verify that we're raising a validation error for duplicate rows. a lot of our test data was actually seeded with duplicate rows (ex: matrices with all 0s), so some unrelated tests had to be fixed as well.

to settle on `sha224`, i benchmarked all of the hash algorithms in `hashlib` with this script, and using one very large dataset:
```
import numpy as np
import pandas as pd
import hashlib
import anndata
import time
from scipy import sparse

HASH_FUNCTIONS = {
    "sha1": lambda b: hashlib.sha1(b).hexdigest(),
    "sha224": lambda b: hashlib.sha224(b).hexdigest(),
    "sha256": lambda b: hashlib.sha256(b).hexdigest(),
    "sha384": lambda b: hashlib.sha384(b).hexdigest(),
    "sha512": lambda b: hashlib.sha512(b).hexdigest(),
    "sha3_224": lambda b: hashlib.sha3_224(b).hexdigest(),
    "sha3_256": lambda b: hashlib.sha3_256(b).hexdigest(),
    "sha3_384": lambda b: hashlib.sha3_384(b).hexdigest(),
    "sha3_512": lambda b: hashlib.sha3_512(b).hexdigest(),
    "shake_128": lambda b: hashlib.shake_128(b).hexdigest(16),
    "shake_256": lambda b: hashlib.shake_256(b).hexdigest(16),
    "blake2b": lambda b: hashlib.blake2b(b).hexdigest()
}


def _check_duplicate_obs_sparse(adata, hash_name="blake2b") -> list[str]:
    """
    Checks for duplicate rows in a CSR matrix using a specified hash function.
    """
    start_time = time.time()
    errors = []

    hash_fn = HASH_FUNCTIONS[hash_name]

    if "in_tissue" in adata.obs.columns:
        obs_to_keep = adata.obs[adata.obs["in_tissue"] != 0].index
        adata = adata[obs_to_keep, :]

    matrix = adata.raw.X if adata.raw else adata.X

    if not isinstance(matrix, sparse.csr_matrix):
        errors.append("Matrix not in sparse csr format, please convert before hashing")
        return errors

    if not matrix.has_canonical_format:
        matrix.sort_indices()
        matrix.sum_duplicates()
    
    assert matrix.has_canonical_format, "Matrix still in non-canonical format"

    indptr = matrix.indptr
    data = matrix.data
    indices = matrix.indices

    def row_hash(row_slice):
        return hash_fn(row_slice.tobytes())

    data_hashes = [row_hash(data[indptr[i] : indptr[i + 1]]) for i in range(matrix.shape[0])]
    index_hashes = [row_hash(indices[indptr[i] : indptr[i + 1]]) for i in range(matrix.shape[0])]

    hash_df = adata.obs.copy()
    hash_df["data_hash"] = data_hashes
    hash_df["index_hash"] = index_hashes

    dup_mask = hash_df.duplicated(subset=["data_hash", "index_hash"], keep=False)
    dup_df = hash_df[dup_mask].copy()

    if not dup_df.empty:
        errors.append(f"[{hash_name}] Found {len(dup_df)} duplicated raw counts in obs")

    print(f"[{hash_name}] _check_duplicate_obs_sparse took", round(time.time() - start_time, 2), "seconds")
    return errors

adata = anndata.read_h5ad("big_boi.h5ad")

for hash_name in HASH_FUNCTIONS:
    errs = _check_duplicate_obs_sparse(adata, hash_name=hash_name)
    for err in errs:
        print(err)
```
which showed sha224 to be the fastest:
```
[sha1] _check_duplicate_obs_sparse took 33.67 seconds
[sha224] _check_duplicate_obs_sparse took 28.74 seconds
[sha256] _check_duplicate_obs_sparse took 30.52 seconds
[sha384] _check_duplicate_obs_sparse took 40.58 seconds
[sha512] _check_duplicate_obs_sparse took 42.03 seconds
[sha3_224] _check_duplicate_obs_sparse took 49.4 seconds
[sha3_256] _check_duplicate_obs_sparse took 51.16 seconds
[sha3_384] _check_duplicate_obs_sparse took 63.15 seconds
[sha3_512] _check_duplicate_obs_sparse took 80.38 seconds
[shake_128] _check_duplicate_obs_sparse took 44.04 seconds
[shake_256] _check_duplicate_obs_sparse took 53.53 seconds
[blake2b] _check_duplicate_obs_sparse took 48.85 seconds
```

## Notes for Reviewer