### PR TITLE
chore: remove printing out collections with an open revision in them

### DIFF
--- a/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
@@ -172,12 +172,6 @@ def dry_run(curator_report_filepath: str, replaced_by_filepath: str) -> None:
             )
     write_to_curator_report(curator_report_filepath, private_curator_report_entry_map, revision_map)
 
-    if revision_map:
-        with open(curator_report_filepath, "a") as f:
-            f.write("\nThe Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:\n")
-            for revision in revision_map.values():
-                f.write(f"{revision}\n")
-
     with open(replaced_by_filepath, "w") as j:
         json.dump(replaced_by_map, j)
 

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/group_datasets_by_collection_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/group_datasets_by_collection_expected
@@ -23,6 +23,3 @@ Deprecated Term: EFO:0000006
 Replaced By: CL:0000006
 Comments: ['Comment adding context to replacement']
 
-
-The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:
-public_coll_0

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/no_deprecated_terms_with_open_revisions
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/no_deprecated_terms_with_open_revisions
@@ -3,6 +3,3 @@ Deprecated Terms in Public Datasets:
 
 Deprecated Terms in Private Datasets:
 
-
-The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:
-public_coll_0

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_comments_and_considers_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_comments_and_considers_expected
@@ -23,6 +23,3 @@ Deprecated Term: EFO:0000005
 Consider: ['EFO:0000001', 'EFO:0000010']
 Comments: ['Consider removing this term entirely', 'Or using one from a different ontology']
 
-
-The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:
-public_coll_0

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_replaced_by_diff_ontology_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_replaced_by_diff_ontology_expected
@@ -25,6 +25,3 @@ Deprecated Term: EFO:0000006
 Replaced By: CL:0000006
 Comments: ['Comment adding context to replacement']
 
-
-The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:
-public_coll_0

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_replaced_by_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_replaced_by_expected
@@ -25,6 +25,3 @@ Note--In A Revision of: public_coll_0
 Deprecated Term: EFO:0000002
 Replaced By: EFO:0000001
 
-
-The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:
-public_coll_0

--- a/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_term_tracker_expected
+++ b/scripts/schema_bump_dry_run_ontologies/tests/fixtures/with_term_tracker_expected
@@ -23,6 +23,3 @@ Deprecated Term: EFO:0000008
 Replaced By: EFO:0000080
 Term Tracker: www.fake-github-link.com/repo/example-1
 
-
-The Following Public Collections Will Not Be Auto-Migrated Due To Having an Open Revision:
-public_coll_0


### PR DESCRIPTION
## Reason for Change

- it seems like we still want to generate the `revision_map` to pass in to `write_to_curator_report`, we just don't want to include language that states these collections won't be auto-migrated
- slack context here: https://czi-sci.slack.com/archives/C08MF1AJ6F5/p1749491523566209?thread_ts=1749139807.104259&cid=C08MF1AJ6F5

## Changes

- removes the portion of the script which writes this language

## Testing

n/a

## Notes for Reviewer