### PR TITLE
feat: update migration script for moving organism from obs to uns

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -22,7 +22,7 @@ with open(os.path.join(BASE_DIR, "migrate_files/automigrate_terms.json"), "r") a
     DEV_STAGE_AUTO_MIGRATE_MAP = json.load(file)
 
 
-ONTOLOGY_TERM_MAPS = {
+ONTOLOGY_OBS_TERM_MAPS = {
     "assay": {
         "EFO:0010961" : "EFO:0022857", # AUTOMATED VISIUM TERM UPDATE
     },
@@ -40,6 +40,11 @@ ONTOLOGY_TERM_MAPS = {
     },
     "tissue": {
         "CL:0010003": "CL:0000322", # AUTOMATED
+    },
+}
+
+ONTOLOGY_TERM_UNS_MAPS = {
+    "organism": {
     },
 }
 
@@ -74,8 +79,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     dataset = utils.read_h5ad(input_file)
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_OBS_TERM_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_UNS_MAPS.items():
+        dataset = utils.replace_ontology_term_uns(dataset, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES
     # Use the template below to define dataset and collection specific ontology changes. Will only apply to dataset

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -72,12 +72,12 @@ def replace_ontology_term_uns(adata: ad.AnnData, ontology_name, update_map) -> a
 def move_ontology_term_from_obs_to_uns(adata: ad.AnnData, key_name, update_map) -> ad.AnnData:
     if key_name not in adata.obs:
         raise KeyError(f"Column '{key_name}' not found in adata.obs, cannot migrate from obs to uns")
-    
+
     values = adata.obs[key_name].unique()
-    
+
     if len(values) != 1:
         raise ValueError(f"Cannot migrate from obs to uns because '{key_name}' has multiple values: {values}")
-    
+
     adata.uns[key_name] = values[0]
 
     # Map old terms to new terms, if needed

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -56,6 +56,14 @@ def replace_ontology_term(dataframe, ontology_name, update_map):
             dataframe[column_name] = dataframe[column_name].cat.remove_categories(old_term)
 
 
+def replace_ontology_term_uns(adata: ad.AnnData, ontology_name, update_map) -> ad.AnnData:
+    key_name = f"{ontology_name}_ontology_term_id"
+    for old_term, new_term in update_map.items():
+        if adata.uns[key_name] == old_term:
+            adata.uns[key_name] = new_term
+    return adata
+
+
 def map_ontology_term(dataframe, ontology_name, map_from_column, update_map):
     column_name = f"{ontology_name}_ontology_term_id"
     if dataframe[column_name].dtype != "category":

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -59,31 +59,23 @@ def replace_ontology_term(dataframe, ontology_name, update_map):
 def replace_ontology_term_uns(adata: ad.AnnData, ontology_name, update_map) -> ad.AnnData:
     key_name = f"{ontology_name}_ontology_term_id"
 
-    # TODO: We should remove this after the schema 6.0 migration
-    if ontology_name == "organism" and key_name not in adata.uns:
-        return move_ontology_term_from_obs_to_uns(adata, key_name, update_map)
-    else:
-        for old_term, new_term in update_map.items():
-            if adata.uns[key_name] == old_term:
-                adata.uns[key_name] = new_term
-    return adata
-
-
-def move_ontology_term_from_obs_to_uns(adata: ad.AnnData, key_name, update_map) -> ad.AnnData:
-    if key_name not in adata.obs:
-        raise KeyError(f"Column '{key_name}' not found in adata.obs, cannot migrate from obs to uns")
-
-    values = adata.obs[key_name].unique()
-
-    if len(values) != 1:
-        raise ValueError(f"Cannot migrate from obs to uns because '{key_name}' has multiple values: {values}")
-
-    adata.uns[key_name] = values[0]
-
-    # Map old terms to new terms, if needed
     for old_term, new_term in update_map.items():
         if adata.uns[key_name] == old_term:
             adata.uns[key_name] = new_term
+    return adata
+
+
+def move_column_from_obs_to_uns(adata: ad.AnnData, column_name: str) -> ad.AnnData:
+    if column_name not in adata.obs:
+        raise KeyError(f"Column '{column_name}' not found in adata.obs, cannot migrate from obs to uns")
+
+    values = adata.obs[column_name].unique()
+
+    if len(values) != 1:
+        raise ValueError(f"Cannot migrate from obs to uns because '{column_name}' has multiple values: {values}")
+
+    adata.uns[column_name] = values[0]
+    del adata.obs[column_name]
 
     return adata
 

--- a/cellxgene_schema_cli/tests/test_migrate.py
+++ b/cellxgene_schema_cli/tests/test_migrate.py
@@ -29,7 +29,7 @@ class TestMigrate:
         }
         test_ONTOLOGY_UNS_TERM_MAPS = {
             "organism": {
-                "Homo sapiens": "Homo sapiens migrated",
+                "NCBITaxon:9606": "NCBITaxon:9606 migrated",
             }
         }
         with TemporaryDirectory() as tmp, patch("cellxgene_schema.migrate.DEPRECATED_FEATURE_IDS", ["DUMMY"]), patch(
@@ -57,6 +57,7 @@ class TestMigrate:
             assert any(adata_raw_with_labels_unmigrated.var.index.isin(["ENSSASG00005000004"]))
             assert not any(adata_raw_with_labels_unmigrated.var.index.isin(["ENSSASG00005000004_NEW"]))
             assert adata_raw_with_labels_unmigrated.X.shape == (2, 2)
+            assert "organism_ontology_term_id" not in adata_raw_with_labels_unmigrated.uns
 
             migrate(
                 input_file=test_h5ad,
@@ -80,4 +81,4 @@ class TestMigrate:
             assert raw_adata.X.shape == (2, 1)
 
             # Verify organism ontology term was mapped
-            assert adata.uns["organism_ontology_term_id"] == "Homo sapiens migrated"
+            assert adata.uns["organism_ontology_term_id"] == "NCBITaxon:9606 migrated"

--- a/cellxgene_schema_cli/tests/test_migrate.py
+++ b/cellxgene_schema_cli/tests/test_migrate.py
@@ -8,7 +8,7 @@ from fixtures.examples_validate import adata_with_labels_unmigrated
 
 class TestMigrate:
     def test_migrate(self):
-        test_ONTOLOGY_TERM_MAPS = {
+        test_ONTOLOGY_OBS_TERM_MAPS = {
             "assay": {
                 "assay:1": "assay:2",
             },
@@ -27,9 +27,16 @@ class TestMigrate:
             "sex": {"sex:1": "sex:2"},
             "tissue": {"tissue:1": "tissue:2"},
         }
+        test_ONTOLOGY_UNS_TERM_MAPS = {
+            "organism": {
+                "Homo sapiens": "Homo sapiens migrated",
+            }
+        }
         with TemporaryDirectory() as tmp, patch("cellxgene_schema.migrate.DEPRECATED_FEATURE_IDS", ["DUMMY"]), patch(
-            "cellxgene_schema.migrate.ONTOLOGY_TERM_MAPS", test_ONTOLOGY_TERM_MAPS
-        ), patch("cellxgene_schema.migrate.GENCODE_MAPPER", {"ENSSASG00005000004": "ENSSASG00005000004_NEW"}):
+            "cellxgene_schema.migrate.ONTOLOGY_OBS_TERM_MAPS", test_ONTOLOGY_OBS_TERM_MAPS
+        ), patch("cellxgene_schema.migrate.GENCODE_MAPPER", {"ENSSASG00005000004": "ENSSASG00005000004_NEW"}), patch(
+            "cellxgene_schema.migrate.ONTOLOGY_TERM_UNS_MAPS", test_ONTOLOGY_UNS_TERM_MAPS
+        ):
             result_h5ad = tmp + "result.h5ad"
             test_h5ad = tmp + "test.h5ad"
             adata_with_labels_unmigrated.copy().write_h5ad(test_h5ad, compression="gzip")
@@ -71,3 +78,6 @@ class TestMigrate:
             assert not any(raw_adata.var.index.isin(["ENSSASG00005000004"]))
             assert any(raw_adata.var.index.isin(["ENSSASG00005000004_NEW"]))
             assert raw_adata.X.shape == (2, 1)
+
+            # Verify organism ontology term was mapped
+            assert adata.uns["organism_ontology_term_id"] == "Homo sapiens migrated"

--- a/cellxgene_schema_cli/tests/test_utils.py
+++ b/cellxgene_schema_cli/tests/test_utils.py
@@ -4,6 +4,7 @@ from anndata import AnnData
 from cellxgene_schema.utils import (
     get_hash_digest_column,
     map_ontology_term,
+    move_column_from_obs_to_uns,
     read_h5ad,
     remap_deprecated_features,
     remove_deprecated_features,
@@ -167,7 +168,7 @@ def test_replace_ontology_term__no_replacement(adata_with_raw, deprecated_term_m
     assert all(a == b for a, b in zip(actual, expected))
 
 
-def test_map_ontology_term__(adata_without_raw):
+def test_map_ontology_term(adata_without_raw):
     update_map = {"donor_1": "CL:0000001", "donor_2": "CL:0000002"}
     map_ontology_term(adata_without_raw.obs, "cell_type", "donor_id", update_map)
     expected = ["CL:0000001", "CL:0000002"]
@@ -177,6 +178,16 @@ def test_map_ontology_term__(adata_without_raw):
     assert all(a == "CL:0000001" for a in donor_1_rows["cell_type_ontology_term_id"])
     donor_2_rows = adata_without_raw.obs.loc[adata_without_raw.obs["donor_id"] == "donor_2"]
     assert all(a == "CL:0000002" for a in donor_2_rows["cell_type_ontology_term_id"])
+
+
+def test_move_column_from_obs_to_uns(adata_with_raw):
+    assert "assay_ontology_term_id" in adata_with_raw.obs.columns
+    assert "assay_ontology_term_id" not in adata_with_raw.uns
+
+    move_column_from_obs_to_uns(adata_with_raw, "assay_ontology_term_id")
+
+    assert "assay_ontology_term_id" not in adata_with_raw.obs.columns
+    assert adata_with_raw.uns["assay_ontology_term_id"] == "EFO:0009899"
 
 
 class TestGetHashDigestColumn:

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -55,7 +55,7 @@ ONTOLOGY_TERM_UNS_MAPS = {
         {% for old, new in ontology_term_map.organism.items() %}
         "{{ old }}": "{{ new }}", # AUTOMATED
         {% endfor %}
-    }
+    },
 }
 
 DEPRECATED_FEATURE_IDS = [

--- a/scripts/migration_assistant/migration_template.jinja
+++ b/scripts/migration_assistant/migration_template.jinja
@@ -12,7 +12,7 @@ from . import utils
 
 # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
 # add them here.
-ONTOLOGY_TERM_MAPS = {
+ONTOLOGY_TERM_OBS_MAPS = {
     "assay": {
         {% for old, new in ontology_term_map.assay.items() %}
         "{{ old }}": "{{ new }}", # AUTOMATED
@@ -50,6 +50,14 @@ ONTOLOGY_TERM_MAPS = {
     },
 }
 
+ONTOLOGY_TERM_UNS_MAPS = {
+    "organism": {
+        {% for old, new in ontology_term_map.organism.items() %}
+        "{{ old }}": "{{ new }}", # AUTOMATED
+        {% endfor %}
+    }
+}
+
 DEPRECATED_FEATURE_IDS = [
     {% for feature in deprecated_feature_ids %}
     "{{ feature }}",
@@ -67,8 +75,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     dataset = utils.read_h5ad(input_file)
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_OBS_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_UNS_MAPS.items():
+        dataset = utils.replace_ontology_term_uns(dataset, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES
     # Use the template below to define dataset and collection specific ontology changes. Will only apply to dataset

--- a/scripts/migration_assistant/tests/test_convert_template.py
+++ b/scripts/migration_assistant/tests/test_convert_template.py
@@ -24,6 +24,7 @@ def test_generate_script__without_gencode_changes(template, tmpdir):  # type: ig
         "self_reported_ethnicity": {},
         "sex": {},
         "tissue": {},
+        "organism": {},
     }
     gencode_term_map = []  # type: ignore
     mock_target_file = tmpdir + "/migrate.py"
@@ -47,7 +48,7 @@ from . import utils
 
 # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
 # add them here.
-ONTOLOGY_TERM_MAPS = {
+ONTOLOGY_TERM_OBS_MAPS = {
     "assay": {
     },
     "cell_type": {
@@ -61,6 +62,11 @@ ONTOLOGY_TERM_MAPS = {
     "sex": {
     },
     "tissue": {
+    },
+}
+
+ONTOLOGY_TERM_UNS_MAPS = {
+    "organism": {
     },
 }
 
@@ -78,8 +84,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     dataset = utils.read_h5ad(input_file)
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_OBS_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_UNS_MAPS.items():
+        dataset = utils.replace_ontology_term_uns(dataset, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES
     # Use the template below to define dataset and collection specific ontology changes. Will only apply to dataset
@@ -123,6 +131,7 @@ def test_generate_script__with_automated_replaced_by_map(template, tmpdir):  # t
         "self_reported_ethnicity": {},
         "sex": {},
         "tissue": {},
+        "organism": {"organism:1": "organism:2"},
     }
     gencode_term_map = []  # type: ignore
     mock_target_file = tmpdir + "/migrate.py"
@@ -146,7 +155,7 @@ from . import utils
 
 # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
 # add them here.
-ONTOLOGY_TERM_MAPS = {
+ONTOLOGY_TERM_OBS_MAPS = {
     "assay": {
         "EFO:0000002": "EFO:0000001", # AUTOMATED
     },
@@ -166,6 +175,12 @@ ONTOLOGY_TERM_MAPS = {
     },
 }
 
+ONTOLOGY_TERM_UNS_MAPS = {
+    "organism": {
+        "organism:1": "organism:2", # AUTOMATED
+    },
+}
+
 DEPRECATED_FEATURE_IDS = [
 ]
 
@@ -180,8 +195,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     dataset = utils.read_h5ad(input_file)
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_OBS_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_UNS_MAPS.items():
+        dataset = utils.replace_ontology_term_uns(dataset, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES
     # Use the template below to define dataset and collection specific ontology changes. Will only apply to dataset
@@ -226,6 +243,7 @@ def test_generate_script__with_gencode_changes(template, tmpdir):  # type: ignor
         "self_reported_ethnicity": {},
         "sex": {},
         "tissue": {},
+        "organism": {},
     }
     mock_target_file = tmpdir + "/migrate.py"
     with mock.patch("scripts.migration_assistant.generate_script.target_file", mock_target_file):
@@ -255,7 +273,7 @@ from . import utils
 
 # If Curators have non-deprecated term changes to apply to all datasets in the corpus where applicable,
 # add them here.
-ONTOLOGY_TERM_MAPS = {
+ONTOLOGY_TERM_OBS_MAPS = {
     "assay": {
     },
     "cell_type": {
@@ -269,6 +287,11 @@ ONTOLOGY_TERM_MAPS = {
     "sex": {
     },
     "tissue": {
+    },
+}
+
+ONTOLOGY_TERM_UNS_MAPS = {
+    "organism": {
     },
 }
 
@@ -288,8 +311,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     dataset = utils.read_h5ad(input_file)
 
     # AUTOMATED, DO NOT CHANGE
-    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_MAPS.items():
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_OBS_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)
+    for ontology_name, deprecated_term_map in ONTOLOGY_TERM_UNS_MAPS.items():
+        dataset = utils.replace_ontology_term_uns(dataset, ontology_name, deprecated_term_map)
 
     # CURATOR-DEFINED, DATASET-SPECIFIC UPDATES
     # Use the template below to define dataset and collection specific ontology changes. Will only apply to dataset


### PR DESCRIPTION
## Reason for Change

- related to the work on moving organism from obs to uns: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-curation/1311

## Changes

- updates the migration script template to migrate organism terms through `uns`, using a new helper function `replace_ontology_term_uns`. for the schema 6.0 migration, i wrote `move_ontology_term_from_obs_to_uns` to migrate terms from `obs` to `uns`, in addition to performing the mapping for deprecated terms

## Testing

- updated tests in `test_migrate` and `test_convert_template`

## Notes for Reviewer