### PR TITLE
feat: add optional intended_features to genetic_perturbations

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/remove_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/remove_labels.py
@@ -76,13 +76,16 @@ class AnnDataLabelRemover:
                         if "reserved_keys" in key_def:
                             self._remove_reserved(component[key], key_def["reserved_keys"])
 
-        # Remove intended_features from each genetic_perturbation entry if present.
-        # This field is not part of the schema but may exist in legacy datasets.
+        # Reset intended_features values in each genetic_perturbation entry.
+        # write_labels populates each value with the feature name; remove_labels resets them
+        # to empty strings so the keys (curator-supplied) are preserved but the written labels
+        # are undone, restoring the artifact to a pre-write-labels state.
         genetic_perturbations = self.adata.uns.get("genetic_perturbations")
         if genetic_perturbations:
             for pert_data in genetic_perturbations.values():
-                if isinstance(pert_data, dict) and "intended_features" in pert_data:
-                    del pert_data["intended_features"]
+                if isinstance(pert_data, dict) and isinstance(pert_data.get("intended_features"), dict):
+                    for feature_id in pert_data["intended_features"]:
+                        pert_data["intended_features"][feature_id] = ""
 
     def _remove_reserved(self, component, reserved):
         """

--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -127,8 +127,9 @@ components:
           genetic_perturbation_ids:
             key_pattern: '^[^\s/,"'']+$'  # No whitespace, slash, comma, double or single quotes
             type: dict
-            # No keys beyond role/protospacer_sequence/protospacer_adjacent_motif (curator-supplied)
-            # and derived_genomic_regions/derived_features (Discover-reserved) are permitted.
+            # No keys beyond role/protospacer_sequence/protospacer_adjacent_motif/intended_features
+            # (curator-supplied) and derived_genomic_regions/derived_features (Discover-reserved)
+            # are permitted.
             no_additional_keys: true
             keys:
               role:
@@ -147,6 +148,21 @@ components:
                 required: True
                 # Format like: "3' NGG" where MOTIF uses allowed ambiguity codes
                 pattern: '^3'' [ABCDGHKMNRSTVWY]+$'
+              intended_features:
+                type: dict
+                required: False
+                # Each key MUST be a valid feature_id from the gene reference for the dataset organism.
+                # ENS-prefixed IDs must have version numbers removed (e.g. ENSG00000186092.7 -> ENSG00000186092).
+                # Values are feature_name (or feature_id if no name is assigned); populated by write_labels.
+                # Additional key-value pairs MUST NOT be present.
+                validate_keys_as: feature_id  # triggers generic feature-id key validation
+                add_labels:
+                  - type: feature_name  # populate each dict value with the feature name for its key
+                no_additional_keys: true
+                keys:
+                  feature_ids:
+                    key_pattern: '^\S+$'  # Non-whitespace; deep gene-reference validation done in code
+                    type: string
             reserved_keys:
               - derived_genomic_regions
               - derived_features
@@ -158,7 +174,7 @@ components:
       unique: true
       type: feature_id
       add_labels:
-        - type: feature_id
+        - type: feature_name
           to_column: feature_name
         - type: feature_reference
           to_column: feature_reference
@@ -189,7 +205,7 @@ components:
       unique: true
       type: feature_id
       add_labels:
-        - type: feature_id
+        - type: feature_name
           to_column: feature_name
         - type: feature_reference
           to_column: feature_reference

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -474,15 +474,18 @@ class Validator:
             if not is_allowed:
                 self.errors.append(f"'{term_id}' in '{column_name}' is not an allowed term id.")
 
-    def _validate_feature_ids(self, column: pd.Series, df_name: str):
+    def _validate_feature_ids(self, column, path: str):
         """
-        Validates all feature ids, i.e. checks that it's present in the reference
-        If there are any errors, it adds them to self.errors
+        Validates all feature IDs in ``column`` against the gene reference.
 
-        :param str column: feature_id column
-        :param str df_name: name of dataframe the feauter id comes from (var or raw.var)
+        Accepts any iterable of feature ID strings — a ``pd.Series``, ``dict.keys()``,
+        a list, etc.  Reports errors using ``path`` to identify the source location.
 
