### PR TITLE
fix: deprecate organism column in addition to organism_ontology_term_id

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -146,6 +146,7 @@ components:
     deprecated_columns:
       - ethnicity
       - ethnicity_ontology_term_id
+      - organism
       - organism_ontology_term_id
     reserved_columns:
       - observation_joinid

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -24,7 +24,6 @@ components:
       - schema_version
       - schema_reference
       - citation
-      - organism
     deprecated_columns:
       - X_normalization
       - default_field

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -24,6 +24,7 @@ components:
       - schema_version
       - schema_reference
       - citation
+      - organism
     deprecated_columns:
       - X_normalization
       - default_field

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -480,6 +480,7 @@ class Validator:
                 if not is_descendant and organism_ontology_id not in gencode.EXEMPT_ORGANISMS:
                     invalid_gene_organisms.append(organism)
 
+        invalid_gene_organisms = list(set(invalid_gene_organisms))
         if len(invalid_gene_organisms) > 0:
             self.errors.append(
                 f"uns['organism_ontology_term_id'] is '{dataset_organism}' but feature_ids are from {invalid_gene_organisms}."

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -480,7 +480,6 @@ class Validator:
                 if not is_descendant and organism_ontology_id not in gencode.EXEMPT_ORGANISMS:
                     invalid_gene_organisms.append(organism)
 
-        invalid_gene_organisms = list(set(invalid_gene_organisms))
         if len(invalid_gene_organisms) > 0:
             self.errors.append(
                 f"uns['organism_ontology_term_id'] is '{dataset_organism}' but feature_ids are from {invalid_gene_organisms}."

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -554,15 +554,22 @@ class TestObs:
         assert len(validator.errors) > 0
         assert validator.errors[0] == "ERROR: 'organism_ontology_term_id' in 'uns' is not present."
 
-    def test_obs_presence_organism(self, validator_with_adata):
+    @pytest.mark.parametrize(
+        "deprecated_column",
+        [
+            "organism_ontology_term_id",
+            "organism",
+        ],
+    )
+    def test_obs_presence_organism(self, validator_with_adata, deprecated_column):
         """
         organism_ontology_term_id cannot be in obs since it's a deprecated column
         """
         validator = validator_with_adata
-        validator.adata.obs["organism_ontology_term_id"] = "NCBITaxon:9606"
+        validator.adata.obs[deprecated_column] = "NCBITaxon:9606"
         validator.validate_adata()
         assert (
-            "ERROR: The field 'organism_ontology_term_id' is present in 'obs', but it is deprecated."
+            f"ERROR: The field '{deprecated_column}' is present in 'obs', but it is deprecated."
             in validator.errors
         )
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -568,10 +568,7 @@ class TestObs:
         validator = validator_with_adata
         validator.adata.obs[deprecated_column] = "NCBITaxon:9606"
         validator.validate_adata()
-        assert (
-            f"ERROR: The field '{deprecated_column}' is present in 'obs', but it is deprecated."
-            in validator.errors
-        )
+        assert f"ERROR: The field '{deprecated_column}' is present in 'obs', but it is deprecated." in validator.errors
 
     @pytest.mark.parametrize(
         "organism_ontology_term_id",


### PR DESCRIPTION
## Reason for Change

https://czi-sci.slack.com/archives/C08MF1AJ6F5/p1748623273521219?thread_ts=1747337258.902249&cid=C08MF1AJ6F5

## Changes

- i had only deprecated `organism_ontology_term_id` in obs, we should also deprecate `organism`

## Testing

updated the existing test to check for both deprecated columns

## Notes for Reviewer