### PR TITLE
fix: close validation gaps in genetic_perturbations (schema 7.1.0)

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -110,6 +110,10 @@ components:
       genetic_perturbations:
         type: dict
         required: False
+        # The literal string "na" is reserved to mean "no perturbation" in obs and MUST NOT be used
+        # as a perturbation identifier key.
+        forbidden_keys:
+          - na
         dependencies:
           - # if obs['genetic_perturbation_id'] is present
             rule:
@@ -123,6 +127,9 @@ components:
           genetic_perturbation_ids:
             key_pattern: '^[^\s/,"'']+$'  # No whitespace, slash, comma, double or single quotes
             type: dict
+            # No keys beyond role/protospacer_sequence/protospacer_adjacent_motif (curator-supplied)
+            # and derived_genomic_regions/derived_features (Discover-reserved) are permitted.
+            no_additional_keys: true
             keys:
               role:
                 type: string
@@ -898,6 +905,10 @@ components:
           - CRISPR knockout mutant
           - CRISPR knockout screen
         dependencies:
+          - # MUST NOT be present when genetic_perturbation_id is absent (schema: "MUST NOT be present otherwise")
+            rule:
+              exclude_obs_key: genetic_perturbation_id
+            type: forbidden
           - # If obs['genetic_perturbation_id'] == 'na' then strategy MUST be 'no perturbations'
             rule:
               column: genetic_perturbation_id

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1154,6 +1154,14 @@ class Validator:
                 else:
                     explicit_keys.add(schema_key)
 
+        # Enforce forbidden_keys: specific literal key names that must not appear in this dict.
+        for forbidden_key in dict_def.get("forbidden_keys", []):
+            if forbidden_key in dictionary:
+                self.errors.append(
+                    f"Key '{forbidden_key}' MUST NOT be present in '{dict_name}'. "
+                    f"Remove it from the h5ad and try again."
+                )
+
         for k in dictionary:
             if k not in explicit_keys:
                 # Check if this dictionary key matches any pattern (in schema order)
@@ -1166,8 +1174,8 @@ class Validator:
                 # Validate against pattern definition if matched, otherwise ignore
                 if matched_pattern_key is not None and isinstance(keys_def, dict) and matched_pattern_key in keys_def:
                     _validate(k, dict_name, keys_def[matched_pattern_key])
-            else:  # If no pattern matched and not explicit, ignore the key
-                # Explicit key - validate it
+            else:
+                # k is an explicit key — validate it
                 if isinstance(keys_def, dict) and k in keys_def:
                     _validate(k, dict_name, keys_def[k])
 
@@ -1176,6 +1184,24 @@ class Validator:
             for schema_key in explicit_keys:
                 if schema_key not in dictionary and schema_key in keys_def:
                     _validate(schema_key, dict_name, keys_def[schema_key])