-        :rtype none
+        :param column: iterable of feature ID strings to validate
+        :param str path: human-readable path used in error messages (e.g. ``"var"`` or
+            ``"uns['genetic_perturbations']['g1']['intended_features']"``)
+
+        :rtype None
         """
 
         # Keep track of all of the gene ids that come from different organisms
@@ -495,7 +498,7 @@ class Validator:
 
             if not organism:
                 self.errors.append(
-                    f"Could not infer organism from feature ID '{feature_id}' in '{df_name}', "
+                    f"Could not infer organism from feature ID '{feature_id}' in '{path}', "
                     f"make sure it is a valid ID."
                 )
                 continue
@@ -505,7 +508,7 @@ class Validator:
             valid_gene_id = get_gene_checker(organism).is_valid_id(feature_id)
 
             if not valid_gene_id:
-                self.errors.append(f"'{feature_id}' is not a valid feature ID in '{df_name}'.")
+                self.errors.append(f"'{feature_id}' is not a valid feature ID in '{path}'.")
 
             if dataset_organism is not None and organism_ontology_id is not None and valid_gene_id:
                 # If the gene id is valid, check if that organism matches the dataset's organism
@@ -1202,6 +1205,11 @@ class Validator:
                     f"'{dict_name}' contains unexpected key(s) {sorted(extra)}. "
                     f"Additional key-value pairs MUST NOT be present."
                 )
+
+        # Generic feature-ID key validation: when the schema marks a dict with
+        # validate_keys_as: feature_id, every key must be a valid feature ID.
+        if dict_def.get("validate_keys_as") == "feature_id":
+            self._validate_feature_ids(dictionary.keys(), dict_name)
 
     def _validate_dataframe(self, df_name: str):
         """
@@ -2137,10 +2145,16 @@ class Validator:
 
             # Process the key definition if we found a match
             if key_def is not None:
-                # Check for add_labels
+                # Check for add_labels that write to a new column/key (to_column / to_key present).
+                # In-place label types (no to_column/to_key, e.g. feature_name on dict values)
+                # do not add new columns and need no availability check here.
                 if isinstance(key_def, dict) and "add_labels" in key_def:
-                    key_path = f"{parent_name}.{actual_key}" if parent_name else actual_key
-                    self._check_single_column_availability(key_path, key_def["add_labels"])
+                    labels_with_targets = [
+                        lbl for lbl in key_def["add_labels"] if lbl.get("to_column") or lbl.get("to_key")
+                    ]
+                    if labels_with_targets:
+                        key_path = f"{parent_name}.{actual_key}" if parent_name else actual_key
+                        self._check_single_column_availability(key_path, labels_with_targets)
 
                 # Recursively check nested dictionaries
                 if isinstance(key_def, dict) and key_def.get("type") == "dict":

--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import traceback
 from typing import Dict, List, Optional
 
@@ -306,7 +307,7 @@ class AnnDataLabelAppender:
 
             mapping_dict = self._get_mapping_dict_curie(ids, column_definition["curie_constraints"])
 
-        elif label_type == "feature_id":
+        elif label_type == "feature_name":
             mapping_dict = self._get_mapping_dict_feature_id(ids=ids)
 
         elif label_type == "feature_reference":
@@ -345,6 +346,55 @@ class AnnDataLabelAppender:
             new_column = self._get_labels(component, column, column_definition, label_def["type"])
             new_column_name = label_def["to_column"]
             getattr_anndata(self.adata, component)[new_column_name] = new_column
