### PR TITLE
fix: package setup with validation_internals

### DIFF
--- a/cellxgene_schema_cli/MANIFEST.in
+++ b/cellxgene_schema_cli/MANIFEST.in
@@ -1,3 +1,5 @@
 include requirements.txt
 include cellxgene_schema/gencode_files/*.gz
 include cellxgene_schema/schema_definitions/*.yaml
+include cellxgene_schema/migrate_files/*.json
+include cellxgene_schema/migrate_files/*.txt

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -13,7 +13,6 @@ import pandas as pd
 from anndata.compat import DaskArray
 from dask.array import map_blocks
 from scipy import sparse
-from validation_internals.check_duplicates import check_duplicate_obs
 
 from . import gencode, schema
 from .gencode import get_gene_checker
@@ -27,6 +26,7 @@ from .utils import (
     is_ontological_descendant_of,
     read_h5ad,
 )
+from .validation_internals.check_duplicates import check_duplicate_obs
 
 logger = logging.getLogger(__name__)
 

--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -3,8 +3,8 @@ import hashlib
 import anndata
 import dask.array as da
 import numpy as np
+from cellxgene_schema.utils import get_matrix_format
 from scipy import sparse
-from utils import get_matrix_format
 
 
 def check_duplicate_obs(adata: anndata.AnnData) -> list[str]:

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 with open("requirements.txt") as fh:
     requirements = fh.read().splitlines()
@@ -14,7 +14,7 @@ setup(
     long_description="Tool for applying and validating cellxgene integration schema to single cell datasets",
     install_requires=requirements,
     python_requires=">=3.10",
-    packages=["cellxgene_schema"],
+    packages=find_packages(exclude=["tests", "scripts"]),
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
 with open("requirements.txt") as fh:
     requirements = fh.read().splitlines()
@@ -14,7 +14,7 @@ setup(
     long_description="Tool for applying and validating cellxgene integration schema to single cell datasets",
     install_requires=requirements,
     python_requires=">=3.10",
-    packages=find_packages(),
+    packages=["cellxgene_schema"],
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 with open("requirements.txt") as fh:
     requirements = fh.read().splitlines()
@@ -14,16 +14,7 @@ setup(
     long_description="Tool for applying and validating cellxgene integration schema to single cell datasets",
     install_requires=requirements,
     python_requires=">=3.10",
-    packages=["cellxgene_schema"],
-    package_dir={"cellxgene_schema": "cellxgene_schema"},
-    package_data={
-        "cellxgene_schema": [
-            "gencode_files/*gz",
-            "migrate_files/*json",
-            "schema_definitions/*yaml",
-            "migrate_files/*.txt",
-        ]
-    },
+    packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
## Reason for Change

discovered that despite the tests passing, we can't actually run the CLI because of how we're doing the package setup

## Changes

- primary change is to update the package setup to just pull in everything from `cellxgene_schema`, rather than needing to further specify all the subdirectories in there. this seems fine to me as i think we can reasonably assume anything within that subdirectory we'd want to include

## Testing

- ran `pip install ~/src/single-cell-curation/cellxgene_schema_cli` and verified i could then run `cellxgene-schema validate input.h5ad`

## Notes for Reviewer