### PR TITLE
Migrate.py updates after second dev migration for schema 6.0

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/migrate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/migrate.py
@@ -120,9 +120,9 @@ def migrate(input_file, output_file, collection_id, dataset_id):
             },
         )
 
-    # errors found in first and second dev migration run
-    # 'organism' already in uns, one more picked up in second dev run
-    if dataset_id in ["de2c780c-1747-40bd-9ccf-9588ec186cee", "ebc2e1ff-c8f9-466a-acf4-9d291afaf8b3"]:
+    # errors found in 3 dev migration runs
+    # will just check for key and delete instead of list of dataset_ids
+    if "organism" in dataset.uns:
         del dataset.uns["organism"]
 
     # feature_is_filtered set incorrectly for dataset with no raw.X matrix, should be all False


### PR DESCRIPTION
## Reason for Change

- #TICKET_NUMBER
- If the reason for this PR's code changes are not clear in the issue, state value/impact

## Changes

- Updates from second schema 6.0 dev migration

## Testing

- Either list QA steps or reasoning you feel QA is unnecessary
- Reminder For CLI changes: upon merge, contact Lattice for final sign-off. Do not release a new cellxgene-schema 
version to PyPI without explicit QA + sign-off from Lattice on all functional CLI changes. They may install the package
version at HEAD of main with 
```
pip install git+https://github.com/chanzuckerberg/single-cell-curation/@main#subdirectory=cellxgene_schema_cli
```

## Notes for Reviewer