### PR TITLE
fix: forbid organism from being provided in uns

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1546,7 +1546,9 @@ class Validator:
         """
 
         for label_def in add_labels_def:
-            reserved_name = label_def["to_column"]
+            reserved_name = label_def.get("to_column")
+            if reserved_name is None:
+                reserved_name = label_def.get("to_key")
 
             if reserved_name in getattr_anndata(self.adata, component):
                 self.errors.append(
@@ -1645,6 +1647,12 @@ class Validator:
                 index_def = component_def["index"]
                 if "add_labels" in index_def:
                     self._check_single_column_availability(component, index_def["add_labels"])
+
+            # Do it for key that map to columns
+            if "keys" in component_def:
+                for key_def in component_def["keys"].values():
+                    if "add_labels" in key_def:
+                        self._check_single_column_availability(component, key_def["add_labels"])
 
     def _check_spatial(self):
         """

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -544,7 +544,7 @@ class TestObs:
         validator.validate_adata()
         assert f"ERROR: Dataframe 'obs' is missing " f"column '{column}'." in validator.errors
 
-    def test_key_presence_organism(self, validator_with_adata):
+    def test_key_presence_organism_ontology_term_id(self, validator_with_adata):
         """
         organism_ontology_term_id must be defined in uns
         """
@@ -553,6 +553,19 @@ class TestObs:
         validator.validate_adata()
         assert len(validator.errors) > 0
         assert validator.errors[0] == "ERROR: 'organism_ontology_term_id' in 'uns' is not present."
+
+    def test_key_presence_organism(self, validator_with_adata):
+        """
+        organism_ontology_term_id must be defined in uns
+        """
+        validator = validator_with_adata
+        validator.adata.uns["organism"] = "Homo sapiens"
+        validator.validate_adata()
+        assert len(validator.errors) > 0
+        assert (
+            validator.errors[0]
+            == "ERROR: Add labels error: Column 'organism' is a reserved column name of 'uns'. Remove it from h5ad and try again."
+        )
 
     @pytest.mark.parametrize(
         "deprecated_column",


### PR DESCRIPTION
## Reason for Change

output from this slack thread: https://czi-sci.slack.com/archives/C08MF1AJ6F5/p1748624494894579

## Changes

- adds validation checking to forbid labeled columns specified in `uns["keys"]` and fail validation as a result

## Testing

- added a unit test to cover this

## Notes for Reviewer