### PR TITLE
feat: make obsm optional for pre-analysis datasets

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -29,10 +29,6 @@ pre_analysis:
     keys:
       cell_type_ontology_term_id:
         allowed: False
-  obsm:
-    required: False
-    allowed: False
-
 components:
   uns:
     type: dict

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -1503,8 +1503,8 @@ class Validator:
         a suffix at least 1 character long. For keys that don't start with "X_", we will run them through the same
         validation checks, but raise warnings instead of errors.
 
-        In the case of the pre_analsysis_flag being True, obsm MUST NOT be present so if we do not see adata.obsm and
-        the flag is correctly set, we exit this validation.
+        In the case of the pre_analysis_flag being True, obsm is optional. If absent, validation is skipped; if
+        present, it is validated as normal.
         :rtype none
         """
 

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -471,7 +471,30 @@ class TestValidate:
 
         assert not validator.errors
 
-    def test__pre_analysis_validate_no_obsm_fails_with_obsm(self, valid_pre_analysis_adata):
+    def test__validate_obsm_fails_with_bad_obsm_in_pre_analysis(self, valid_pre_analysis_adata):
+        import numpy as np
+
+        validator = Validator(pre_analysis_check_flag=True)
+        validator.adata = valid_pre_analysis_adata.copy()
+        # X_ embeddings require at least 2 columns — 1 column is invalid
+        validator.adata.obsm = {"X_umap": np.zeros([validator.adata.n_obs, 1])}
+        validator._set_schema_def()
+
+        validator._validate_obsm()
+
+        assert validator.errors
+        assert any("at least two columns" in e for e in validator.errors)
+
+    def test__validate_obsm_passes_without_obsm_in_pre_analysis(self, valid_pre_analysis_adata):
+        validator = Validator(pre_analysis_check_flag=True)
+        validator.adata = valid_pre_analysis_adata  # obsm is None
+        validator._set_schema_def()
+
+        validator._validate_obsm()
+
+        assert not validator.errors
+
+    def test__pre_analysis_check_passes_with_obsm_present(self, valid_pre_analysis_adata):
         validator = Validator()
         validator.adata = valid_pre_analysis_adata.copy()
         validator.adata.obsm = good_obsm
@@ -479,11 +502,7 @@ class TestValidate:
 
         validator._pre_analysis_check()  # Directly call private method for testing purposes
 
-        EXPECTED_ERROR_STRING = "[PRE ANALYSIS COMPONENT] obsm is not allowed to exist during pre analysis validation"
-
-        assert validator.errors
-        assert len(validator.errors) == 1
-        assert EXPECTED_ERROR_STRING in validator.errors
+        assert not validator.errors
 
     def test__pre_analysis_validate_no_cell_type_ontology_term_id_fails_with_value_present(
         self, valid_pre_analysis_adata


### PR DESCRIPTION
obsm was previously forbidden in pre-analysis datasets. It is now optional: absent obsm is valid, and present obsm is validated as normal.