### PR TITLE
feat: add forbidden values for donor_id and validation test for tissu…

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -736,6 +736,8 @@ components:
       donor_id:
         type: categorical
         subtype: str
+        forbidden:
+          - na
         dependencies:
           - # If tissue_type is "cell line", donor_id must be "na"
             rule:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -729,6 +729,15 @@ class Validator:
                 # check for null values--skip on column defs with enums, since it will already be part of that check
                 if not column_def.get("enum") and column.isnull().any():
                     self.errors.append(f"Column '{column_name}' in dataframe '{df_name}' must not contain NaN values.")
+                if forbidden_values := column_def.get("forbidden"):
+                    # Check for forbidden values
+                    bad_values = column.drop_duplicates()[column.drop_duplicates().isin(forbidden_values)]
+                    bad_values = bad_values.tolist()
+                    if bad_values:
+                        self.errors.append(
+                            f"Column '{column_name}' in dataframe '{df_name}' contains forbidden values "
+                            f"'{bad_values}'. Values must not be one of {forbidden_values}"
+                        )
 
         if column_def.get("type") == "feature_is_filtered":
             self._validate_column_feature_is_filtered(column, column_name, df_name)

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -1591,6 +1591,21 @@ class TestObs:
             )
         ]
 
+    def test_donor_id_cannot_be_na_when_tissue_type_is_not_cell_line(self, validator_with_adata):
+        """
+        donor_id is 'na' when tissue_type is not 'cell line', which is invalid
+        """
+        validator = validator_with_adata
+        obs = validator.adata.obs
+        obs["donor_id"] = obs["donor_id"].cat.add_categories("na")
+        obs["donor_id"][:] = "na"
+
+        validator.validate_adata()
+        assert validator.errors == [
+            "ERROR: Column 'donor_id' in dataframe 'obs' contains forbidden values "
+            "'['na']'. Values must not be one of ['na']"
+        ]
+
     def test_donor_id_is_na_when_tissue_type_is_cell_line(self, validator_with_cell_line_tissue_type):
         """
         donor_id is 'na' when tissue_type is 'cell line', which is valid


### PR DESCRIPTION
This pull request introduces validation logic to ensure that the value 'na' is forbidden in the `donor_id` column except when `tissue_type` is "cell line". The changes include updates to the schema definition, validation logic, and new test coverage for this rule.

Validation logic and schema enforcement:

* Added a `forbidden` field to the `donor_id` schema definition in `schema_definition.yaml` to explicitly forbid the value 'na' except when allowed by dependency rules.
* Updated the `_validate_column` function in `validate.py` to check for forbidden values in columns and report errors if any are found.

Testing:

* Added a new test to verify that 'na' is not allowed in the `donor_id` column when `tissue_type` is not 'cell line', ensuring the validation logic works as intended.