### PR TITLE
migrate.py updates after first 6.0 dev migration

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -117,6 +117,32 @@ def migrate(input_file, output_file, collection_id, dataset_id):
             },
         )
 
+    # errors found in first dev migration run
+    # 'organism' already in uns
+    if dataset_id == "de2c780c-1747-40bd-9ccf-9588ec186cee":
+        del dataset.uns["organism"]
+
+    # deprecated CL term found in 3 datasets in one collection
+    if dataset_id in [
+        "773b9b2e-70c8-40be-8cbb-e7b5abab360d",
+        "e5233a94-9e43-418c-8209-6f1400c31530",
+        "7bb64315-9e5a-41b9-9235-59acf9642a3e",
+    ]:
+        utils.replace_ontology_term(dataset.obs, "cell_type", {"CL:0000651": "CL:0002181"})
+
+    # 2 other datasets with deprecated CL term
+    if dataset_id in ["e40c6272-af77-4a10-9385-62a398884f27", "d6dfdef1-406d-4efb-808c-3c5eddbfe0cb"]:
+        utils.replace_ontology_term(dataset.obs, "cell_type", {"CL:0000212": "CL:0000677"})
+
+    # feature_is_filtered set incorrectly for dataset with no raw.X matrix, should be all False
+    if dataset_id == "ee195b7d-184d-4dfa-9b1c-51a7e601ac11":
+        dataset.var["feature_is_filtered"] = False
+
+    # 11 datasets with "organism_ontology_term_id_colors" in uns, all can be removed
+    # seems easy enough to quickly check for key, can also list out the 11 dataset_ids
+    if "organism_ontology_term_id_colors" in dataset.uns:
+        del dataset.uns["organism_ontology_term_id_colors"]
+
     if GENCODE_MAPPER:
         dataset = utils.remap_deprecated_features(adata=dataset, remapped_features=GENCODE_MAPPER)
 


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- After first dev migration for 6.0 schema changes, I made the following updates to migrate.py. Originally from this conversation about the migration report:
https://stanford-gecko-group.slack.com/archives/C08MF1AJ6F5/p1749830978785359
https://czi-sci.slack.com/archives/C08MF1AJ6F5/p1749830978785359

- Will need to further investigate datasets with duplicate raw counts; these will need re-curation and likely input from original contributors.

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer