### PR TITLE
chore: fix matrix utils

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/utils.py
@@ -33,8 +33,8 @@ def get_matrix_format(matrix: DaskArray) -> str:
     return determine_matrix_format(matrix)
 
 
-def count_matrix_nonzero(matrix: DaskArray, is_sparse_matrix: bool) -> int:
-    return calculate_matrix_nonzero(matrix, is_sparse_matrix)
+def count_matrix_nonzero(matrix: DaskArray) -> int:
+    return calculate_matrix_nonzero(matrix)
 
 
 def check_non_csr_matrices(adata: ad.AnnData):


### PR DESCRIPTION
## Reason for Change

we shouldn't need to pass in `is_sparse_matrix` into `count_matrix_nonzero`. we don't in data portal, which is causing this test failure: https://github.com/chanzuckerberg/single-cell-data-portal/actions/runs/15541164909/job/43752045725?pr=7600

we also don't even use that param in the `matrix_utils` method since we compute `is_sparse_matrix` anyways

## Changes

- as titled

## Testing

n/a

## Notes for Reviewer