### PR TITLE
fix: pin duckdb version in requirements.txt

### DIFF
--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,7 +1,7 @@
 anndata==0.11.4
 cellxgene-ontology-guide==1.8.0-alpha
 click<9
-Cython<4
+Cython==3.1.3
 dask[array, dataframe]==2024.12.0
 ibis-framework[duckdb]>=10.3
 numpy<3

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,8 +1,9 @@
 anndata==0.11.4
 cellxgene-ontology-guide==1.8.0-alpha
 click<9
-Cython==3.1.3
+Cython<4
 dask[array, dataframe]==2024.12.0
+duckdb==1.3.2 # This is a third-party dependency of ibis-framework, pinned to avoid a breaking change in 1.4.0
 ibis-framework[duckdb]>=10.3
 numpy<3
 pandas>2,<3


### PR DESCRIPTION
## Reason for Change
fixing a bug when ingesting ATAC datasets
```
{ "levelname": "ERROR", "asctime": "2025-09-16T18:04:14.016Z", "name": "processing", "message": "validation failed", "lineno": 185, "pathname": "/backend/layers/processing/process_validate_atac.py", "exc_info": "Traceback (most recent call last):\n File \"/backend/layers/processing/process_validate_atac.py\", line 180, in process\n errors, fragment_index_file, fragment_file = self.schema_validator.validate_atac(\n File \"/backend/layers/thirdparty/schema_validator_provider.py\", line 102, in validate_atac\n atac_seq.process_fragment(fragment_file, anndata_file, True, output_file=output_file),\n File \"/opt/venv/lib/python3.10/site-packages/cellxgene_schema/atac_seq.py\", line 226, in process_fragment\n errors = validate_anndata_with_fragment(parquet_file, anndata_file, organism_ontology_term_id)\n File \"/opt/venv/lib/python3.10/site-packages/cellxgene_schema/atac_seq.py\", line 284, in validate_anndata_with_fragment\n validate_fragment_start_coordinate_greater_than_0(parquet_file),\n File \"/opt/venv/lib/python3.10/site-packages/cellxgene_schema/atac_seq.py\", line 135, in wrapper\n return func(*args, **kwargs)\n File \"/opt/venv/lib/python3.10/site-packages/cellxgene_schema/atac_seq.py\", line 313, in validate_fragment_start_coordinate_greater_than_0\n if not (df[\"start coordinate\"] > 0).all().execute():\n File \"/opt/venv/lib/python3.10/site-packages/ibis/expr/types/core.py\", line 424, in execute\n return self._find_backend(use_default=True).execute(\n File \"/opt/venv/lib/python3.10/site-packages/ibis/backends/duckdb/__init__.py\", line 1415, in execute\n for name, col in zip(table.column_names, table.columns)\nAttributeError: 'pyarrow.lib.RecordBatchReader' object has no attribute 'column_names'" }
```

## Changes

- pin duckdb to the last working version and add a comment

## Testing

- unit tests will pass again

## Notes for Reviewer

create a patch release of cellxgene_schema