### PR TITLE
fix: decouple schema version from package version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.0.1
+current_version = 6.2.2
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 
@@ -15,7 +15,3 @@ values =
 [bumpversion:file:cellxgene_schema_cli/setup.py]
 search = version="{current_version}"
 replace = version="{new_version}"
-
-[bumpversion:file:cellxgene_schema_cli/cellxgene_schema/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.2.2
+current_version = 6.0.1
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<prerel>rc)\.(?P<prerelversion>\d+))?
 serialize = 

--- a/cellxgene_schema_cli/cellxgene_schema/__init__.py
+++ b/cellxgene_schema_cli/cellxgene_schema/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "6.0.1"
+__schema_version__ = "6.0.0"

--- a/cellxgene_schema_cli/cellxgene_schema/schema.py
+++ b/cellxgene_schema_cli/cellxgene_schema/schema.py
@@ -1,7 +1,7 @@
 import semver
 import yaml
 
-from . import __version__, env
+from . import __schema_version__, env
 
 
 def get_schema_definition() -> dict:
@@ -17,5 +17,5 @@ def get_schema_definition() -> dict:
 
 
 def get_current_schema_version() -> str:
-    current_version: semver.Version = semver.Version.parse(__version__)
+    current_version: semver.Version = semver.Version.parse(__schema_version__)
     return f"{str(current_version.major)}.{str(current_version.minor)}.0"

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="6.2.2",
+    version="6.0.1",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/setup.py
+++ b/cellxgene_schema_cli/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as fh:
 
 setup(
     name="cellxgene-schema",
-    version="6.0.1",
+    version="6.2.2",
     url="https://github.com/chanzuckerberg/single-cell-curation",
     license="MIT",
     author="Chan Zuckerberg Initiative",

--- a/cellxgene_schema_cli/tests/test_schema.py
+++ b/cellxgene_schema_cli/tests/test_schema.py
@@ -5,7 +5,7 @@ from cellxgene_schema import schema
 
 
 # Mock the version to ensure consistent test results
-@patch("cellxgene_schema.schema.__version__", "6.0.0")
+@patch("cellxgene_schema.schema.__schema_version__", "6.0.0")
 def test_get_current_schema_version():
     assert semver.Version.is_valid(schema.get_current_schema_version())
     assert schema.get_current_schema_version() == "6.0.0"


### PR DESCRIPTION
## Reason for Change

- Recent case where package version was updated to address a bug, but schema version was not intended to be bumped. 
- bumpversion.cfg, if run locally, updates the schema version without committing the change to git, leading to confusion when the schema_version being minted does not match files committed in main

## Changes

- schema_version is now a separate var from package version, must be updated manually rather than in one-go with bumpversion (this is reasonable given that bumpversion is designed for package versioning)
- update package version to 6.2.2 to match the patch release this will go out with, update schema version to 6.0.0 as expected
