### PR TITLE
feat: update migrate script

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -91,10 +91,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
             {
                 "Healthy": "PATO:0000461",
                 "HIV": "MONDO:0005109",
-                "VL_HIV": "MONDO:0005109 || MONDO:0011989",
+                "VL_HIV": "MONDO:0005109 || MONDO:0005445",
                 "aL_HIV": "MONDO:0005109 || MONDO:0011989",
-                "cVL_HIV": "MONDO:0005109 || MONDO:0011989",
-                "pVL_HIV": "MONDO:0005109 || MONDO:0011989",
+                "cVL_HIV": "MONDO:0005109 || MONDO:0005445",
+                "pVL_HIV": "MONDO:0005109 || MONDO:0005445",
             }
         )
 

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -80,17 +80,6 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
 
-    if collection_id == "398e34a9-8736-4b27-a9a7-31a47a67f446":
-        utils.replace_ontology_term(dataset.obs, "cell_type", {"CL:0000451": "CL:4047054"})
-    
-    if collection_id == "126afc71-47fb-4e9d-8aaf-9d9f61e0ac77":
-        if dataset.obs["disease_group"] != "Healthy" and dataset.obs["disease_group"] != "HIV":
-            dataset.obs["disease_ontology_term_id"] = "MONDO:0005109 || MONDO:0011989"
-    
-    if collection_id == "eeba7193-4d32-46bd-a21b-089936d60601":
-        if dataset.obs["sample_id"].str.startswith("mraf"):
-            dataset.obs["disease_ontology_term_id"] = "MONDO:0004981 || MONDO:1030008"
-
     if GENCODE_MAPPER:
         dataset = utils.remap_deprecated_features(adata=dataset, remapped_features=GENCODE_MAPPER)
 

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -80,6 +80,40 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
 
+    if dataset.uns["title"] == "Time-resolved single-cell analysis of Brca1 associated mammary tumourigenesis reveals aberrant differentiation of luminal progenitors":
+        utils.replace_ontology_term(dataset.obs, "cell_type", {"CL:0000451": "CL:4047054"})
+
+    if collection_id == "126afc71-47fb-4e9d-8aaf-9d9f61e0ac77":
+        utils.map_ontology_term(
+            dataset.obs,
+            "disease",
+            "disease_group",
+            {
+                "Healthy": "PATO:0000461",
+                "HIV": "MONDO:0005109",
+                "VL_HIV": "MONDO:0005109 || MONDO:0011989",
+                "aL_HIV": "MONDO:0005109 || MONDO:0011989",
+                "cVL_HIV": "MONDO:0005109 || MONDO:0011989",
+                "pVL_HIV": "MONDO:0005109 || MONDO:0011989",
+            }
+        )
+
+    if collection_id == "eeba7193-4d32-46bd-a21b-089936d60601":
+        utils.map_ontology_term(
+            dataset.obs,
+            "disease",
+            "sample_id",
+            {
+                "mraf1": "MONDO:0004981 || MONDO:1030008",
+                "mraf2": "MONDO:0004981 || MONDO:1030008",
+                "mraf3": "MONDO:0004981 || MONDO:1030008",
+                "mraf4": "MONDO:0004981 || MONDO:1030008",
+                "mraf7": "MONDO:0004981 || MONDO:1030008",
+                "mraf13": "MONDO:0004981 || MONDO:1030008",
+                "mraf14": "MONDO:0004981 || MONDO:1030008",
+            }
+        )
+
     if GENCODE_MAPPER:
         dataset = utils.remap_deprecated_features(adata=dataset, remapped_features=GENCODE_MAPPER)
 

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -80,7 +80,10 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
 
