### PR TITLE
fix: memory optimization in feature_is_filtered validation

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -14,8 +14,8 @@ logger = logging.getLogger("cellxgene_schema")
 )
 @click.option("-v", "--verbose", help="When present will set logging level to debug", is_flag=True)
 def schema_cli(verbose):
-    logging.basicConfig(level=logging.ERROR)
-    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+    # logging.basicConfig(level=logging.ERROR)
+    logger.setLevel(logging.DEBUG)
 
 
 @schema_cli.command(

--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -14,8 +14,8 @@ logger = logging.getLogger("cellxgene_schema")
 )
 @click.option("-v", "--verbose", help="When present will set logging level to debug", is_flag=True)
 def schema_cli(verbose):
-    # logging.basicConfig(level=logging.ERROR)
-    logger.setLevel(logging.DEBUG)
+    logging.basicConfig(level=logging.ERROR)
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
 
 
 @schema_cli.command(

--- a/cellxgene_schema_cli/cellxgene_schema/matrix_utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/matrix_utils.py
@@ -61,8 +61,23 @@ def compute_column_sums(matrix: Union[DaskArray, np.ndarray, sparse.spmatrix]) -
 
     # Handle Dask array (could be sparse or dense)
     if isinstance(matrix, DaskArray):
-        col_sums = matrix.sum(axis=0, dtype=float, split_every=8)
-        return col_sums.compute()
+
+        def sum_columns(chunk):
+            return chunk.sum(axis=0)
+
+        # If chunks along axis=0 > 1, we need to sum per block then aggregate
+        if len(matrix.chunks[0]) > 1:
+            partial_sums = map_blocks(
+                sum_columns,
+                matrix,
+                drop_axis=0,
+                new_axis=0,
+                dtype=matrix.dtype,
+            )
+            column_sum = partial_sums.sum(axis=0)
+            return np.asarray(column_sum.compute()).ravel()
+        else:
+            return sum_columns(matrix.compute())
 
     raise TypeError(f"Unsupported matrix type: {type(matrix)}")
 

--- a/cellxgene_schema_cli/cellxgene_schema/matrix_utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/matrix_utils.py
@@ -2,6 +2,7 @@ from typing import Union
 
 import anndata as ad
 import numpy as np
+import sparse as sp
 from anndata.compat import DaskArray
 from dask.array import map_blocks
 from scipy import sparse
@@ -62,20 +63,18 @@ def compute_column_sums(matrix: Union[DaskArray, np.ndarray, sparse.spmatrix]) -
     # Handle Dask array (could be sparse or dense)
     if isinstance(matrix, DaskArray):
 
-        def sum_columns(chunk):
-            return chunk.sum(axis=0)
+        def to_coo(chunk):
+            # convert to sparse.COO, so we can use dask's internal chunked sum
+            if sparse.issparse(chunk):
+                return sp.COO.from_scipy_sparse(chunk)
+            else:
+                return sp.COO(chunk)
 
-        partial_sums = map_blocks(
-            sum_columns,
-            matrix,
-            drop_axis=0,
-            new_axis=0,
-            dtype=matrix.dtype,
-        )
-        column_sum = partial_sums.sum(axis=0)
-        return np.asarray(column_sum.compute()).ravel()
+        x_coo = matrix.map_blocks(to_coo, dtype=matrix.dtype)
 
-    raise TypeError(f"Unsupported matrix type: {type(matrix)}")
+        # 'split_every' is used to ensure that the computation is split into memory manageable chunks
+        col_sums = x_coo.sum(axis=0, split_every=8).compute()
+        return col_sums
 
 
 def calculate_matrix_nonzero(matrix: DaskArray) -> int:

--- a/cellxgene_schema_cli/cellxgene_schema/matrix_utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/matrix_utils.py
@@ -63,7 +63,7 @@ def compute_column_sums(matrix: Union[DaskArray, np.ndarray, sparse.spmatrix]) -
     # Handle Dask array (could be sparse or dense)
     if isinstance(matrix, DaskArray):
 
-        def to_coo(chunk):
+        def to_coo(chunk: Union[np.ndarray, sparse.spmatrix]) -> sp.COO:
             # convert to sparse.COO, so we can use dask's internal chunked sum
             if sparse.issparse(chunk):
                 return sp.COO.from_scipy_sparse(chunk)

--- a/cellxgene_schema_cli/cellxgene_schema/matrix_utils.py
+++ b/cellxgene_schema_cli/cellxgene_schema/matrix_utils.py
@@ -65,19 +65,15 @@ def compute_column_sums(matrix: Union[DaskArray, np.ndarray, sparse.spmatrix]) -
         def sum_columns(chunk):
             return chunk.sum(axis=0)
 
-        # If chunks along axis=0 > 1, we need to sum per block then aggregate
-        if len(matrix.chunks[0]) > 1:
-            partial_sums = map_blocks(
-                sum_columns,
-                matrix,
-                drop_axis=0,
-                new_axis=0,
-                dtype=matrix.dtype,
-            )
-            column_sum = partial_sums.sum(axis=0)
-            return np.asarray(column_sum.compute()).ravel()
-        else:
-            return sum_columns(matrix.compute())
+        partial_sums = map_blocks(
+            sum_columns,
+            matrix,
+            drop_axis=0,
+            new_axis=0,
+            dtype=matrix.dtype,
+        )
+        column_sum = partial_sums.sum(axis=0)
+        return np.asarray(column_sum.compute()).ravel()
 
     raise TypeError(f"Unsupported matrix type: {type(matrix)}")
 

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -621,8 +621,11 @@ class Validator:
                 )
             return
         else:
+            logger.debug("Getting matrix sums for feature_is_filtered validation.")
             sum_X = compute_column_sums(self.adata.X)
+            logger.debug("Finished getting X matrix sums for feature_is_filtered validation.")
             sum_raw_X = compute_column_sums(self.adata.raw.X)
+            logger.debug("Finished getting raw matrix sums for feature_is_filtered validation.")
             try:
                 ensembl_ids_all_zeros = []
                 for i, _ in enumerate(sum_X):
@@ -647,6 +650,7 @@ class Validator:
                 return
 
         if sum(column) > 0:
+            logger.debug("Calculating non-zero values for feature_is_filtered validation.")
             n_nonzero = calculate_matrix_nonzero(self.adata.X[:, column])
 
             if n_nonzero > 0:
@@ -655,6 +659,7 @@ class Validator:
                     f"{n_nonzero} non-zero values in the corresponding columns of the matrix 'X'. All values for "
                     f"these features must be 0."
                 )
+        logger.debug("Finished validating feature_is_filtered.")
 
     def _validate_column(
         self, column: pd.Series, column_name: str, df_name: str, column_def: dict, default_error_message_suffix=None

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -32,7 +32,6 @@ from .utils import (
 )
 from .validation_internals.check_duplicates import check_duplicate_obs
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 ASSAY_VISIUM = "EFO:0010961"  # generic term

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -32,6 +32,7 @@ from .utils import (
 )
 from .validation_internals.check_duplicates import check_duplicate_obs
 
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 ASSAY_VISIUM = "EFO:0010961"  # generic term
@@ -2143,6 +2144,7 @@ class Validator:
         self._validate_cell_type_ontology_term_id()
 
         # Verifies there are no duplicate obs rows, by raw counts
+        logger.debug("Checking for duplicate observations by raw counts...")
         self.errors.extend(check_duplicate_obs(self.adata))
 
         # Checks each component

--- a/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validation_internals/check_duplicates.py
@@ -7,7 +7,6 @@ import numpy as np
 from cellxgene_schema.matrix_utils import determine_matrix_format
 from scipy import sparse
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -9,6 +9,7 @@ pandas>2,<3
 pyarrow>=19
 PyYAML<7
 scipy<1.16 # broken in 1.15.0 see https://github.com/chanzuckerberg/single-cell-curation/issues/1165
+sparse==0.15.1
 semver<4
 xxhash<4
 matplotlib<4


### PR DESCRIPTION
## Reason for Change

- OOMs on large datasets during latest migration dev run, identified this as a point of memory leakage (still OOMs on datasets with 2M+ cells even after increasing to 64GB RAM machines)
- original implementation introduced [here](https://github.com/chanzuckerberg/single-cell-curation/pull/1395/files)

## Changes

- use dask's built-in 'sum' function, which can sum over dask array sparse matrix columns in a memory-optimized way (manages intermediate sums efficiently using tree-reduction)
- set optional 'split_every' arg to 8, to limit number of intermediate artifacts held in RAM
- requires converting blocks to COO matrices to be compatible with built-in sum function
- custom implementation was holding many intermediate artifacts (dense array blocks) concurrently in memory, causing OOMs.
         -  Alternative approach would require limiting parallelization or otherwise re-creating dask's built-in sparse matrix sum function to work for csr matrices 
- added more debug logging for future investigation into potentially memory-intensive jobs 

## Tests
- dev migration run successfully on previously failing datasets using this branch