+
+        # Enforce no_additional_keys: every key in the dictionary must be either an explicit schema
+        # key, match a key_pattern, or appear in reserved_keys (reserved keys are already caught
+        # separately as a distinct error, so they are excluded here to avoid double-reporting).
+        if dict_def.get("no_additional_keys"):
+            reserved = set(dict_def.get("reserved_keys", []))
+            extra = set()
+            for k in dictionary:
+                if k in explicit_keys or k in reserved:
+                    continue
+                if any(compiled_pattern.fullmatch(k) for compiled_pattern in key_patterns.values()):
+                    continue
+                extra.add(k)
+            if extra:
+                self.errors.append(
+                    f"'{dict_name}' contains unexpected key(s) {sorted(extra)}. "
+                    f"Additional key-value pairs MUST NOT be present."
+                )
 
     def _validate_dataframe(self, df_name: str):
         """
@@ -1597,10 +1623,15 @@ class Validator:
         gp_id_col_def = self._get_column_def("obs", "genetic_perturbation_id")
         delimiter = gp_id_col_def["multi_term"]["delimiter"]
 
-        for _, row in obs.iterrows():
-            gid = row.get("genetic_perturbation_id")
-            strat = row.get("genetic_perturbation_strategy")
-            gid_str = str(gid)
+        # Operate on unique (gid, strategy) pairs rather than every obs row. Both columns are
+        # categorical, so the deduplicated set is bounded by the number of distinct perturbation
+        # combinations rather than the number of cells. This avoids O(N) iteration and ensures
+        # each validation error is only reported once regardless of how many cells share a value.
+        unique_pairs = obs[["genetic_perturbation_id", "genetic_perturbation_strategy"]].drop_duplicates()
+
+        for _, row in unique_pairs.iterrows():
+            gid_str = str(row["genetic_perturbation_id"])
+            strat = row["genetic_perturbation_strategy"]
 
             # 'na' is valid and means no perturbation for this cell; skip multi-term checks
             if gid_str == "na":

--- a/cellxgene_schema_cli/cellxgene_schema_definition.json
+++ b/cellxgene_schema_cli/cellxgene_schema_definition.json
@@ -377,6 +377,10 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "no_additional_keys": {
+          "type": "boolean",
+          "description": "If true, keys beyond those declared in 'keys', 'reserved_keys', and matching 'key_pattern' are forbidden"
+        },
         "keys": {
           "type": "object",
           "description": "For dictionary fields, specification for key names and their nested field specifications",

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -1137,6 +1137,88 @@ adata_gene_perturbations_invalid_obs_without_uns = anndata.AnnData(
     var=good_var,
 )
 
+# -------------------------
+# Invalid: uns['genetic_perturbations'] uses "na" as a perturbation identifier key.
+# The literal string "na" is reserved (means "no perturbation" in obs) and MUST NOT be a key.
+bad_obs_na_key = good_obs.copy()
+bad_obs_na_key["genetic_perturbation_id"] = pd.Categorical(
+    ["na", "na"],
+    categories=["na"],
+)
+bad_obs_na_key["genetic_perturbation_strategy"] = pd.Categorical(
+    ["no perturbations", "no perturbations"],
+    categories=[
+        "control",
+        "CRISPR activation screen",
+        "CRISPR interference screen",
+        "CRISPR knockout mutant",
+        "CRISPR knockout screen",
+        "no perturbations",
+    ],
+)
+bad_uns_na_key = {
+    **good_uns,
+    "genetic_perturbations": {
+        "na": {
+            "role": "targeting",
+            "protospacer_sequence": "CAGAGGGAGGAGAGAACCG",
+            "protospacer_adjacent_motif": "3' NGG",
+        }
+    },
+}
+adata_gene_perturbations_invalid_na_key = anndata.AnnData(
+    X=X.copy(),
+    obs=bad_obs_na_key,
+    uns=bad_uns_na_key,
+    obsm=good_obsm,
+    var=good_var,
+)
+
+# -------------------------
+# Invalid: obs contains genetic_perturbation_strategy but genetic_perturbation_id is absent.
+# genetic_perturbation_strategy MUST NOT be present when genetic_perturbation_id is absent.
+bad_obs_strategy_without_id = good_obs.copy()
+bad_obs_strategy_without_id["genetic_perturbation_strategy"] = pd.Categorical(
+    ["CRISPR knockout screen", "CRISPR knockout screen"],
+    categories=[
+        "control",
+        "CRISPR activation screen",
+        "CRISPR interference screen",
+        "CRISPR knockout mutant",
+        "CRISPR knockout screen",
+        "no perturbations",
+    ],
+)
+adata_gene_perturbations_invalid_strategy_without_id = anndata.AnnData(
+    X=X.copy(),
+    obs=bad_obs_strategy_without_id,  # Has genetic_perturbation_strategy but NO genetic_perturbation_id
+    uns=good_uns,  # Does NOT have genetic_perturbations
+    obsm=good_obsm,
+    var=good_var,
+)
+
+# -------------------------
+# Invalid: a perturbation entry contains an unrecognised extra key.
+# Additional key-value pairs MUST NOT be present in genetic_perturbations[id].
+bad_uns_extra_key = {
+    **good_uns,
+    "genetic_perturbations": {
+        gp_id_1: {
+            "role": "targeting",
+            "protospacer_sequence": "CAGAGGGAGGAGAGAACCG",
+            "protospacer_adjacent_motif": "3' NGG",
+            "extra_annotation": "not_allowed",  # Unknown extra key
+        }
+    },
+}
+adata_gene_perturbations_invalid_extra_key = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_gene_perturbations.copy(),
+    uns=bad_uns_extra_key,
+    obsm=good_obsm,
+    var=good_var,
+)
+
 # -----------------------------------------------------------------#
 # Experimental condition fixtures (schema 7.1.0)
 

--- a/cellxgene_schema_cli/tests/test_genetic_perturbations.py
+++ b/cellxgene_schema_cli/tests/test_genetic_perturbations.py
@@ -10,6 +10,7 @@ from fixtures.examples_validate import (
     adata_gene_perturbations_invalid_contains_derived,
     adata_gene_perturbations_invalid_contains_derived_features,
     adata_gene_perturbations_invalid_control_role_mismatch,
+    adata_gene_perturbations_invalid_extra_key,
     adata_gene_perturbations_invalid_key_comma,
     adata_gene_perturbations_invalid_key_quote,
     adata_gene_perturbations_invalid_key_slash,
@@ -19,12 +20,14 @@ from fixtures.examples_validate import (
     adata_gene_perturbations_invalid_missing_pam,
     adata_gene_perturbations_invalid_missing_protospacer,
     adata_gene_perturbations_invalid_missing_role,
+    adata_gene_perturbations_invalid_na_key,
     adata_gene_perturbations_invalid_obs_without_uns,
     adata_gene_perturbations_invalid_pam_format,
     adata_gene_perturbations_invalid_protospacer_chars,
     adata_gene_perturbations_invalid_protospacer_long,
     adata_gene_perturbations_invalid_protospacer_short,
     adata_gene_perturbations_invalid_role_enum,
+    adata_gene_perturbations_invalid_strategy_without_id,
 )
 
 
@@ -69,6 +72,9 @@ def test_valid_gene_perturbations_control():
         adata_gene_perturbations_invalid_role_enum,
         adata_gene_perturbations_invalid_contains_derived_features,
         adata_gene_perturbations_invalid_obs_without_uns,
+        adata_gene_perturbations_invalid_na_key,
+        adata_gene_perturbations_invalid_strategy_without_id,
+        adata_gene_perturbations_invalid_extra_key,
     ],
 )
 def test_invalid_gene_perturbations(bad):
@@ -85,3 +91,24 @@ def test_invalid_gene_perturbations_missing_obs_columns():
         in error
         for error in errors
     )
+
+
+def test_invalid_gene_perturbations_na_key():
+    """uns['genetic_perturbations'] must not use 'na' as a perturbation identifier key."""
+    success, errors = _validate_adata(adata_gene_perturbations_invalid_na_key)
+    assert not success, f"Expected validation to fail but it succeeded. Errors: {errors}"
+    assert any("'na'" in error and "MUST NOT be present" in error for error in errors)
+
+
+def test_invalid_gene_perturbations_strategy_without_id():
+    """genetic_perturbation_strategy must not be present when genetic_perturbation_id is absent."""
+    success, errors = _validate_adata(adata_gene_perturbations_invalid_strategy_without_id)
+    assert not success, f"Expected validation to fail but it succeeded. Errors: {errors}"
+    assert any("genetic_perturbation_strategy" in error and "not present" in error for error in errors)
+
+
+def test_invalid_gene_perturbations_extra_key():
+    """Unknown extra keys in a genetic_perturbations entry must be rejected."""
+    success, errors = _validate_adata(adata_gene_perturbations_invalid_extra_key)
+    assert not success, f"Expected validation to fail but it succeeded. Errors: {errors}"
+    assert any("extra_annotation" in error and "MUST NOT be present" in error for error in errors)


### PR DESCRIPTION
Five bugs caught during review:

- Reject "na" as a perturbation identifier key in uns['genetic_perturbations'] (schema: "The key MUST NOT be 'na'"). Implemented via a new generic `forbidden_keys` list in schema_definition.yaml, enforced by _validate_dict.

- Reject obs['genetic_perturbation_strategy'] when obs['genetic_perturbation_id'] is absent (schema: "MUST NOT be present otherwise"). Implemented via a new `type: forbidden` / `exclude_obs_key` dependency in schema_definition.yaml, handled by the existing forbidden-column machinery in _validate_dataframe.

- Reject unknown extra keys in a genetic_perturbations[id] entry (schema: "Additional key-value pairs MUST NOT be present"). Implemented via a new generic `no_additional_keys` flag in schema_definition.yaml, enforced by _validate_dict using fullmatch against key_patterns to correctly handle both explicit and pattern-matched keys.

- Replace O(N) obs.iterrows() in _cross_validate_genetic_perturbations with drop_duplicates() over the two categorical columns. Errors are now emitted once per unique (gid, strategy) pair rather than once per cell.

- Fix misleading comment on the else branch of _validate_dict (line ~1177).

Tests: add three fixtures and four targeted test cases covering the new checks.