-    if dataset.uns["title"] == "Time-resolved single-cell analysis of Brca1 associated mammary tumourigenesis reveals aberrant differentiation of luminal progenitors":
+    if (
+        dataset.uns["title"]
+        == "Time-resolved single-cell analysis of Brca1 associated mammary tumourigenesis reveals aberrant differentiation of luminal progenitors"
+    ):
         utils.replace_ontology_term(dataset.obs, "cell_type", {"CL:0000451": "CL:4047054"})
 
     if collection_id == "126afc71-47fb-4e9d-8aaf-9d9f61e0ac77":
@@ -95,7 +98,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
                 "aL_HIV": "MONDO:0005109 || MONDO:0011989",
                 "cVL_HIV": "MONDO:0005109 || MONDO:0005445",
                 "pVL_HIV": "MONDO:0005109 || MONDO:0005445",
-            }
+            },
         )
 
     if collection_id == "eeba7193-4d32-46bd-a21b-089936d60601":
@@ -111,7 +114,7 @@ def migrate(input_file, output_file, collection_id, dataset_id):
                 "mraf7": "MONDO:0004981 || MONDO:1030008",
                 "mraf13": "MONDO:0004981 || MONDO:1030008",
                 "mraf14": "MONDO:0004981 || MONDO:1030008",
-            }
+            },
         )
 
     if GENCODE_MAPPER:

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -80,6 +80,17 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     #   <custom transformation logic beyond scope of replace_ontology_term>
     # ...
 
+    if collection_id == "398e34a9-8736-4b27-a9a7-31a47a67f446":
+        utils.replace_ontology_term(dataset.obs, "cell_type", {"CL:0000451": "CL:4047054"})
+    
+    if collection_id == "126afc71-47fb-4e9d-8aaf-9d9f61e0ac77":
+        if dataset.obs["disease_group"] != "Healthy" and dataset.obs["disease_group"] != "HIV":
+            dataset.obs["disease_ontology_term_id"] = "MONDO:0005109 || MONDO:0011989"
+    
+    if collection_id == "eeba7193-4d32-46bd-a21b-089936d60601":
+        if dataset.obs["sample_id"].str.startswith("mraf"):
+            dataset.obs["disease_ontology_term_id"] = "MONDO:0004981 || MONDO:1030008"
+
     if GENCODE_MAPPER:
         dataset = utils.remap_deprecated_features(adata=dataset, remapped_features=GENCODE_MAPPER)
 

--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -49,6 +49,14 @@ def migrate(input_file, output_file, collection_id, dataset_id):
     # Migrate organism_ontology_term_id for 6.0.0
     dataset = utils.move_column_from_obs_to_uns(adata=dataset, column_name="organism_ontology_term_id")
 
+    # Migrate delimter from `,` to ` || ` for self_reported_ethnicity_ontology_term_id
+    utils.replace_delimiter(
+        dataframe=dataset.obs,
+        old_delimiter=",",
+        new_delimiter=" || ",
+        column_name="self_reported_ethnicity_ontology_term_id",
+    )
+
     # AUTOMATED, DO NOT CHANGE
     for ontology_name, deprecated_term_map in ONTOLOGY_TERM_OBS_MAPS.items():
         utils.replace_ontology_term(dataset.obs, ontology_name, deprecated_term_map)

--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -65,9 +65,25 @@ def replace_ontology_term_uns(adata: ad.AnnData, ontology_name, update_map) -> a
     return adata
 
 
+def replace_delimiter(dataframe, old_delimiter: str, new_delimiter: str, column_name: str):
+    """
+    Replace the delimiter in a column of a dataframe.
+
+    :param dataframe: The dataframe containing the column to modify.
+    :param old_delimiter: The delimiter to replace.
+    :param new_delimiter: The new delimiter to use.
+    :param column_name: The name of the column to modify.
+    """
+    if column_name not in dataframe.columns:
+        raise KeyError(f"Column '{column_name}' not found")
+
+    dataframe[column_name] = dataframe[column_name].str.replace(old_delimiter, new_delimiter, regex=False)
+
+
 def move_column_from_obs_to_uns(adata: ad.AnnData, column_name: str) -> ad.AnnData:
     if column_name not in adata.obs:
