### PR TITLE
feat: update schema version to 7.0.0 and bump COG to 1.9.0

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/__init__.py
+++ b/cellxgene_schema_cli/cellxgene_schema/__init__.py
@@ -1,1 +1,1 @@
-__schema_version__ = "6.0.0"
+__schema_version__ = "7.0.0"

--- a/cellxgene_schema_cli/cellxgene_schema/ontology_parser.py
+++ b/cellxgene_schema_cli/cellxgene_schema/ontology_parser.py
@@ -1,3 +1,3 @@
 from cellxgene_ontology_guide.ontology_parser import OntologyParser
 
-ONTOLOGY_PARSER = OntologyParser(schema_version="v7.0.0-alpha")
+ONTOLOGY_PARSER = OntologyParser(schema_version="v7.0.0")

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata==0.11.4
-cellxgene-ontology-guide==1.8.0-alpha
+cellxgene-ontology-guide==1.9.0
 click<9
 Cython<4
 dask[array, dataframe]==2024.12.0

--- a/scripts/schema_bump_dry_run_ontologies/requirements.txt
+++ b/scripts/schema_bump_dry_run_ontologies/requirements.txt
@@ -1,2 +1,2 @@
 requests<3
-cellxgene-ontology-guide==1.6.0
+cellxgene-ontology-guide==1.9.0


### PR DESCRIPTION
This pull request updates the codebase and dependencies to support schema version 7.0.0 and the latest stable release of `cellxgene-ontology-guide`. The changes ensure consistency across the schema version, ontology parser usage, and package requirements.

Schema and ontology updates:

* Updated `__schema_version__` to `"7.0.0"` in `cellxgene_schema/__init__.py` to reflect the new schema version.
* Changed the `OntologyParser` initialization to use schema version `"v7.0.0"` instead of the alpha version in `ontology_parser.py`.

Dependency upgrades:

* Upgraded `cellxgene-ontology-guide` to version `1.9.0` in both `cellxgene_schema_cli/requirements.txt` and `scripts/schema_bump_dry_run_ontologies/requirements.txt` to use the latest stable release. [[1]](diffhunk://#diff-e5ba12c959032b3522a700ca2e461b6216891b310fc989d4d357ff9437405a3fL2-R2) [[2]](diffhunk://#diff-c08a1e28cdcabaf044f7d650122687501533fddfd18773da95616b4d9ca42233L2-R2)