### PR TITLE
fix: invalid gene check

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -465,7 +465,7 @@ class Validator:
                     f"Could not infer organism from feature ID '{feature_id}' in '{df_name}', "
                     f"make sure it is a valid ID."
                 )
-                return
+                continue
             else:
                 organism_ontology_id = organism.value
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1830,18 +1830,22 @@ class TestVar:
         """
         feature_id (var.index) str.
 
-        This tests the case of an ID with an incorrect format "ENSEBML_NOGENE"
+        This tests the case of an ID with an incorrect format where you can't infer the organism
+        from the ID.
         """
         validator = validator_with_adata
         component = getattr_anndata(validator.adata, component_name)
 
         new_index = list(component.index)
         new_index[0] = "ENSEBML_NOGENE"
+        new_index[1] = "INVALID_GENE_ID"
         component.set_index(pd.Index(new_index), inplace=True)
 
         validator.validate_adata()
         assert validator.errors == [
             f"ERROR: Could not infer organism from feature ID 'ENSEBML_NOGENE' "
+            f"in '{component_name}', make sure it is a valid ID.",
+            f"ERROR: Could not infer organism from feature ID 'INVALID_GENE_ID' "
             f"in '{component_name}', make sure it is a valid ID."
         ]
 

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1846,7 +1846,7 @@ class TestVar:
             f"ERROR: Could not infer organism from feature ID 'ENSEBML_NOGENE' "
             f"in '{component_name}', make sure it is a valid ID.",
             f"ERROR: Could not infer organism from feature ID 'INVALID_GENE_ID' "
-            f"in '{component_name}', make sure it is a valid ID."
+            f"in '{component_name}', make sure it is a valid ID.",
         ]
 
     @pytest.mark.parametrize("component_name", ["var", "raw.var"])


### PR DESCRIPTION
## Reason for Change

https://czi-sci.slack.com/archives/C07AV4NU9D2/p1755897599662919?thread_ts=1755889725.833399&cid=C07AV4NU9D2

## Changes

- replaces return with continue, so that we append errors for each invalid gene

## Testing

updated an existing test we had to ensure we would return 2 errors for 2 invalid genes

## Notes for Reviewer