### PR TITLE
feat: Add experimental_condition_ontology_term_id, experimental_condition, and perturbation_types fields 

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/map_species.py
+++ b/cellxgene_schema_cli/cellxgene_schema/map_species.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def map_species(input_file, output_file):
-    ontology_parser = OntologyParser("6.0.0")
+    ontology_parser = OntologyParser("7.1.0")
     adata = ad.read_h5ad(input_file, backed="r")
     map_columns = [
         ("organism_cell_type_ontology_term_id", "cell_type_ontology_term_id", "CL"),

--- a/cellxgene_schema_cli/cellxgene_schema/ontology_parser.py
+++ b/cellxgene_schema_cli/cellxgene_schema/ontology_parser.py
@@ -1,3 +1,3 @@
 from cellxgene_ontology_guide.ontology_parser import OntologyParser
 
-ONTOLOGY_PARSER = OntologyParser(schema_version="v7.0.0")
+ONTOLOGY_PARSER = OntologyParser(schema_version="v7.1.0")

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -203,6 +203,8 @@ components:
       - organism_ontology_term_id
     reserved_columns:
       - observation_joinid
+      - experimental_condition
+      - perturbation_types
     columns:
       cell_type_ontology_term_id:
         error_message_suffix: >-
@@ -823,6 +825,68 @@ components:
           The value MUST be either 'na' or one or more genetic perturbation identifiers in ascending lexical order
           separated by the delimiter ` || ` with no duplication of identifiers. Each identifier MUST match a key in
           uns['genetic_perturbations'].
+      experimental_condition_ontology_term_id:
+        type: curie
+        required: False
+        forbidden_when_all_na: True
+        curie_constraints:
+          ontologies:
+            - CHEBI
+            - EFO
+            - UniProt
+          stripped_prefixes:
+            UniProt:
+              - "anti-"
+          exceptions:
+            - na
+          forbidden:
+            terms:
+              - CHEBI:23367
+              - CHEBI:24431
+              - CHEBI:24835
+              - CHEBI:24867
+              - CHEBI:24870
+              - CHEBI:25212
+              - CHEBI:25367
+              - CHEBI:25699
+              - CHEBI:33238
+              - CHEBI:33259
+              - CHEBI:33497
+              - CHEBI:33595
+              - CHEBI:33674
+              - CHEBI:33675
+              - CHEBI:36342
+              - CHEBI:36357
+              - CHEBI:36358
+              - CHEBI:36914
+              - CHEBI:37577
+              - CHEBI:50906
+            ancestors:
+              CHEBI:
+                - CHEBI:36342  # subatomic particle and descendants
+                - CHEBI:50906  # role and descendants
+          allowed:
+            terms:
+              EFO:
+                - EFO:0001702  # temperature (exact)
+                - EFO:0002755  # diet (exact match; descendants covered by ancestors below)
+              UniProt:
+                - all
+            ancestors:
+              CHEBI:
+                - CHEBI:24431  # chemical entity and descendants
+              EFO:
+                - EFO:0002755  # diet and descendants
+          multi_term:
+            delimiter: " || "
+            sorted: True
+        add_labels:
+          - type: curie
+            to_column: experimental_condition
+        error_message_suffix: >-
+          The value MUST be "na" or one or more term identifiers in ascending lexical order separated by " || "
+          with no duplication. Allowed: descendants of CHEBI:24431 (excluding listed forbidden CHEBI terms),
+          EFO:0001702 (temperature) or EFO:0002755 (diet) or its descendants, uniprot: terms, anti-uniprot: terms.
       is_primary_data:
         type: bool
       genetic_perturbation_strategy:

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -263,6 +263,9 @@ class Validator:
 
         :returns bool
         """
+        # Terms not recognized by the OntologyParser (e.g. anti-uniprot: prefix) cannot have ancestors checked
+        if not ONTOLOGY_PARSER.is_valid_term_id(term_id):
+            return False
         for ontology_name in forbidden_def:
             for ancestor in forbidden_def[ontology_name]:
                 if ancestor in ONTOLOGY_PARSER.get_term_ancestors(term_id):
@@ -305,19 +308,26 @@ class Validator:
 
         return any(checks)
 
-    def _validate_curie_ontology(self, term_id: str, column_name: str, allowed_ontologies: List[str]) -> bool:
+    def _validate_curie_ontology(
+        self,
+        term_id: str,
+        column_name: str,
+        allowed_ontologies: List[str],
+        report_term_id: Optional[str] = None,
+    ) -> bool:
         """
         Validate a single curie term id belongs to specified ontologies. If it does belong to an allowed ontology
         verifies that it is not deprecated (obsolete).
         If there are any errors, it adds them to self.errors
 
-        :param str term_id: the curie term id to validate
+        :param str term_id: the curie term id to validate (may be a normalized form, e.g. with prefix stripped)
         :param str column_name: original column name in adata where the term_id comes from (used for error messages)
         :param List[str] allowed_ontologies: allowed ontologies
+        :param Optional[str] report_term_id: term id to use in error messages (defaults to term_id)
 
         :rtype bool
         """
-
+        report_id = report_term_id if report_term_id is not None else term_id
         checks = []
 
         for ontology_name in allowed_ontologies:
@@ -328,12 +338,12 @@ class Validator:
             checks.append(is_valid)
 
             if is_valid and ONTOLOGY_PARSER.is_term_deprecated(term_id):
-                self.errors.append(f"'{term_id}' in '{column_name}' is a deprecated term id of '{ontology_name}'.")
+                self.errors.append(f"'{report_id}' in '{column_name}' is a deprecated term id of '{ontology_name}'.")
                 return False
 
         if sum(checks) == 0:
             self.errors.append(
-                f"'{term_id}' in '{column_name}' is not a valid ontology term id of '{', '.join(allowed_ontologies)}'."
+                f"'{report_id}' in '{column_name}' is not a valid ontology term id of '{', '.join(allowed_ontologies)}'."
             )
             return False
         return True
@@ -399,23 +409,47 @@ class Validator:
 
         :rtype None
         """
-        # Check if term_id is forbidden by schema definition. Sometimes, these are also invalid ontology
+        # Apply stripped_prefixes: some fields allow terms with a label prefix (e.g. "anti-uniprot:")
+        # whose underlying ontology term (e.g. "uniprot:Q99467") must be validated. The prefix is stripped
+        # before ontology checks but retained in user-facing error messages.
+        #
+        # stripped_prefixes format: {ontology_name: [prefix, ...], ...}
+        #   For "anti-uniprot:Q99467" with {UniProt: ["anti-"]}:
+        #     term_id           = "anti-uniprot:Q99467"  (retained for error messages)
+        #     ontology_term_id  = "uniprot:Q99467"        (used for all OntologyParser lookups)
+        #   For "CHEBI:16412" (no matching prefix):
+        #     term_id = ontology_term_id = "CHEBI:16412"  (unchanged)
+        ontology_term_id = term_id
+        stripped_prefixes = curie_constraints.get("stripped_prefixes", {})
+        for _, prefixes in stripped_prefixes.items():
+            for prefix in prefixes:
+                if term_id.startswith(prefix):
+                    ontology_term_id = term_id[len(prefix) :]
+                    break
+            if ontology_term_id != term_id:
+                break
+
+        # Check if ontology_term_id is forbidden by schema definition. Sometimes, these are also invalid ontology
         # terms, but it's preferred to report these as "not allowed" terms rather than "invalid ontology terms"
         if "forbidden" in curie_constraints:
             forbidden_terms = curie_constraints["forbidden"].get("terms", [])
-            if term_id in forbidden_terms:
+            if ontology_term_id in forbidden_terms:
                 self.errors.append(f"'{term_id}' in '{column_name}' is not allowed.")
                 return
 
         # If the term id does not belong to an allowed ontology, the subsequent checks are redundant
-        if not self._validate_curie_ontology(term_id, column_name, curie_constraints["ontologies"]):
+        if not self._validate_curie_ontology(
+            ontology_term_id, column_name, curie_constraints["ontologies"], report_term_id=term_id
+        ):
             return
 
         # Must be valid ontology term to validate against forbidden curie ancestors
         if (
             "forbidden" in curie_constraints
             and "ancestors" in curie_constraints["forbidden"]
-            and self._has_forbidden_curie_ancestor(term_id, column_name, curie_constraints["forbidden"]["ancestors"])
+            and self._has_forbidden_curie_ancestor(
+                ontology_term_id, column_name, curie_constraints["forbidden"]["ancestors"]
+            )
         ):
             self.errors.append(f"'{term_id}' in '{column_name}' is not allowed.")
             return
@@ -425,15 +459,15 @@ class Validator:
             is_allowed = False
             if "terms" in curie_constraints["allowed"]:
                 for ontology_name, allow_list in curie_constraints["allowed"]["terms"].items():
-                    if ONTOLOGY_PARSER.is_valid_term_id(term_id, ontology_name) and (
-                        allow_list == ["all"] or term_id in set(allow_list)
+                    if ONTOLOGY_PARSER.is_valid_term_id(ontology_term_id, ontology_name) and (
+                        allow_list == ["all"] or ontology_term_id in set(allow_list)
                     ):
                         is_allowed = True
                         # break
             if (
                 not is_allowed
                 and "ancestors" in curie_constraints["allowed"]
-                and self._validate_curie_ancestors(term_id, curie_constraints["allowed"]["ancestors"])
+                and self._validate_curie_ancestors(ontology_term_id, curie_constraints["allowed"]["ancestors"])
             ):
                 is_allowed = True
 
@@ -701,6 +735,13 @@ class Validator:
 
         if column_def.get("unique") and column.nunique() != len(column):
             self.errors.append(f"Column '{column_name}' in dataframe '{df_name}' is not unique.")
+
+        # If forbidden_when_all_na is set, the column must not exist when every row value is "na".
+        if column_def.get("forbidden_when_all_na") and (column == "na").all():
+            self.errors.append(
+                f"Column '{column_name}' in dataframe '{df_name}' MUST NOT be present when all "
+                f"values are 'na'. Remove it from h5ad and try again."
+            )
 
         if column_def.get("type") == "bool" and column.dtype != bool:
             self.errors.append(
@@ -1271,6 +1312,9 @@ class Validator:
                     # Validate columns that are only required in certain circumstances
                     try:
                         column_def = self._get_column_def(df_name, column_name)
+                        # If the column is explicitly marked as not required, skip the missing-column error
+                        if not column_def.get("required", True):
+                            continue
                         deps = column_def.get("dependencies")
                         if deps:
                             dep_defs = deps if isinstance(deps, list) else [deps]
@@ -1933,11 +1977,17 @@ class Validator:
 
         :rtype none
         """
+        # Columns already listed in reserved_columns are handled by the reserved_columns check;
+        # skip them here to avoid duplicate error messages.
+        component_reserved = set(self._get_component_def(component).get("reserved_columns", []))
 
         for label_def in add_labels_def:
             reserved_name = label_def.get("to_column")
             if reserved_name is None:
                 reserved_name = label_def.get("to_key")
+
+            if reserved_name in component_reserved:
+                continue
 
             if reserved_name in getattr_anndata(self.adata, component):
                 self.errors.append(

--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -98,21 +98,41 @@ class AnnDataLabelAppender:
 
         return flatten
 
-    def _get_ontology_term_label(self, term_id: str, allowed_ontologies: List[str]) -> str:
+    def _get_ontology_term_label(
+        self, term_id: str, allowed_ontologies: List[str], stripped_prefixes: Optional[dict] = None
+    ) -> str:
         """
         Fetches human-readable label corresponding to a single ontology term_id, if it is a term_id defined in one of the
          allowed_ontologies. Raises ValueError if no ontology term label is found (should've triggered validation
          error if term_id is not valid).
 
+        When stripped_prefixes is provided, terms matching a configured prefix (e.g. "anti-" for UniProt) are
+        stripped before lookup and the prefix is prepended to the returned label
+        (e.g. "anti-uniprot:Q99467" → "anti-" + label("uniprot:Q99467") = "anti-CD180_HUMAN").
+
         :param term_id: str single ontology term ID
         :param allowed_ontologies: List[str] list of ontologies to check for term_id label in
+        :param stripped_prefixes: Optional[dict] prefix stripping rules from curie_constraints,
+            e.g. {"UniProt": ["anti-"]}
         :return: str term label
         """
+        label_prefix = ""
+        term_to_look_up = term_id
+        if stripped_prefixes:
+            for _, prefixes in stripped_prefixes.items():
+                for prefix in prefixes:
+                    if term_id.startswith(prefix):
+                        label_prefix = prefix
+                        term_to_look_up = term_id[len(prefix) :]
+                        break
+                if label_prefix:
+                    break
+
         for ontology_name in allowed_ontologies:
             if ontology_name == "NA":
                 continue
-            elif ONTOLOGY_PARSER.is_valid_term_id(term_id, ontology_name):
-                return ONTOLOGY_PARSER.get_term_label(term_id)
+            elif ONTOLOGY_PARSER.is_valid_term_id(term_to_look_up, ontology_name):
+                return label_prefix + ONTOLOGY_PARSER.get_term_label(term_to_look_up)
         raise ValueError(f"Add labels error: Unable to get label for '{term_id}'")
 
     def _get_mapping_dict_curie(self, ids: List[str], curie_constraints: dict) -> Dict[str, str]:
@@ -131,6 +151,7 @@ class AnnDataLabelAppender:
         allowed_ontologies = curie_constraints["ontologies"]
         multi_term_def = curie_constraints.get("multi_term")
         delimiter = None if multi_term_def is None else multi_term_def["delimiter"]
+        stripped_prefixes = curie_constraints.get("stripped_prefixes")
 
         # Map term_ids to their human-readable ontology labels
         for term_id in ids:
@@ -140,10 +161,13 @@ class AnnDataLabelAppender:
                 continue
 
             if delimiter is not None:
-                labels = [self._get_ontology_term_label(term, allowed_ontologies) for term in term_id.split(delimiter)]
+                labels = [
+                    self._get_ontology_term_label(term, allowed_ontologies, stripped_prefixes)
+                    for term in term_id.split(delimiter)
+                ]
                 mapping_dict[term_id] = delimiter.join(labels)
             else:
-                mapping_dict[term_id] = self._get_ontology_term_label(term_id, allowed_ontologies)
+                mapping_dict[term_id] = self._get_ontology_term_label(term_id, allowed_ontologies, stripped_prefixes)
 
         return mapping_dict
 
@@ -333,8 +357,12 @@ class AnnDataLabelAppender:
 
             # Doing it for columns
             if "columns" in self.schema_def["components"][component]:
+                component_df = getattr_anndata(self.adata, component)
                 for column, column_def in self.schema_def["components"][component]["columns"].items():
                     if "add_labels" in column_def:
+                        # Skip optional columns that are not present in the dataframe
+                        if not column_def.get("required", True) and column not in component_df.columns:
+                            continue
                         self._add_column(component, column, column_def)
 
             # Doing it for index
@@ -363,6 +391,72 @@ class AnnDataLabelAppender:
             col = df[column]
             if col.dtype == "category":
                 df[column] = col.cat.remove_unused_categories()
+
+    def _get_perturbation_types_for_obs(self, ec_val: Optional[str], gp_val: Optional[str]) -> str:
+        """
+        Derive the perturbation_types value for a single observation.
+
+        :param ec_val: value of experimental_condition_ontology_term_id, or None if absent
+        :param gp_val: value of genetic_perturbation_id, or None if absent
+        :return: "no perturbations" or sorted " || "-delimited perturbation type set
+        """
+        DIET_ONTO_TERM = "EFO:0002755"
+        TEMPERATURE_ONTO_TERM = "EFO:0001702"
+
+        ec_is_na = ec_val is None or ec_val == "na"
+        gp_is_na = gp_val is None or gp_val == "na"
+
+        if ec_is_na and gp_is_na:
+            return "no perturbations"
+
+        types: set = set()
+        delimiter = " || "
+
+        if not ec_is_na:
+            for term in ec_val.split(delimiter):
+                if term.startswith("CHEBI:"):
+                    types.add("chemical")
+                elif term.startswith("uniprot:") or term.startswith("anti-uniprot:"):
+                    types.add("protein")
+                elif term == TEMPERATURE_ONTO_TERM:
+                    types.add("temperature")
+                elif term.startswith("EFO:"):
+                    ancestors = ONTOLOGY_PARSER.get_term_ancestors(term, include_self=True)
+                    if DIET_ONTO_TERM in ancestors:
+                        types.add("diet")
+
+        if not gp_is_na:
+            types.add("genetic")
+
+        return delimiter.join(sorted(types)) if types else "no perturbations"
+
+    def _annotate_perturbation_types(self):
+        """
+        Add obs['perturbation_types'] when experimental_condition_ontology_term_id or
+        genetic_perturbation_id is present in obs.
+
+        perturbation_types is a cross-column derivation (depends on both
+        experimental_condition_ontology_term_id and genetic_perturbation_id) that cannot be expressed
+        as a single-source add_labels entry, so it is handled here explicitly.
+        """
+        obs = self.adata.obs
+        has_ec = "experimental_condition_ontology_term_id" in obs.columns
+        has_gp = "genetic_perturbation_id" in obs.columns
+
+        if not has_ec and not has_gp:
+            return
+
+        ec_vals = obs["experimental_condition_ontology_term_id"].astype(str) if has_ec else None
+        gp_vals = obs["genetic_perturbation_id"].astype(str) if has_gp else None
+
+        # Only compute once per unique (ec_val, gp_val) pair for efficiency
+        iter_ec = ec_vals if ec_vals is not None else (["na"] * len(obs))
+        iter_gp = gp_vals if gp_vals is not None else (["na"] * len(obs))
+        unique_combos = set(zip(iter_ec, iter_gp))
+        combo_to_type = {(ec, gp): self._get_perturbation_types_for_obs(ec, gp) for ec, gp in unique_combos}
+
+        pt_values = [combo_to_type[(ec, gp)] for ec, gp in zip(iter_ec, iter_gp)]
+        obs["perturbation_types"] = pd.Categorical(pt_values)
 
     def _annotate_genetic_perturbations(self):
         """
@@ -401,6 +495,9 @@ class AnnDataLabelAppender:
 
         # Add columns to dataset dataframes based on values in other columns, as defined in schema definition yaml
         self._add_labels()
+
+        # Annotate perturbation_types (cross-column derivation from ec and gp fields)
+        self._annotate_perturbation_types()
 
         # Annotate genetic perturbations if present
         self._annotate_genetic_perturbations()

--- a/cellxgene_schema_cli/cellxgene_schema_definition.json
+++ b/cellxgene_schema_cli/cellxgene_schema_definition.json
@@ -381,6 +381,10 @@
           "type": "object",
           "description": "For dictionary fields, specification for key names and their nested field specifications",
           "additionalProperties": {"$ref": "#/$defs/field_specification"}
+        },
+        "forbidden_when_all_na": {
+          "type": "boolean",
+          "description": "If true, the column must not be present when all values are 'na'"
         }
       },
       "additionalProperties": false
@@ -406,6 +410,14 @@
           "type": "array",
           "description": "Special string values that are allowed (e.g., 'unknown', 'na')",
           "items": {"type": "string"}
+        },
+        "stripped_prefixes": {
+          "type": "object",
+          "description": "Per-ontology label prefixes to strip before ontology validation. The prefix is retained in error messages and prepended to labels (e.g. {\"UniProt\": [\"anti-\"]} strips 'anti-' from 'anti-uniprot:X' before validating against UniProt).",
+          "additionalProperties": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
         },
         "multi_term": {
           "type": "object",

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -1,5 +1,5 @@
 anndata==0.11.4
-cellxgene-ontology-guide==1.9.0
+cellxgene-ontology-guide==1.10.0
 click<9
 Cython<4
 dask[array, dataframe]==2024.12.0

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -1162,3 +1162,206 @@ adata_gene_perturbations_invalid_obs_without_uns = anndata.AnnData(
     obsm=good_obsm,
     var=good_var,
 )
+
+# -----------------------------------------------------------------#
+# Experimental condition fixtures (schema 7.1.0)
+
+# -------------------------
+# Valid: single CHEBI term (aspirin = chemical perturbation)
+good_obs_ec_chebi = good_obs.copy()
+good_obs_ec_chebi["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["CHEBI:15365", "CHEBI:15365"],
+    categories=["CHEBI:15365"],
+)
+
+adata_ec_valid_chebi = anndata.AnnData(X=X.copy(), obs=good_obs_ec_chebi, uns=good_uns, obsm=good_obsm, var=good_var)
+adata_ec_valid_chebi.raw = adata_ec_valid_chebi.copy()
+adata_ec_valid_chebi.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Valid: anti-uniprot protein term (antibody)
+good_obs_ec_anti_uniprot = good_obs.copy()
+good_obs_ec_anti_uniprot["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["anti-uniprot:Q99467", "anti-uniprot:Q99467"],
+    categories=["anti-uniprot:Q99467"],
+)
+
+adata_ec_valid_anti_uniprot = anndata.AnnData(
+    X=X.copy(), obs=good_obs_ec_anti_uniprot, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_valid_anti_uniprot.raw = adata_ec_valid_anti_uniprot.copy()
+adata_ec_valid_anti_uniprot.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Valid: uniprot protein term (no anti- prefix)
+good_obs_ec_uniprot = good_obs.copy()
+good_obs_ec_uniprot["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["uniprot:Q99467", "uniprot:Q99467"],
+    categories=["uniprot:Q99467"],
+)
+
+adata_ec_valid_uniprot = anndata.AnnData(
+    X=X.copy(), obs=good_obs_ec_uniprot, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_valid_uniprot.raw = adata_ec_valid_uniprot.copy()
+adata_ec_valid_uniprot.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Valid: EFO:0001702 temperature term
+good_obs_ec_temperature = good_obs.copy()
+good_obs_ec_temperature["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["EFO:0001702", "EFO:0001702"],
+    categories=["EFO:0001702"],
+)
+
+adata_ec_valid_temperature = anndata.AnnData(
+    X=X.copy(), obs=good_obs_ec_temperature, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_valid_temperature.raw = adata_ec_valid_temperature.copy()
+adata_ec_valid_temperature.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Valid: EFO:0002755 diet root term
+good_obs_ec_diet_root = good_obs.copy()
+good_obs_ec_diet_root["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["EFO:0002755", "EFO:0002755"],
+    categories=["EFO:0002755"],
+)
+
+adata_ec_valid_diet_root = anndata.AnnData(
+    X=X.copy(), obs=good_obs_ec_diet_root, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_valid_diet_root.raw = adata_ec_valid_diet_root.copy()
+adata_ec_valid_diet_root.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Valid: EFO:0002757 (a descendant of diet EFO:0002755)
+good_obs_ec_diet_desc = good_obs.copy()
+good_obs_ec_diet_desc["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["EFO:0002757", "EFO:0002757"],
+    categories=["EFO:0002757"],
+)
+
+adata_ec_valid_diet_descendant = anndata.AnnData(
+    X=X.copy(), obs=good_obs_ec_diet_desc, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_valid_diet_descendant.raw = adata_ec_valid_diet_descendant.copy()
+adata_ec_valid_diet_descendant.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Valid: multi-term sorted " || " (CHEBI + EFO:0002755)
+good_obs_ec_multi = good_obs.copy()
+good_obs_ec_multi["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["CHEBI:15365 || EFO:0002755", "CHEBI:15365 || EFO:0002755"],
+    categories=["CHEBI:15365 || EFO:0002755"],
+)
+
+adata_ec_valid_multi = anndata.AnnData(X=X.copy(), obs=good_obs_ec_multi, uns=good_uns, obsm=good_obsm, var=good_var)
+adata_ec_valid_multi.raw = adata_ec_valid_multi.copy()
+adata_ec_valid_multi.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Valid: absent (column not present) — field is not required
+adata_ec_absent = adata  # reuse base adata without the column
+
+# -------------------------
+# Valid: all "na" values — column absent is preferred but this must fail
+# (forbidden_when_all_na)
+bad_obs_ec_all_na = good_obs.copy()
+bad_obs_ec_all_na["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["na", "na"],
+    categories=["na"],
+)
+
+adata_ec_invalid_all_na = anndata.AnnData(X=X.copy(), obs=bad_obs_ec_all_na, uns=good_uns, obsm=good_obsm, var=good_var)
+adata_ec_invalid_all_na.raw = adata_ec_invalid_all_na.copy()
+adata_ec_invalid_all_na.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Invalid: forbidden CHEBI term (CHEBI:23367 = molecular entity)
+bad_obs_ec_forbidden_chebi = good_obs.copy()
+bad_obs_ec_forbidden_chebi["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["CHEBI:23367", "CHEBI:23367"],
+    categories=["CHEBI:23367"],
+)
+
+adata_ec_invalid_forbidden_chebi = anndata.AnnData(
+    X=X.copy(), obs=bad_obs_ec_forbidden_chebi, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_invalid_forbidden_chebi.raw = adata_ec_invalid_forbidden_chebi.copy()
+adata_ec_invalid_forbidden_chebi.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Invalid: EFO term that is not allowed (not EFO:0001702 / not a diet descendant)
+bad_obs_ec_efo_not_allowed = good_obs.copy()
+bad_obs_ec_efo_not_allowed["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["EFO:0009899", "EFO:0009899"],  # 10x 3' v2 assay — valid EFO but not allowed here
+    categories=["EFO:0009899"],
+)
+
+adata_ec_invalid_efo_not_allowed = anndata.AnnData(
+    X=X.copy(), obs=bad_obs_ec_efo_not_allowed, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_invalid_efo_not_allowed.raw = adata_ec_invalid_efo_not_allowed.copy()
+adata_ec_invalid_efo_not_allowed.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Invalid: multi-term unsorted
+bad_obs_ec_unsorted = good_obs.copy()
+bad_obs_ec_unsorted["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["EFO:0002755 || CHEBI:15365", "EFO:0002755 || CHEBI:15365"],  # unsorted (should be CHEBI first)
+    categories=["EFO:0002755 || CHEBI:15365"],
+)
+
+adata_ec_invalid_multi_unsorted = anndata.AnnData(
+    X=X.copy(), obs=bad_obs_ec_unsorted, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_invalid_multi_unsorted.raw = adata_ec_invalid_multi_unsorted.copy()
+adata_ec_invalid_multi_unsorted.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Invalid: reserved column 'experimental_condition' manually set by curator
+bad_obs_ec_reserved = good_obs.copy()
+bad_obs_ec_reserved["experimental_condition"] = pd.Categorical(
+    ["some label", "some label"],
+    categories=["some label"],
+)
+
+adata_ec_invalid_reserved_label_column = anndata.AnnData(
+    X=X.copy(), obs=bad_obs_ec_reserved, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_invalid_reserved_label_column.raw = adata_ec_invalid_reserved_label_column.copy()
+adata_ec_invalid_reserved_label_column.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Invalid: reserved column 'perturbation_types' manually set by curator
+bad_obs_perturbation_types_reserved = good_obs.copy()
+bad_obs_perturbation_types_reserved["perturbation_types"] = pd.Categorical(
+    ["chemical", "chemical"],
+    categories=["chemical"],
+)
+
+adata_ec_invalid_reserved_perturbation_types = anndata.AnnData(
+    X=X.copy(), obs=bad_obs_perturbation_types_reserved, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_invalid_reserved_perturbation_types.raw = adata_ec_invalid_reserved_perturbation_types.copy()
+adata_ec_invalid_reserved_perturbation_types.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Valid: experimental_condition_ontology_term_id + genetic_perturbation_id together
+# (used for perturbation_types derivation: chemical + genetic)
+good_obs_ec_and_gp = good_obs_gene_perturbations.copy()
+good_obs_ec_and_gp["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["CHEBI:15365", "CHEBI:15365"],
+    categories=["CHEBI:15365"],
+)
+
+adata_ec_valid_with_gp = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_ec_and_gp,
+    uns=good_uns_with_gene_perturbations_curator,
+    obsm=good_obsm,
+    var=good_var,
+)
+adata_ec_valid_with_gp.raw = adata_ec_valid_with_gp.copy()
+adata_ec_valid_with_gp.raw.var.drop("feature_is_filtered", axis=1, inplace=True)

--- a/cellxgene_schema_cli/tests/test_experimental_condition.py
+++ b/cellxgene_schema_cli/tests/test_experimental_condition.py
@@ -1,0 +1,237 @@
+"""
+Tests for schema 7.1.0 experimental_condition fields:
+  - experimental_condition_ontology_term_id (curator-annotated, optional)
+  - experimental_condition (Discover-annotated label, reserved)
+  - perturbation_types (Discover-annotated, cross-column derived, reserved)
+"""
+
+import tempfile
+
+from cellxgene_schema.validate import validate
+from cellxgene_schema.write_labels import AnnDataLabelAppender
+from fixtures.examples_validate import (
+    adata_ec_absent,
+    adata_ec_invalid_all_na,
+    adata_ec_invalid_efo_not_allowed,
+    adata_ec_invalid_forbidden_chebi,
+    adata_ec_invalid_multi_unsorted,
+    adata_ec_invalid_reserved_label_column,
+    adata_ec_invalid_reserved_perturbation_types,
+    adata_ec_valid_anti_uniprot,
+    adata_ec_valid_chebi,
+    adata_ec_valid_diet_descendant,
+    adata_ec_valid_diet_root,
+    adata_ec_valid_multi,
+    adata_ec_valid_temperature,
+    adata_ec_valid_uniprot,
+    adata_ec_valid_with_gp,
+    adata_gene_perturbations,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate(adata):
+    with tempfile.TemporaryDirectory() as tmp:
+        p = tmp + "/temp.h5ad"
+        adata.copy().write_h5ad(p, compression="gzip")
+        success, errors, _ = validate(p)
+        return success, errors
+
+
+def _write_labels(adata):
+    import anndata as ad
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = tmp + "/labeled.h5ad"
+        appender = AnnDataLabelAppender(adata.copy())
+        appender.write_labels(out)
+        return ad.read_h5ad(out)
+
+
+# ---------------------------------------------------------------------------
+# Validation — valid cases
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentalConditionValid:
+    def test_absent_column_is_valid(self):
+        """Field is optional; omitting it entirely must pass validation."""
+        success, errors = _validate(adata_ec_absent)
+        assert success, errors
+
+    def test_chebi_term(self):
+        success, errors = _validate(adata_ec_valid_chebi)
+        assert success, errors
+
+    def test_anti_uniprot_term(self):
+        """anti-uniprot: prefix should be stripped before ontology validation."""
+        success, errors = _validate(adata_ec_valid_anti_uniprot)
+        assert success, errors
+
+    def test_uniprot_term(self):
+        success, errors = _validate(adata_ec_valid_uniprot)
+        assert success, errors
+
+    def test_temperature_term(self):
+        success, errors = _validate(adata_ec_valid_temperature)
+        assert success, errors
+
+    def test_diet_root_term(self):
+        success, errors = _validate(adata_ec_valid_diet_root)
+        assert success, errors
+
+    def test_diet_descendant_term(self):
+        success, errors = _validate(adata_ec_valid_diet_descendant)
+        assert success, errors
+
+    def test_multi_term_sorted(self):
+        success, errors = _validate(adata_ec_valid_multi)
+        assert success, errors
+
+    def test_ec_with_genetic_perturbation(self):
+        """ec + gp together must be valid (perturbation_types will be derived)."""
+        success, errors = _validate(adata_ec_valid_with_gp)
+        assert success, errors
+
+
+# ---------------------------------------------------------------------------
+# Validation — invalid cases
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentalConditionInvalid:
+    def test_all_na_forbidden(self):
+        """Column present with every row == 'na' must fail (forbidden_when_all_na)."""
+        success, errors = _validate(adata_ec_invalid_all_na)
+        assert not success
+        assert any("experimental_condition_ontology_term_id" in e for e in errors)
+
+    def test_forbidden_chebi_term(self):
+        """CHEBI:23367 (molecular entity) is explicitly forbidden."""
+        success, errors = _validate(adata_ec_invalid_forbidden_chebi)
+        assert not success
+        assert any("CHEBI:23367" in e for e in errors)
+
+    def test_efo_term_not_in_allowed_list(self):
+        """An EFO term that is neither EFO:0001702 nor a diet descendant is not allowed."""
+        success, errors = _validate(adata_ec_invalid_efo_not_allowed)
+        assert not success
+        assert any("EFO:0009899" in e for e in errors)
+
+    def test_multi_term_unsorted(self):
+        """Multi-term values must be in sorted order."""
+        success, errors = _validate(adata_ec_invalid_multi_unsorted)
+        assert not success
+
+    def test_reserved_experimental_condition_column(self):
+        """Curator must not manually set obs['experimental_condition'] (it is reserved)."""
+        success, errors = _validate(adata_ec_invalid_reserved_label_column)
+        assert not success
+        assert any("experimental_condition" in e for e in errors)
+
+    def test_reserved_perturbation_types_column(self):
+        """Curator must not manually set obs['perturbation_types'] (it is reserved)."""
+        success, errors = _validate(adata_ec_invalid_reserved_perturbation_types)
+        assert not success
+        assert any("perturbation_types" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Label writing — experimental_condition label column
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentalConditionLabels:
+    def test_chebi_label_added(self):
+        """write_labels should add obs['experimental_condition'] with human-readable label."""
+        labeled = _write_labels(adata_ec_valid_chebi)
+        assert "experimental_condition" in labeled.obs.columns
+        assert labeled.obs["experimental_condition"].iloc[0] == "acetylsalicylic acid"
+
+    def test_anti_uniprot_label_prefixed(self):
+        """anti- prefix must be retained in the label (anti-CD180_HUMAN)."""
+        labeled = _write_labels(adata_ec_valid_anti_uniprot)
+        assert "experimental_condition" in labeled.obs.columns
+        assert labeled.obs["experimental_condition"].iloc[0] == "anti-CD180_HUMAN"
+
+    def test_uniprot_label_added(self):
+        labeled = _write_labels(adata_ec_valid_uniprot)
+        assert "experimental_condition" in labeled.obs.columns
+        assert labeled.obs["experimental_condition"].iloc[0] == "CD180_HUMAN"
+
+    def test_absent_column_no_label_added(self):
+        """If experimental_condition_ontology_term_id is absent, no label column should be added."""
+        labeled = _write_labels(adata_ec_absent)
+        assert "experimental_condition" not in labeled.obs.columns
+
+    def test_multi_term_label(self):
+        """Multi-term values should produce ' || '-joined labels."""
+        labeled = _write_labels(adata_ec_valid_multi)
+        label = labeled.obs["experimental_condition"].iloc[0]
+        assert " || " in label
+        assert "acetylsalicylic acid" in label
+        assert "diet" in label
+
+
+# ---------------------------------------------------------------------------
+# Label writing — perturbation_types derivation
+# ---------------------------------------------------------------------------
+
+
+class TestPerturbationTypesLabels:
+    def test_no_perturbation_columns_no_perturbation_types(self):
+        """Without ec or gp columns, perturbation_types must not be added."""
+        labeled = _write_labels(adata_ec_absent)
+        assert "perturbation_types" not in labeled.obs.columns
+
+    def test_chebi_ec_gives_chemical_type(self):
+        labeled = _write_labels(adata_ec_valid_chebi)
+        assert "perturbation_types" in labeled.obs.columns
+        assert labeled.obs["perturbation_types"].iloc[0] == "chemical"
+
+    def test_anti_uniprot_ec_gives_protein_type(self):
+        labeled = _write_labels(adata_ec_valid_anti_uniprot)
+        assert "perturbation_types" in labeled.obs.columns
+        assert labeled.obs["perturbation_types"].iloc[0] == "protein"
+
+    def test_uniprot_ec_gives_protein_type(self):
+        labeled = _write_labels(adata_ec_valid_uniprot)
+        assert "perturbation_types" in labeled.obs.columns
+        assert labeled.obs["perturbation_types"].iloc[0] == "protein"
+
+    def test_temperature_ec_gives_temperature_type(self):
+        labeled = _write_labels(adata_ec_valid_temperature)
+        assert "perturbation_types" in labeled.obs.columns
+        assert labeled.obs["perturbation_types"].iloc[0] == "temperature"
+
+    def test_diet_ec_gives_diet_type(self):
+        labeled = _write_labels(adata_ec_valid_diet_root)
+        assert "perturbation_types" in labeled.obs.columns
+        assert labeled.obs["perturbation_types"].iloc[0] == "diet"
+
+    def test_diet_descendant_gives_diet_type(self):
+        labeled = _write_labels(adata_ec_valid_diet_descendant)
+        assert "perturbation_types" in labeled.obs.columns
+        assert labeled.obs["perturbation_types"].iloc[0] == "diet"
+
+    def test_gp_only_gives_genetic_type(self):
+        labeled = _write_labels(adata_gene_perturbations)
+        assert "perturbation_types" in labeled.obs.columns
+        assert all(labeled.obs["perturbation_types"] == "genetic")
+
+    def test_ec_and_gp_gives_combined_type(self):
+        """CHEBI ec + genetic gp should produce 'chemical || genetic'."""
+        labeled = _write_labels(adata_ec_valid_with_gp)
+        assert "perturbation_types" in labeled.obs.columns
+        pt = labeled.obs["perturbation_types"].iloc[0]
+        assert pt == "chemical || genetic"
+
+    def test_multi_ec_gives_multiple_types(self):
+        """CHEBI + diet ec should give 'chemical || diet'."""
+        labeled = _write_labels(adata_ec_valid_multi)
+        assert "perturbation_types" in labeled.obs.columns
+        pt = labeled.obs["perturbation_types"].iloc[0]
+        assert pt == "chemical || diet"


### PR DESCRIPTION
## Reason for Change

- https://czi.atlassian.net/browse/VC-5249

## Changes

- Bump cellxgene-ontology-guide to 1.10.0 and update OntologyParser to schema v7.1.0
- Add experimental_condition_ontology_term_id to obs: optional curie field accepting CHEBI, EFO (temperature/diet), and UniProt/anti-UniProt terms with forbidden term lists and multi-term support
- Generalise curie validation via stripped_prefixes in schema_definition.yaml so anti-uniprot: terms are validated against the underlying UniProt term while preserving the prefix in labels
- Add forbidden_when_all_na schema key so a column present with all-na values fails validation
- Reserve experimental_condition and perturbation_types in obs.reserved_columns
- write_labels adds experimental_condition label column (with anti- prefix re-prepended)
- write_labels derives perturbation_types cross-column from experimental_condition_ontology_term_id and genetic_perturbation_id (chemical / protein / temperature / diet / genetic)
- Add stripped_prefixes and forbidden_when_all_na to cellxgene_schema_definition.json
- Add 30 tests covering validation and label-writing for all new fields
