### PR TITLE
fix: allow EFO:0002756 (fasting) as a valid diet perturbation term

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
+++ b/cellxgene_schema_cli/cellxgene_schema/schema_definitions/schema_definition.yaml
@@ -887,6 +887,7 @@ components:
               EFO:
                 - EFO:0001702  # temperature (exact)
                 - EFO:0002755  # diet (exact match; descendants covered by ancestors below)
+                - EFO:0002756  # fasting (exact; not a descendant of diet)
               UniProt:
                 - all
             ancestors:
@@ -903,7 +904,8 @@ components:
         error_message_suffix: >-
           The value MUST be "na" or one or more term identifiers in ascending lexical order separated by " || "
           with no duplication. Allowed: descendants of CHEBI:24431 (excluding listed forbidden CHEBI terms),
-          EFO:0001702 (temperature) or EFO:0002755 (diet) or its descendants, uniprot: terms, anti-uniprot: terms.
+          EFO:0001702 (temperature) or EFO:0002755 (diet) or its descendants or EFO:0002756 (fasting),
+          uniprot: terms, anti-uniprot: terms.
       is_primary_data:
         type: bool
       genetic_perturbation_strategy:

--- a/cellxgene_schema_cli/cellxgene_schema/write_labels.py
+++ b/cellxgene_schema_cli/cellxgene_schema/write_labels.py
@@ -472,6 +472,7 @@ class AnnDataLabelAppender:
         :return: "no perturbations" or sorted " || "-delimited perturbation type set
         """
         DIET_ONTO_TERM = "EFO:0002755"
+        FASTING_ONTO_TERM = "EFO:0002756"
         TEMPERATURE_ONTO_TERM = "EFO:0001702"
 
         ec_is_na = ec_val is None or ec_val == "na"
@@ -492,9 +493,12 @@ class AnnDataLabelAppender:
                 elif term == TEMPERATURE_ONTO_TERM:
                     types.add("temperature")
                 elif term.startswith("EFO:"):
-                    ancestors = ONTOLOGY_PARSER.get_term_ancestors(term, include_self=True)
-                    if DIET_ONTO_TERM in ancestors:
+                    if term == FASTING_ONTO_TERM:
                         types.add("diet")
+                    else:
+                        ancestors = ONTOLOGY_PARSER.get_term_ancestors(term, include_self=True)
+                        if DIET_ONTO_TERM in ancestors:
+                            types.add("diet")
 
         if not gp_is_na:
             types.add("genetic")

--- a/cellxgene_schema_cli/tests/fixtures/examples_validate.py
+++ b/cellxgene_schema_cli/tests/fixtures/examples_validate.py
@@ -1422,6 +1422,20 @@ adata_ec_valid_diet_descendant.raw = adata_ec_valid_diet_descendant.copy()
 adata_ec_valid_diet_descendant.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
 
 # -------------------------
+# Valid: EFO:0002756 fasting (not a descendant of EFO:0002755 diet, but explicitly allowed)
+good_obs_ec_fasting = good_obs.copy()
+good_obs_ec_fasting["experimental_condition_ontology_term_id"] = pd.Categorical(
+    ["EFO:0002756", "EFO:0002756"],
+    categories=["EFO:0002756"],
+)
+
+adata_ec_valid_fasting = anndata.AnnData(
+    X=X.copy(), obs=good_obs_ec_fasting, uns=good_uns, obsm=good_obsm, var=good_var
+)
+adata_ec_valid_fasting.raw = adata_ec_valid_fasting.copy()
+adata_ec_valid_fasting.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# -------------------------
 # Valid: multi-term sorted " || " (CHEBI + EFO:0002755)
 good_obs_ec_multi = good_obs.copy()
 good_obs_ec_multi["experimental_condition_ontology_term_id"] = pd.Categorical(

--- a/cellxgene_schema_cli/tests/test_experimental_condition.py
+++ b/cellxgene_schema_cli/tests/test_experimental_condition.py
@@ -21,6 +21,7 @@ from fixtures.examples_validate import (
     adata_ec_valid_chebi,
     adata_ec_valid_diet_descendant,
     adata_ec_valid_diet_root,
+    adata_ec_valid_fasting,
     adata_ec_valid_multi,
     adata_ec_valid_temperature,
     adata_ec_valid_uniprot,
@@ -85,6 +86,11 @@ class TestExperimentalConditionValid:
 
     def test_diet_descendant_term(self):
         success, errors = _validate(adata_ec_valid_diet_descendant)
+        assert success, errors
+
+    def test_fasting_term(self):
+        """EFO:0002756 (fasting) is explicitly allowed even though it is not a descendant of EFO:0002755."""
+        success, errors = _validate(adata_ec_valid_fasting)
         assert success, errors
 
     def test_multi_term_sorted(self):
@@ -214,6 +220,12 @@ class TestPerturbationTypesLabels:
 
     def test_diet_descendant_gives_diet_type(self):
         labeled = _write_labels(adata_ec_valid_diet_descendant)
+        assert "perturbation_types" in labeled.obs.columns
+        assert labeled.obs["perturbation_types"].iloc[0] == "diet"
+
+    def test_fasting_ec_gives_diet_type(self):
+        """EFO:0002756 (fasting) is not a descendant of EFO:0002755 but must still produce 'diet'."""
+        labeled = _write_labels(adata_ec_valid_fasting)
         assert "perturbation_types" in labeled.obs.columns
         assert labeled.obs["perturbation_types"].iloc[0] == "diet"
 


### PR DESCRIPTION
EFO:0002756 is not a descendant of EFO:0002755 (diet) so it must be explicitly allowed in schema curie constraints and handled as a direct match in perturbation_types derivation to produce the "diet" type. This is an edit to schema 7.1.0 definition.