### PR TITLE
fix: ontology_bump skip to support '||' separator.

### DIFF
--- a/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/ontology_bump_dry_run.py
@@ -51,7 +51,12 @@ def map_deprecated_terms(
     for ontology_type in ONTOLOGY_TYPES:
         if ontology_type in dataset:
             for ontology_term in dataset[ontology_type]:
-                ontology_term_ids = ontology_term["ontology_term_id"].split(",")
+                if "," in ontology_term["ontology_term_id"]:
+                    ontology_term_ids = [term_id.strip() for term_id in ontology_term["ontology_term_id"].split(",")]
+                elif "||" in ontology_term["ontology_term_id"]:
+                    ontology_term_ids = [term_id.strip() for term_id in ontology_term["ontology_term_id"].split("||")]
+                else:
+                    ontology_term_ids = [ontology_term["ontology_term_id"]]
                 for ontology_term_id in ontology_term_ids:
                     if ontology_term_id in non_deprecated_term_cache:
                         continue

--- a/scripts/schema_bump_dry_run_ontologies/tests/test_ontology_bump_dry_run.py
+++ b/scripts/schema_bump_dry_run_ontologies/tests/test_ontology_bump_dry_run.py
@@ -212,13 +212,22 @@ class TestOntologyBumpDryRun:
             assert list(expected) == list(tmp)
             assert expected_replaced_by_map == json.load(tmp_json)
 
-    def test_with_comma_delimited_onto_id_list(self, setup):  # type: ignore
+    @pytest.mark.parametrize(
+        "separator,expected_file",
+        [
+            (",", "with_comma_delimited_onto_id_list_expected"),
+            ("||", "with_pipepipe_delimited_onto_id_list_expected"),
+        ],
+    )
+    def test_with_multi_delimited_onto_id_list(self, setup, separator, expected_file):  # type: ignore
         public_datasets, private_collections, expected_replaced_by_map = setup
         private_collections.pop()
-        public_datasets[0]["self_reported_ethnicity"] = [{"ontology_term_id": "HANCESTRO:0000001,HANCESTRO:0000002"}]
+        public_datasets[0]["self_reported_ethnicity"] = [
+            {"ontology_term_id": f"HANCESTRO:0000001{separator}HANCESTRO:0000002"}
+        ]
         expected_replaced_by_map["self_reported_ethnicity"]["HANCESTRO:0000002"] = "HANCESTRO:0000003"
         with NamedTemporaryFile() as tmp, NamedTemporaryFile() as tmp_json, open(
-            f"{FIXTURES_ROOT}/with_comma_delimited_onto_id_list_expected", "rb"
+            f"{FIXTURES_ROOT}/{expected_file}", "rb"
         ) as expected:
             ontology_bump_dry_run.dry_run(tmp.name, tmp_json.name)
             assert list(expected) == list(tmp)


### PR DESCRIPTION
## Reason for Change

This pull request enhances the handling of ontology term IDs in the ontology bump dry run script and improves the associated test coverage. The main improvements are the ability to support both comma- and double-pipe-delimited ontology term IDs, and a refactored, parameterized test to ensure both cases are properly handled.

**Ontology term ID parsing improvements:**

* Updated `map_deprecated_terms` in `ontology_bump_dry_run.py` to support both comma (`,`) and double-pipe (`||`) delimiters when splitting `ontology_term_id` values, ensuring robust parsing of multiple term IDs.

**Testing enhancements:**

* Refactored the test for multi-delimited ontology term IDs in `test_ontology_bump_dry_run.py` to use `pytest.mark.parametrize`, covering both comma and double-pipe delimiters and generalizing the expected output file selection.