### PR TITLE
fix: clean up intermediate sort files for ATAC

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -479,4 +479,5 @@ def prepare_fragment(
         logger.info(f"Processing chromosome: {chromosome}")
         temp_data = sort_fragment(parquet_file, tempdir, chromosome)
         write_algorithm(temp_data, bgzip_output_file)
+        Path(temp_data).unlink(missing_ok=True)  # clean up temporary file
     logger.info(f"bgzip compression completed successfully for {bgzip_output_file}")


### PR DESCRIPTION
## Reason for Change

- this PR aims to resolve https://czi.atlassian.net/jira/software/c/projects/VC/boards/1534?selectedIssue=VC-2554

## Changes

- delete intermediate files when compressing to bgzip.
 
## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer