### PR TITLE
fix: only check duplicate rows of raw matrix, not normalized matrix

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -11,6 +11,10 @@ def check_duplicate_obs(adata: anndata.AnnData) -> list[str]:
     """
     Checks for duplicate rows in obs by raw count.
 
+    We only want to check duplicate rows for the 'raw' matrix. If adata.raw is
+    not provided, then we assume adata.X is the raw data. If both are provided,
+    then we only want to validate against adata.raw.X
+
     :rtype List of errors that were seen. If no errors, validation is good.
     """
 
@@ -22,8 +26,8 @@ def check_duplicate_obs(adata: anndata.AnnData) -> list[str]:
 
     to_validate = [(adata.X, "adata.X")]
 
-    if adata.raw:
-        to_validate.append((adata.raw.X, "adata.raw.X"))
+    if adata.raw is not None:
+        to_validate = [(adata.raw.X, "adata.raw.X")]
 
     for matrix, matrix_name in to_validate:
         matrix_format = determine_matrix_format(matrix)

--- a/cellxgene_schema_cli/tests/test_check_duplicates.py
+++ b/cellxgene_schema_cli/tests/test_check_duplicates.py
@@ -1,3 +1,4 @@
+import anndata
 import numpy
 import pytest
 from cellxgene_schema.validation_internals.check_duplicates import check_duplicate_obs
@@ -15,9 +16,26 @@ class TestCheckDuplicates:
     def test__check_duplicate_obs_ok(self, valid_adata):
         assert check_duplicate_obs(valid_adata) == []
 
-    def test__obs_has_duplicate_rows(self, valid_adata):
+    def test__obs_has_duplicate_rows_X(self, valid_adata):
         # zeros out the X matrix, resulting in duplicate rows of all 0's
+        # this is valid because X is not the raw matrix
         valid_adata.X = from_array(
             sparse.csr_matrix((valid_adata.obs.shape[0], valid_adata.var.shape[0]), dtype=numpy.float32)
         )
+        assert check_duplicate_obs(valid_adata) == []
+
+    def test__obs_has_duplicate_rows_X_raw(self, valid_adata):
+        # zeros out raw.X
+        raw = anndata.AnnData(X=valid_adata.raw.X, obs=valid_adata.obs, var=valid_adata.raw.var)
+        raw.X = from_array(sparse.csr_matrix((valid_adata.obs.shape[0], valid_adata.var.shape[0]), dtype=numpy.float32))
+        valid_adata.raw = raw
+        assert check_duplicate_obs(valid_adata) == ["Found 2 duplicated raw counts in obs adata.raw.X."]
+
+    def test__obs_has_duplicate_rows_X_no_raw(self, valid_adata):
+        # zeros out the X matrix, resulting in duplicate rows of all 0's
+        # this is not valid because X is by default the raw matrix
+        valid_adata.X = from_array(
+            sparse.csr_matrix((valid_adata.obs.shape[0], valid_adata.var.shape[0]), dtype=numpy.float32)
+        )
+        valid_adata.raw = None
         assert check_duplicate_obs(valid_adata) == ["Found 2 duplicated raw counts in obs adata.X."]


### PR DESCRIPTION
## Reason for Change

it looks like we actually only want to check the raw matrix for the duplicate rows. so if `raw.X` is provided, then that is the raw matrix. otherwise, we assume `X` is the raw matrix.

context: https://czi-sci.slack.com/archives/C08MF1AJ6F5/p1746570075756179?thread_ts=1746028640.679369&cid=C08MF1AJ6F5

## Changes

- updated the logic / comments accordingly

## Testing

i added more test coverage to make sure we only raise the error for the raw matrix

## Notes for Reviewer