### PR TITLE
fix: stricter control on sorting

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -580,7 +580,5 @@ def deduplicate_fragment_rows(
         uniq_proc.wait()
         sort_proc.wait()
         gzip_proc.wait()
-    if bgzip_proc.returncode != 0:
-        raise RuntimeError(f"bgzip compression failed with error code {bgzip_proc.returncode}")
     logger.info(f"bgzip compression completed successfully for {output_file_name}")
     return str(output_file_name)

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -1,7 +1,6 @@
 import gzip
 import logging
 import os
-import shlex
 import shutil
 import subprocess
 import tempfile
@@ -547,11 +546,15 @@ def deduplicate_fragment_rows(
     gzip_cmd = ["gzip", "-dc", str(fragment_file_name)]
     sort_cmd = [
         "sort",
-        "-t", "\t",
-        "-k1,1", "-k2,2n", "-k3,3n", "-k4,4",
+        "-t",
+        "\t",
+        "-k1,1",
+        "-k2,2n",
+        "-k3,3n",
+        "-k4,4",
         f"-S{sort_memory}%",
         f"--parallel={num_cores}",
-        f'--compress-program=pigz -p {num_cores}',
+        f"--compress-program=pigz -p {num_cores}",
     ]
     uniq_cmd = ["uniq"]
     bgzip_cmd = ["bgzip", "-@", str(num_cores), "-c"]

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -545,7 +545,7 @@ def deduplicate_fragment_rows(
     sort_memory = calculate_sort_memory(num_cores, sort_memory_percent)
     cmd = (
         f"gzip -dc {shlex.quote(str(fragment_file_name))} | "
-        f"LC_ALL=C sort -t $'\t' -k1,1 -k2,2n -k3,3n -k4,4 "
+        f"LC_ALL=C sort -t \\t -k1,1 -k2,2n -k3,3n -k4,4 "
         f"-S {sort_memory}% --parallel={num_cores} "
         f'--compress-program="pigz -p {num_cores}" | '
         f"uniq | bgzip -@ {num_cores} -c > {shlex.quote(str(output_file_name))}"

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -516,6 +516,23 @@ def deduplicate_fragment_rows(
     :return: Path to the deduplicated bgzipped output file.
     :raises RuntimeError: If the bgzip compression process fails.
     """
+    if shutil.which("sort") is None:
+        raise RuntimeError(
+            "The 'sort' command is not installed or not found in PATH. It is required to sort the fragment file."
+        )
+    if shutil.which("bgzip") is None:
+        raise RuntimeError(
+            "The 'bgzip' command is not installed or not found in PATH. It is required to compress the fragment file."
+        )
+    if shutil.which("pigz") is None:
+        raise RuntimeError(
+            "The 'pigz' command is not installed or not found in PATH. It is required to compress the fragment file."
+        )
+    if shutil.which("uniq") is None:
+        raise RuntimeError(
+            "The 'pigz' command is not installed or not found in PATH. It is required to compress the fragment file."
+        )
+
     logger.info(f"deduplicating fragment file: {fragment_file_name}")
 
     output_file_name = (
@@ -528,7 +545,7 @@ def deduplicate_fragment_rows(
     sort_memory = calculate_sort_memory(num_cores, sort_memory_percent)
     cmd = (
         f"gzip -dc {shlex.quote(str(fragment_file_name))} | "
-        f"LC_ALL=C sort -t $'\\t' -k1,1 -k2,2n -k3,3n -k4,4 "
+        f"LC_ALL=C sort -t $'\t' -k1,1 -k2,2n -k3,3n -k4,4 "
         f"-S {sort_memory}% --parallel={num_cores} "
         f'--compress-program="pigz -p {num_cores}" | '
         f"uniq | bgzip -@ {num_cores} -c > {shlex.quote(str(output_file_name))}"

--- a/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
+++ b/cellxgene_schema_cli/cellxgene_schema/atac_seq.py
@@ -454,7 +454,7 @@ def prepare_fragment(
         )
 
     num_cores = os.cpu_count()
-
+    sort_memory = 70 // num_cores
     with open(bgzip_output_file, "wb") as out_f:
         gzip_proc = subprocess.Popen(["gzip", "-dc", fragment_file], stdout=subprocess.PIPE)
         sort_proc = subprocess.Popen(
@@ -466,7 +466,8 @@ def prepare_fragment(
                 "-k1,1",
                 "-k2,2n",
                 "-k3,3n",
-                "-S 40%",
+                "-k4,4",
+                f"-S {sort_memory}%",
                 '--compress-program="pigz -p {num_cores}"',
             ],
             stdin=gzip_proc.stdout,

--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -112,6 +112,27 @@ def fragment_validate(h5ad_file, fragment_file, generate_index, output_file):
         sys.exit(1)
 
 
+# add a cli command to deduplicate an ATAC fragment file
+@schema_cli.command(
+    name="deduplicate-fragment",
+    short_help="Deduplicate an ATAC SEQ fragment file.",
+    help="Deduplicate an ATAC SEQ fragment file. If deduplication fails this command will return an exit status of 1 "
+    "otherwise 0. The deduplicated fragment will have the file suffix .dedup.bgz and the index will have the file "
+    "suffix .dedup.bgz.tbi.",
+)
+@click.argument("fragment_file", nargs=1, type=click.Path(exists=True, dir_okay=False))
+@click.option("-o", "--output-file", help="Output file for the deduplicated fragment.", type=click.Path(exists=False))
+@click.option("-m", "--memory", help="Memory limit as a percentage of total memory.", type=int, default=80)
+def deduplicate_fragment(fragment_file, output_file, tempdir, memory):
+    from .atac_seq import deduplicate_fragment_rows
+
+    try:
+        deduplicate_fragment_rows(fragment_file, output_file_name=output_file, sort_memory_percent=memory)
+    except Exception as e:
+        logger.error(f"Failed to deduplicate fragment file: {e}")
+        sys.exit(1)
+
+
 @schema_cli.command(
     name="check-anndata-requires-fragment",
     short_help="Check if that the anndata provided supports an Atac seq fragment file.",

--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -123,7 +123,7 @@ def fragment_validate(h5ad_file, fragment_file, generate_index, output_file):
 @click.argument("fragment_file", nargs=1, type=click.Path(exists=True, dir_okay=False))
 @click.option("-o", "--output-file", help="Output file for the deduplicated fragment.", type=click.Path(exists=False))
 @click.option("-m", "--memory", help="Memory limit as a percentage of total memory.", type=int, default=80)
-def deduplicate_fragment(fragment_file, output_file, tempdir, memory):
+def deduplicate_fragment(fragment_file, output_file, memory):
     from .atac_seq import deduplicate_fragment_rows
 
     try:

--- a/cellxgene_schema_cli/tests/test_atac_seq.py
+++ b/cellxgene_schema_cli/tests/test_atac_seq.py
@@ -569,7 +569,7 @@ class TestIndexFragmentWithLineCountValidation:
         test_lines = [f"chr1\t100\t200\t{TEST_BARCODE}\t5\n", f"chr1\t300\t400\t{TEST_BARCODE}\t3\n"]
         test_fragment_file = create_fragment_file_from_dataframe(
             os.path.join(tmpdir, "test_fragments.tsv.gz"),
-            pd.DataFrame([line.split("\t") for line in test_lines], columns=atac_seq.column_ordering),
+            pd.DataFrame([line.rstrip('\n').split("\t") for line in test_lines], columns=atac_seq.column_ordering),
         )
         output_file = os.path.join(tmpdir, "output.bgz")
 

--- a/cellxgene_schema_cli/tests/test_atac_seq.py
+++ b/cellxgene_schema_cli/tests/test_atac_seq.py
@@ -133,7 +133,7 @@ class TestProcessFragment:
         fragments_file = os.path.join(FIXTURES_ROOT, "atac_seq", fragment_file)
         # Act
         result = atac_seq.process_fragment(
-            fragments_file,
+            str(fragments_file),
             anndata_file,
             generate_index=True,
             output_file=str(atac_fragment_bgzip_file_path),
@@ -187,6 +187,8 @@ class TestProcessFragment:
             output_file=str(atac_fragment_bgzip_file_path),
         )
         result = [r for r in result if "Error" in r]
+        # Assert
+        assert len(result) == 1
 
 
 class TestPrepareFragment:

--- a/cellxgene_schema_cli/tests/test_atac_seq.py
+++ b/cellxgene_schema_cli/tests/test_atac_seq.py
@@ -569,7 +569,7 @@ class TestIndexFragmentWithLineCountValidation:
         test_lines = [f"chr1\t100\t200\t{TEST_BARCODE}\t5\n", f"chr1\t300\t400\t{TEST_BARCODE}\t3\n"]
         test_fragment_file = create_fragment_file_from_dataframe(
             os.path.join(tmpdir, "test_fragments.tsv.gz"),
-            pd.DataFrame([line.rstrip('\n').split("\t") for line in test_lines], columns=atac_seq.column_ordering),
+            pd.DataFrame([line.rstrip("\n").split("\t") for line in test_lines], columns=atac_seq.column_ordering),
         )
         output_file = os.path.join(tmpdir, "output.bgz")
 


### PR DESCRIPTION
## Reason for Change

- a continuation of https://github.com/chanzuckerberg/single-cell-curation/pull/1427
- add a cli command to deduplicate an ATAC fragment.

## Changes

- sort by the 4th column
- limit the amount of memory per thread when sorting.
- add CLI command to deduplicate an atac fragement

## Testing
- added test case for deduplicating atac fragments

## Notes for Reviewer
add to [release 6.0.4](https://github.com/chanzuckerberg/single-cell-curation/pull/1429)