### PR TITLE
fix: add-labels import and spatial cell_type check for pre-analysis

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/cli.py
+++ b/cellxgene_schema_cli/cellxgene_schema/cli.py
@@ -74,8 +74,7 @@ def schema_validate(h5ad_file, add_labels_file, ignore_labels, pre_analysis_flag
 @click.argument("input_file", nargs=1, type=click.Path(exists=True, dir_okay=False))
 @click.argument("output_file", nargs=1, type=click.Path(exists=False, dir_okay=False))
 def add_labels(input_file, output_file):
-    from utils import read_h5ad
-
+    from .utils import read_h5ad
     from .write_labels import AnnDataLabelAppender
 
     logger.info(f"Loading h5ad from {input_file}")

--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -2313,6 +2313,9 @@ class Validator:
         elif self.is_visium_and_is_single_true and "in_tissue" not in self.adata.obs.columns:
             # valid spatial assay, but missing "in_tissue" column
             return
+        elif "cell_type_ontology_term_id" not in self.adata.obs.columns:
+            # pre-analysis datasets are not required (and not allowed) to have cell_type_ontology_term_id
+            return
 
         # Validate all out of tissue (in_tissue==0) spatial spots have unknown cell ontology term
         is_spatial = (

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -1410,6 +1410,16 @@ class TestCheckSpatial:
         validator.validate_adata()
         assert validator.errors == ["ERROR: adata.obsm['spatial'] contains at least one NaN value."]
 
+    def test__validate_spatial_cell_type_ontology_term_id_skipped_for_pre_analysis(self):
+        validator: Validator = Validator(pre_analysis_check_flag=True)
+        validator._set_schema_def()
+        validator.adata = adata_visium.copy()
+        # pre-analysis Visium datasets do not have cell_type_ontology_term_id
+        del validator.adata.obs["cell_type_ontology_term_id"]
+
+        validator._validate_spatial_cell_type_ontology_term_id()
+        assert not validator.errors
+
 
 class TestValidatorValidateDataFrame:
     @pytest.mark.parametrize("_type", [np.int64, np.int32, int, np.float64, np.float32, float, str])


### PR DESCRIPTION
- Correct relative import of `read_h5ad` in `add-labels` CLI entry point.
- Skip `_validate_spatial_cell_type_ontology_term_id` when `cell_type_ontology_term_id` is absent from obs, which is the case for Visium pre-analysis datasets (the column is disallowed there per schema_definition.yaml).