-        raise KeyError(f"Column '{column_name}' not found in adata.obs, cannot migrate from obs to uns")
+        logger.warning(f"Column '{column_name}' not found in adata.obs, cannot migrate from obs to uns")
+        return adata
 
     values = adata.obs[column_name].unique()
 

--- a/cellxgene_schema_cli/tests/test_migrate.py
+++ b/cellxgene_schema_cli/tests/test_migrate.py
@@ -33,7 +33,7 @@ class TestMigrate:
             }
         }
         with TemporaryDirectory() as tmp, patch("cellxgene_schema.migrate.DEPRECATED_FEATURE_IDS", ["DUMMY"]), patch(
-            "cellxgene_schema.migrate.ONTOLOGY_OBS_TERM_MAPS", test_ONTOLOGY_OBS_TERM_MAPS
+            "cellxgene_schema.migrate.ONTOLOGY_TERM_OBS_MAPS", test_ONTOLOGY_OBS_TERM_MAPS
         ), patch("cellxgene_schema.migrate.GENCODE_MAPPER", {"ENSSASG00005000004": "ENSSASG00005000004_NEW"}), patch(
             "cellxgene_schema.migrate.ONTOLOGY_TERM_UNS_MAPS", test_ONTOLOGY_UNS_TERM_MAPS
         ):

--- a/cellxgene_schema_cli/tests/test_schema.py
+++ b/cellxgene_schema_cli/tests/test_schema.py
@@ -4,4 +4,4 @@ from cellxgene_schema import schema
 
 def test_get_current_schema_version():
     assert semver.Version.is_valid(schema.get_current_schema_version())
-    assert schema.get_current_schema_version() == "5.3.0"
+    assert schema.get_current_schema_version() == "6.0.0"

--- a/cellxgene_schema_cli/tests/test_utils.py
+++ b/cellxgene_schema_cli/tests/test_utils.py
@@ -9,6 +9,7 @@ from cellxgene_schema.utils import (
     read_h5ad,
     remap_deprecated_features,
     remove_deprecated_features,
+    replace_delimiter,
     replace_ontology_term,
 )
 from fixtures.examples_validate import adata, adata_non_raw, h5ad_valid
@@ -200,6 +201,14 @@ def test_move_column_from_obs_to_uns(adata_with_raw):
 
     assert "assay_ontology_term_id" not in adata_with_raw.obs.columns
     assert adata_with_raw.uns["assay_ontology_term_id"] == "EFO:0009899"
+
+
+def test_replace_delimiter(adata_with_raw):
+    adata_with_raw.obs["self_reported_ethnicity_ontology_term_id"] = "HsapDv:0000003,HsapDv:0000004"
+
+    replace_delimiter(adata_with_raw.obs, ",", " || ", "self_reported_ethnicity_ontology_term_id")
+
+    assert adata_with_raw.obs["self_reported_ethnicity_ontology_term_id"].eq("HsapDv:0000003 || HsapDv:0000004").all()
 
 
 class TestGetHashDigestColumn:


### PR DESCRIPTION
## Reason for Change

a few changes here, based on feedback from lattice in [this thread](https://czi-sci.slack.com/archives/C08MF1AJ6F5/p1749151615477039?thread_ts=1749139807.104259&cid=C08MF1AJ6F5)

## Changes

- added a new util method `replace_delimiter` to migrate the delimiter of `self_reported_ethnicity_ontology_term_id`
- i updated the logic in `move_column_from_obs_to_uns` to log a warning instead of raising a keyerror if the column isn't found. mostly just because it makes writing the migration unit test easier, but i also think we shouldn't fail the migration if the column isn't found in case we need to re-run migration for something that is partially migrated or something like that.

## Testing

- added test coverage for `replace_delimiter`
- fixed a few random tests that were failing that were introduced when i merged my earlier PR when GHA's were down

## Notes for Reviewer