### PR TITLE
chore: bump ontology parser version

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/map_species.py
+++ b/cellxgene_schema_cli/cellxgene_schema/map_species.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def map_species(input_file, output_file):
-    ontology_parser = OntologyParser("5.3.0")
+    ontology_parser = OntologyParser("6.0.0")
     adata = ad.read_h5ad(input_file, backed="r")
     map_columns = [
         ("organism_cell_type_ontology_term_id", "cell_type_ontology_term_id", "CL"),

--- a/cellxgene_schema_cli/cellxgene_schema/ontology_parser.py
+++ b/cellxgene_schema_cli/cellxgene_schema/ontology_parser.py
@@ -1,3 +1,3 @@
 from cellxgene_ontology_guide.ontology_parser import OntologyParser
 
-ONTOLOGY_PARSER = OntologyParser(schema_version="v5.3.0")
+ONTOLOGY_PARSER = OntologyParser(schema_version="v6.0.0")

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1296,7 +1296,7 @@ class TestObs:
 
     @pytest.mark.parametrize(
         "organism_ontology_term_id",
-        ["EFO:0000001", "CL:0007021", "NCBITaxon:1234", "NCBITaxon:9615"],
+        ["EFO:0000001", "CL:4023077", "NCBITaxon:1234", "NCBITaxon:9615"],
     )
     def test_organism_ontology_term_id__invalid(self, validator_with_adata, organism_ontology_term_id):
         """
@@ -2863,7 +2863,7 @@ class TestZebrafish:
 
     @pytest.mark.parametrize(
         "cell_type_ontology_term_id",
-        ["ZFA:0000003", "CL:0007021", "unknown"],
+        ["ZFA:0000003", "CL:4023077", "unknown"],
     )
     def test_cell_type_ontology_term_id(self, validator_with_zebrafish_adata, cell_type_ontology_term_id):
         """
@@ -2962,7 +2962,7 @@ class TestZebrafish:
     @pytest.mark.parametrize(
         "tissue_ontology_term_id",
         [
-            "CL:0007021",  # valid CL term for cell culture
+            "CL:4023077",  # valid CL term for cell culture
             "ZFA:0000003",  # valid ZFA term
         ],
     )
@@ -3085,7 +3085,7 @@ class TestFruitFly:
 
     @pytest.mark.parametrize(
         "cell_type_ontology_term_id",
-        ["FBbt:00049192", "CL:0007021", "unknown"],
+        ["FBbt:00049192", "CL:4023077", "unknown"],
     )
     def test_cell_type_ontology_term_id(self, validator_with_fruitfly_adata, cell_type_ontology_term_id):
         """
@@ -3184,7 +3184,7 @@ class TestFruitFly:
     @pytest.mark.parametrize(
         "tissue_ontology_term_id",
         [
-            "CL:0007021",  # valid CL term for cell culture
+            "CL:4023077",  # valid CL term for cell culture
             "FBbt:00049192",  # valid FBbt term
         ],
     )
@@ -3314,7 +3314,7 @@ class TestRoundworm:
 
     @pytest.mark.parametrize(
         "cell_type_ontology_term_id",
-        ["WBbt:0005762", "CL:0007021", "unknown"],
+        ["WBbt:0005762", "CL:4023077", "unknown"],
     )
     def test_cell_type_ontology_term_id(self, validator_with_roundworm_adata, cell_type_ontology_term_id):
         """
@@ -3441,7 +3441,7 @@ class TestRoundworm:
     @pytest.mark.parametrize(
         "tissue_ontology_term_id",
         [
-            "CL:0007021",  # valid CL term for cell culture
+            "CL:4023077",  # valid CL term for cell culture
             "WBbt:0005762",  # valid WBbt term
         ],
     )


### PR DESCRIPTION
## Reason for Change

as titled. i realized when i bumped COG to 1.7.2, i forgot to bump to 6.0.0 in the ontology parser 🤦‍♀️ 

## Testing

- looks like `CL:0007021` was deprecated, so i replaced it with a random valid CL term in the tests that use that.

## Notes for Reviewer