### PR TITLE
fix: catch indexerror

### DIFF
--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1731,6 +1731,25 @@ class TestVar:
             "ERROR: Gene 'ERCC-00002' at index 0 has all-zero values in adata.X. Either feature_is_filtered should be set to True or adata.raw.X should be set to all-zero values."
         ]
 
+    def test_feature_is_filtered_var_mishapen(self, validator_with_adata):
+        validator = validator_with_adata
+        gene_index = 0
+        gene_name = validator_with_adata.adata.raw.var_names[gene_index]
+        var_to_keep = [v for v in validator_with_adata.adata.raw.var_names if v != gene_name]
+        raw_adata = anndata.AnnData(
+            X=validator_with_adata.adata.raw.X,
+            obs=validator_with_adata.adata.obs,
+            var=validator_with_adata.adata.raw.var,
+        )
+        new_raw_adata = raw_adata[:, var_to_keep]
+        validator_with_adata.adata.raw = new_raw_adata
+        validator.validate_adata()
+        assert not validator.is_valid
+        assert (
+            "ERROR: Could not complete full validation of feature_is_filtered because of size differences between var and raw.var."
+            in validator.errors
+        )
+
     def test_columns_not_in_raw_var(self, validator_with_adata):
         """
         Curators MUST annotate the following column only in the var dataframe.

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1603,8 +1603,8 @@ class TestObs:
         validator = validator_with_adata
         validator.adata.obs = pd.concat([validator.adata.obs, validator.adata.obs["suspension_type"]], axis=1)
 
-        with pytest.raises(ValueError):
-            validator.validate_adata()
+        validator.validate_adata()
+        assert len(validator.errors) > 0
 
     def test_nan_values_must_be_rejected(self, validator_with_adata):
         """
@@ -1859,8 +1859,8 @@ class TestVar:
         validator = validator_with_adata
         validator.adata.var = pd.concat([validator.adata.var, validator.adata.var["feature_is_filtered"]], axis=1)
 
-        with pytest.raises(ValueError):
-            validator.validate_adata()
+        validator.validate_adata()
+        assert len(validator.errors) > 0
 
     def test_raw_var_column_name_uniqueness(self, validator_with_adata):
         validator = validator_with_adata
@@ -1869,8 +1869,8 @@ class TestVar:
         validator.adata.raw = validator.adata
         validator.adata.var = original_var  # Ensure only the raw.var has duplicate columns
 
-        with pytest.raises(ValueError):
-            validator.validate_adata()
+        validator.validate_adata()
+        assert len(validator.errors) > 0
 
 
 class TestUns:


### PR DESCRIPTION
## Reason for Change

the validation for `feature_is_filtered` fails with an `IndexError` if you pass in invalid anndata: https://czi-sci.slack.com/archives/C08MF1AJ6F5/p1747163016677619?thread_ts=1746730671.752919&cid=C08MF1AJ6F5

## Changes

- updated the validator to specifically catch the `IndexError` in this case
- i wrapped the full validation in a try/except loop that way if we run into a similar issue in the future, we don't get an uncaught exception. the validation script will just print out the relevant error

## Testing

- added test coverage that we generate the error "ERROR: Could not complete full validation of feature_is_filtered because of size differences between var and raw.var."

## Notes for Reviewer