### PR TITLE
fix: add na as valid for uberon organisms

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -590,6 +590,7 @@ components:
                     - UBERON:0000105
               exceptions:
                 - unknown
+                - na
               forbidden:
                 terms:
                   - UBERON:0000071


### PR DESCRIPTION
## Reason for Change

https://czi-sci.slack.com/archives/C07AV4NU9D2/p1756319936449219?thread_ts=1756231861.939489&cid=C07AV4NU9D2

## Changes

- updates the "If organism is none of the above" rule to allow `na` as an exception. this is how the other organism-specific terms are written

## Testing

lattice already has tests written for this, not sure if it's worth it for me to rewrite the same thing when i'm fairly confident this is the fix

## Notes for Reviewer