### PR TITLE
fix: skip pre-analysis-forbidden fields in AnnDataLabelAppender._add_labels

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -350,18 +350,29 @@ class AnnDataLabelAppender:
         """
         Add columns to dataset dataframes based on values in other columns, as defined in schema definition yaml.
         """
+        pre_analysis_constraints = self.schema_def.get("pre_analysis", {}) if self.pre_analysis else {}
+
         for component in ["obs", "var", "raw.var"]:
             # If the component does not exist, skip (this is for raw.var)
             if getattr_anndata(self.adata, component) is None:
                 continue
 
+            # Skip components not allowed in pre-analysis mode (e.g. obsm)
+            comp_pa = pre_analysis_constraints.get(component, {})
+            if not comp_pa.get("allowed", True):
+                continue
+
             # Doing it for columns
             if "columns" in self.schema_def["components"][component]:
                 component_df = getattr_anndata(self.adata, component)
+                pa_forbidden_keys = {k for k, v in comp_pa.get("keys", {}).items() if not v.get("allowed", True)}
                 for column, column_def in self.schema_def["components"][component]["columns"].items():
                     if "add_labels" in column_def:
                         # Skip optional columns that are not present in the dataframe
                         if not column_def.get("required", True) and column not in component_df.columns:
+                            continue
+                        # Skip columns explicitly forbidden in pre-analysis mode
+                        if column in pa_forbidden_keys:
                             continue
                         self._add_column(component, column, column_def)
 
@@ -371,9 +382,15 @@ class AnnDataLabelAppender:
                 self._add_column(component, "index", index_def)
 
         uns_def = self.schema_def["components"]["uns"]
+        uns_pa_forbidden_keys = {
+            k for k, v in pre_analysis_constraints.get("uns", {}).get("keys", {}).items() if not v.get("allowed", True)
+        }
         for key in uns_def["keys"]:
             key_def = uns_def["keys"][key]
             if "add_labels" in key_def:
+                # Skip uns keys explicitly forbidden in pre-analysis mode (e.g. default_embedding)
+                if key in uns_pa_forbidden_keys:
+                    continue
                 label_type = key_def["add_labels"][0]["type"]
                 if label_type == "curie":
                     label_to_write = key_def["add_labels"][0]["to_key"]

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -62,7 +62,7 @@ def validator_with_minimal_adata():
 
 @pytest.fixture
 def label_writer(valid_adata):
-    return AnnDataLabelAppender(adata_valid)
+    return AnnDataLabelAppender(valid_adata)
 
 
 @pytest.fixture
@@ -334,7 +334,7 @@ class TestAddLabelFunctions:
     def test__write__pre_analysis_adata_skips_forbidden_fields(self, valid_pre_analysis_adata):
         """
         write_labels with a pre-analysis-shaped adata (no cell_type_ontology_term_id,
-        no obsm, no default_embedding) must not crash and must not add the
+        no obsm, no uns['default_embedding']) must not crash and must not add the
         cell_type label column.
         """
         writer = AnnDataLabelAppender(valid_pre_analysis_adata, pre_analysis=True)

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -331,6 +331,22 @@ class TestAddLabelFunctions:
             writer.write_labels(labels_path)
         assert writer.adata.uns["is_pre_analysis"] is True
 
+    def test__write__pre_analysis_adata_skips_forbidden_fields(self, valid_pre_analysis_adata):
+        """
+        write_labels with a pre-analysis-shaped adata (no cell_type_ontology_term_id,
+        no obsm, no default_embedding) must not crash and must not add the
+        cell_type label column.
+        """
+        writer = AnnDataLabelAppender(valid_pre_analysis_adata, pre_analysis=True)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            labels_path = "/".join([temp_dir, "labels.h5ad"])
+            result = writer.write_labels(labels_path)
+        assert result
+        assert not writer.errors
+        assert writer.adata.uns["is_pre_analysis"] is True
+        assert "cell_type_ontology_term_id" not in writer.adata.obs.columns
+        assert "cell_type" not in writer.adata.obs.columns
+
     def test__write__Fail(self, label_writer):
         label_writer.adata.write_h5ad = mock.Mock(side_effect=Exception("Test Fail"))
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
When pre_analysis=True, _add_labels now reads the pre_analysis constraints from the schema definition to skip columns/keys that are not allowed (cell_type_ontology_term_id in obs, default_embedding in uns, obsm). Previously the required-column guard did not skip these, causing an AttributeError when the caller passed a pre-analysis-shaped adata that had those fields removed.

Adds test_write__pre_analysis_adata_skips_forbidden_fields which would have caught the regression.