+
+    def _apply_dict_labels(self, data: dict, schema_def: dict) -> None:
+        """
+        Recursively walk ``data`` guided by ``schema_def`` and, for any dict value whose schema
+        entry carries ``add_labels``, apply the declared label types in-place.
+
+        Supported label types for dicts:
+        * ``feature_name`` — for each key (feature_id) in the dict, set its value to the feature
+          name returned by the gene reference (or to the key itself when no name is found).
+
+        Any future dict in schema_definition.yaml annotated with
+        ``add_labels: [{type: feature_name}]`` is handled automatically here.
+        """
+        keys_def = schema_def.get("keys", {})
+        if not isinstance(keys_def, dict):
+            return
+
+        key_patterns: Dict[str, re.Pattern] = {}
+        explicit_keys: set = set()
+        for schema_key, key_def in keys_def.items():
+            if isinstance(key_def, dict) and key_def.get("key_pattern"):
+                key_patterns[schema_key] = re.compile(key_def["key_pattern"])
+            else:
+                explicit_keys.add(schema_key)
+
+        for actual_key, actual_value in data.items():
+            matching_key_def = None
+            if actual_key in explicit_keys:
+                matching_key_def = keys_def.get(actual_key)
+            else:
+                for schema_key, compiled_pattern in key_patterns.items():
+                    if compiled_pattern.match(actual_key):
+                        matching_key_def = keys_def.get(schema_key)
+                        break
+
+            if not isinstance(matching_key_def, dict) or matching_key_def.get("type") != "dict":
+                continue
+            if not isinstance(actual_value, dict):
+                continue
+
+            for label_def in matching_key_def.get("add_labels", []):
+                if label_def.get("type") == "feature_name":
+                    feature_ids = list(actual_value.keys())
+                    name_map = self._get_mapping_dict_feature_id(ids=feature_ids)
+                    for feature_id, name in name_map.items():
+                        actual_value[feature_id] = name
+
+            # Recurse into sub-dicts
+            self._apply_dict_labels(actual_value, matching_key_def)
 
     def _add_labels(self):
         """
@@ -401,6 +451,10 @@ class AnnDataLabelAppender:
                     )
                 else:
                     raise TypeError(f"'{label_type}' is not supported with uns 'add-labels'")
+
+        # Apply feature_name labels to nested uns dicts (e.g. intended_features inside
+        # genetic_perturbations entries) driven by add_labels in the schema definition.
+        self._apply_dict_labels(self.adata.uns, uns_def)
 
     def _remove_categories_with_zero_values(self):
         df = self.adata.obs

--- a/cellxgene_schema_cli/cellxgene_schema_definition.json
+++ b/cellxgene_schema_cli/cellxgene_schema_definition.json
@@ -381,6 +381,11 @@
           "type": "boolean",
           "description": "If true, keys beyond those declared in 'keys', 'reserved_keys', and matching 'key_pattern' are forbidden"
         },
+        "validate_keys_as": {
+          "type": "string",
+          "description": "Triggers generic key validation; 'feature_id' validates each key against the gene reference for the dataset organism",
+          "enum": ["feature_id"]
+        },
         "keys": {
           "type": "object",
           "description": "For dictionary fields, specification for key names and their nested field specifications",
@@ -647,7 +652,7 @@
           "type": "string",
           "description": "The type of label to add",
           "enum": [
-            "curie", "feature_id", "feature_reference", "feature_biotype", 
+            "curie", "feature_name", "feature_reference", "feature_biotype",
             "feature_length", "feature_type"
           ]
         },

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -1219,6 +1219,123 @@ adata_gene_perturbations_invalid_extra_key = anndata.AnnData(
     var=good_var,
 )
 
+# -------------------------
+# Valid: intended_features present with valid human gene IDs (no version suffix)
+good_uns_with_intended_features = {
+    **good_uns,
+    "genetic_perturbations": {
+        gp_id_1: {
+            "role": "targeting",
+            "protospacer_sequence": "CAGAGGGAGGAGAGAACCG",
+            "protospacer_adjacent_motif": "3' NGG",
+            "intended_features": {
+                "ENSG00000141510": "",  # TP53 — value is arbitrary; write_labels will populate
+                "ENSG00000012048": "anything",  # BRCA1
+            },
+        },
+        gp_id_2: {
+            "role": "targeting",
+            "protospacer_sequence": "GGGCCCTCCGGGAAGATGG",
+            "protospacer_adjacent_motif": "3' NGG",
+            # No intended_features — optional field absent is also valid
+        },
+    },
+}
+
+adata_gene_perturbations_with_intended_features = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_gene_perturbations.copy(),
+    uns=good_uns_with_intended_features,
+    obsm=good_obsm,
+    var=good_var,
+)
+adata_gene_perturbations_with_intended_features.raw = adata_gene_perturbations_with_intended_features.copy()
+adata_gene_perturbations_with_intended_features.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
+# Invalid: intended_features key has ENS version suffix (must be stripped)
+# Both perturbation IDs are present so obs cross-validation passes; only the
+# intended_features key is invalid.
+bad_uns_intended_features_versioned_id = {
+    **good_uns,
+    "genetic_perturbations": {
+        gp_id_1: {
+            "role": "targeting",
+            "protospacer_sequence": "CAGAGGGAGGAGAGAACCG",
+            "protospacer_adjacent_motif": "3' NGG",
+            "intended_features": {
+                "ENSG00000141510.7": "",  # version suffix — invalid
+            },
+        },
+        gp_id_2: {
+            "role": "targeting",
+            "protospacer_sequence": "GGGCCCTCCGGGAAGATGG",
+            "protospacer_adjacent_motif": "3' NGG",
+        },
+    },
+}
+adata_gene_perturbations_invalid_intended_features_versioned = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_gene_perturbations.copy(),
+    uns=bad_uns_intended_features_versioned_id,
+    obsm=good_obsm,
+    var=good_var,
+)
+
+# -------------------------
+# Invalid: intended_features key is not a valid gene ID
+bad_uns_intended_features_bad_id = {
+    **good_uns,
+    "genetic_perturbations": {
+        gp_id_1: {
+            "role": "targeting",
+            "protospacer_sequence": "CAGAGGGAGGAGAGAACCG",
+            "protospacer_adjacent_motif": "3' NGG",
+            "intended_features": {
+                "NOT_A_GENE_ID": "",
+            },
+        },
+        gp_id_2: {
+            "role": "targeting",
+            "protospacer_sequence": "GGGCCCTCCGGGAAGATGG",
+            "protospacer_adjacent_motif": "3' NGG",
+        },
+    },
+}
+adata_gene_perturbations_invalid_intended_features_bad_id = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_gene_perturbations.copy(),
+    uns=bad_uns_intended_features_bad_id,
+    obsm=good_obsm,
+    var=good_var,
+)
+
+# -------------------------
+# Invalid: intended_features is not a dict (wrong type)
+bad_uns_intended_features_not_dict = {
+    **good_uns,
+    "genetic_perturbations": {
+        gp_id_1: {
+            "role": "targeting",
+            "protospacer_sequence": "CAGAGGGAGGAGAGAACCG",
+            "protospacer_adjacent_motif": "3' NGG",
+            "intended_features": ["ENSG00000141510"],  # list, not dict
+        },
+        gp_id_2: {
+            "role": "targeting",
+            "protospacer_sequence": "GGGCCCTCCGGGAAGATGG",
+            "protospacer_adjacent_motif": "3' NGG",
+        },
+    },
+}
+adata_gene_perturbations_invalid_intended_features_not_dict = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_gene_perturbations.copy(),
+    uns=bad_uns_intended_features_not_dict,
+    obsm=good_obsm,
+    var=good_var,
+)
+
 # -----------------------------------------------------------------#
 # Experimental condition fixtures (schema 7.1.0)
 

--- a/cellxgene_schema_cli/tests/test_genetic_perturbations.py
+++ b/cellxgene_schema_cli/tests/test_genetic_perturbations.py
@@ -11,6 +11,9 @@ from fixtures.examples_validate import (
     adata_gene_perturbations_invalid_contains_derived_features,
     adata_gene_perturbations_invalid_control_role_mismatch,
     adata_gene_perturbations_invalid_extra_key,
+    adata_gene_perturbations_invalid_intended_features_bad_id,
+    adata_gene_perturbations_invalid_intended_features_not_dict,
+    adata_gene_perturbations_invalid_intended_features_versioned,
     adata_gene_perturbations_invalid_key_comma,
     adata_gene_perturbations_invalid_key_quote,
     adata_gene_perturbations_invalid_key_slash,
@@ -28,6 +31,7 @@ from fixtures.examples_validate import (
     adata_gene_perturbations_invalid_protospacer_short,
     adata_gene_perturbations_invalid_role_enum,
     adata_gene_perturbations_invalid_strategy_without_id,
+    adata_gene_perturbations_with_intended_features,
 )
 
 
@@ -75,6 +79,9 @@ def test_valid_gene_perturbations_control():
         adata_gene_perturbations_invalid_na_key,
         adata_gene_perturbations_invalid_strategy_without_id,
         adata_gene_perturbations_invalid_extra_key,
+        adata_gene_perturbations_invalid_intended_features_versioned,
+        adata_gene_perturbations_invalid_intended_features_bad_id,
+        adata_gene_perturbations_invalid_intended_features_not_dict,
     ],
 )
 def test_invalid_gene_perturbations(bad):
@@ -112,3 +119,30 @@ def test_invalid_gene_perturbations_extra_key():
     success, errors = _validate_adata(adata_gene_perturbations_invalid_extra_key)
     assert not success, f"Expected validation to fail but it succeeded. Errors: {errors}"
     assert any("extra_annotation" in error and "MUST NOT be present" in error for error in errors)
+
+
+def test_valid_gene_perturbations_with_intended_features():
+    """intended_features with valid gene IDs (no version suffix) must pass validation."""
+    success, errors = _validate_adata(adata_gene_perturbations_with_intended_features)
+    assert success, errors
+
+
+def test_invalid_intended_features_versioned_id():
+    """intended_features key with ENS version suffix must fail (version must be stripped)."""
+    success, errors = _validate_adata(adata_gene_perturbations_invalid_intended_features_versioned)
+    assert not success, f"Expected validation to fail but it succeeded. Errors: {errors}"
+    # Versioned IDs are not found in the gene reference; the validator cannot infer the organism.
+    assert any("ENSG00000141510.7" in error for error in errors)
+
+
+def test_invalid_intended_features_bad_id():
+    """intended_features key that is not a valid gene ID must fail validation."""
+    success, errors = _validate_adata(adata_gene_perturbations_invalid_intended_features_bad_id)
+    assert not success, f"Expected validation to fail but it succeeded. Errors: {errors}"
+    assert any("NOT_A_GENE_ID" in error for error in errors)
+
+
+def test_invalid_intended_features_not_dict():
+    """intended_features value that is not a dict must fail validation."""
+    success, errors = _validate_adata(adata_gene_perturbations_invalid_intended_features_not_dict)
+    assert not success, f"Expected validation to fail but it succeeded. Errors: {errors}"

--- a/cellxgene_schema_cli/tests/test_remove_labels.py
+++ b/cellxgene_schema_cli/tests/test_remove_labels.py
@@ -184,6 +184,55 @@ class TestRemoveLabelsGeneticPerturbations:
 
         assert "genetic_perturbations" not in minimal_adata.uns
 
+    def test_intended_features_values_reset(self, minimal_adata):
+        """intended_features keys are preserved but values are reset to empty strings."""
+        minimal_adata.uns["genetic_perturbations"] = {
+            "guide1": {
+                "role": "targeting",
+                "protospacer_sequence": "GCTGCTGCTGCTGCTGCTGA",
+                "protospacer_adjacent_motif": "3' NGG",
+                "intended_features": {
+                    "ENSG00000141510": "TP53",  # populated by write_labels
+                    "ENSG00000012048": "BRCA1",
+                },
+            },
+            "guide2": {
+                "role": "targeting",
+                "protospacer_sequence": "GGGCCCTCCGGGAAGATGG",
+                "protospacer_adjacent_motif": "3' NGG",
+                # No intended_features — should remain unaffected
+            },
+        }
+
+        remover = AnnDataLabelRemover(minimal_adata)
+        remover.remove_labels()
+
+        gp = minimal_adata.uns["genetic_perturbations"]
+        # Keys must be preserved
+        assert "intended_features" in gp["guide1"]
+        assert "ENSG00000141510" in gp["guide1"]["intended_features"]
+        assert "ENSG00000012048" in gp["guide1"]["intended_features"]
+        # Values must be reset to empty strings
+        assert gp["guide1"]["intended_features"]["ENSG00000141510"] == ""
+        assert gp["guide1"]["intended_features"]["ENSG00000012048"] == ""
+        # Guide without intended_features is unaffected
+        assert "intended_features" not in gp["guide2"]
+
+    def test_intended_features_absent_no_error(self, minimal_adata):
+        """No error when no perturbation entry has intended_features."""
+        minimal_adata.uns["genetic_perturbations"] = {
+            "guide1": {
+                "role": "targeting",
+                "protospacer_sequence": "GCTGCTGCTGCTGCTGCTGA",
+                "protospacer_adjacent_motif": "3' NGG",
+            },
+        }
+
+        remover = AnnDataLabelRemover(minimal_adata)
+        remover.remove_labels()  # must not raise
+
+        assert "intended_features" not in minimal_adata.uns["genetic_perturbations"]["guide1"]
+
 
 class TestRemoveReservedRecursive:
     """Test recursive removal of reserved_keys with nested structures"""


### PR DESCRIPTION
Adds genetic_perturbations[id]['intended_features'] as an optional curator-supplied dict. Keys are feature IDs (ENS version numbers must be stripped); values are populated by write_labels with the gene symbol from the gene reference (or the feature ID itself if no symbol is assigned). remove_labels resets values to empty strings, preserving the curator-supplied keys.

Generalizes validation and label-writing infrastructure:
- _validate_dict: new validate_keys_as: feature_id hook calls _validate_feature_ids on any dict's keys (schema-driven, reusable)
- _validate_feature_ids: broadened to accept any iterable, not just pd.Series
- write_labels: new _apply_dict_labels traversal applies add_labels (type: feature_name) to nested uns dicts (schema-driven, reusable)
- Renames add_labels type feature_id -> feature_name in var/raw.var index definitions (more accurate: it writes the name, not the ID)
- Updates cellxgene_schema_definition.json meta-schema accordingly