### PR TITLE
feat: extend Slide-seqV2 spatial checks to descendants of EFO:0920001 (Curio Seeker support)

### DIFF
--- a/cellxgene_schema_cli/cellxgene_schema/validate.py
+++ b/cellxgene_schema_cli/cellxgene_schema/validate.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 ASSAY_VISIUM = "EFO:0010961"  # generic term
 ASSAY_VISIUM_11M = "EFO:0022860"  # specific visium assay
-ASSAY_SLIDE_SEQV2 = "EFO:0030062"
+ASSAY_BEAD_BASED_SPATIAL = "EFO:0920001"  # generic parent term (Slide-seqV2, Curio Seeker, etc.)
 
 VISIUM_AND_IS_SINGLE_TRUE_MATRIX_SIZE = 4992
 VISIUM_11MM_AND_IS_SINGLE_TRUE_MATRIX_SIZE = 14336
@@ -49,9 +49,11 @@ SPATIAL_HIRES_IMAGE_MAX_DIMENSION_SIZE_VISIUM_11MM = 4000
 
 CONDITION_IS_VISIUM = "a descendant of 'EFO:0010961' (Visium Spatial Gene Expression)"
 CONDITION_IS_VISIUM_11M = f"'{ASSAY_VISIUM_11M} (Visium CytAssist Spatial Gene Expression, 11mm)"
-CONDITION_IS_SEQV2 = f"'{ASSAY_SLIDE_SEQV2}' (Slide-seqV2)"
+CONDITION_IS_BEAD_BASED_SPATIAL = f"a descendant of '{ASSAY_BEAD_BASED_SPATIAL}' (bead-based spatial transcriptomics)"
 
-ERROR_SUFFIX_SPATIAL = f"obs['assay_ontology_term_id'] is either {CONDITION_IS_VISIUM} or {CONDITION_IS_SEQV2}"
+ERROR_SUFFIX_SPATIAL = (
+    f"obs['assay_ontology_term_id'] is either {CONDITION_IS_VISIUM} or {CONDITION_IS_BEAD_BASED_SPATIAL}"
+)
 ERROR_SUFFIX_VISIUM = f"obs['assay_ontology_term_id'] is {CONDITION_IS_VISIUM}"
 ERROR_SUFFIX_VISIUM_11M = f"obs['assay_ontology_term_id'] is {CONDITION_IS_VISIUM_11M}"
 
@@ -175,16 +177,21 @@ class Validator:
 
     def _is_supported_spatial_assay(self) -> bool:
         """
-        Determine if the assay_ontology_term_id is either Visium (EFO:0010961) or Slide-seqV2 (EFO:0030062).
+        Determine if the assay_ontology_term_id is either a descendant of Visium (EFO:0010961)
+        or a descendant of bead-based spatial transcriptomics (EFO:0920001).
 
-        :return True if assay_ontology_term_id is Visium or Slide-seqV2, False otherwise.
+        :return True if assay_ontology_term_id is a supported spatial assay, False otherwise.
         :rtype bool
         """
         if self.is_spatial is None:
             try:
                 _spatial = (
                     self._is_visium_including_descendants()
-                    or self.adata.obs.assay_ontology_term_id.isin([ASSAY_SLIDE_SEQV2]).astype(bool).any()
+                    or self.adata.obs.assay_ontology_term_id.apply(
+                        lambda t: is_ontological_descendant_of(ONTOLOGY_PARSER, t, ASSAY_BEAD_BASED_SPATIAL, False)
+                    )
+                    .astype(bool)
+                    .any()
                 )
                 self.is_spatial = bool(_spatial)
             except AttributeError:

--- a/cellxgene_schema_cli/tests/test_schema_compliance.py
+++ b/cellxgene_schema_cli/tests/test_schema_compliance.py
@@ -735,7 +735,14 @@ class TestObs:
 
     @pytest.mark.parametrize(
         "assay_ontology_term_id, all_same",
-        [("EFO:0022859", True), ("EFO:0030062", True), ("EFO:0022860", True), ("EFO:0008995", False)],
+        [
+            ("EFO:0022859", True),
+            ("EFO:0030062", True),
+            ("EFO:0022860", True),
+            ("EFO:0920002", True),  # Curio Seeker, 3mm (descendant of bead-based spatial transcriptomics)
+            ("EFO:0920003", True),  # Curio Seeker, 10mm (descendant of bead-based spatial transcriptomics)
+            ("EFO:0008995", False),
+        ],
     )
     def test_assay_ontology_term_id__all_same(self, validator_with_visium_assay, assay_ontology_term_id, all_same):
         """
@@ -2893,7 +2900,16 @@ class TestObsm:
             in validator.warnings
         )
 
-    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0022859", "EFO:0030062", "EFO:0022860"])
+    @pytest.mark.parametrize(
+        "assay_ontology_term_id",
+        [
+            "EFO:0022859",
+            "EFO:0030062",
+            "EFO:0022860",
+            "EFO:0920002",  # Curio Seeker, 3mm
+            "EFO:0920003",  # Curio Seeker, 10mm
+        ],
+    )
     def test_obsm_values_no_X_embedding__visium_dataset(self, validator_with_visium_assay, assay_ontology_term_id):
         """
         X_{suffix} embeddings MAY exist for spatial datasets

--- a/cellxgene_schema_cli/tests/test_validate.py
+++ b/cellxgene_schema_cli/tests/test_validate.py
@@ -656,7 +656,7 @@ class TestCheckSpatial:
         # Confirm key type dict is required.
         validator.validate_adata()
         assert (
-            "ERROR: A dict in uns['spatial'] is required when obs['assay_ontology_term_id'] is either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or 'EFO:0030062' (Slide-seqV2)."
+            "ERROR: A dict in uns['spatial'] is required when obs['assay_ontology_term_id'] is either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or a descendant of 'EFO:0920001' (bead-based spatial transcriptomics)."
             in validator.errors
         )
 
@@ -681,7 +681,8 @@ class TestCheckSpatial:
         validator._check_spatial_uns()
         assert validator.errors == [
             "uns['spatial'] is only allowed when obs['assay_ontology_term_id'] is either "
-            "a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or 'EFO:0030062' (Slide-seqV2)"
+            "a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or "
+            "a descendant of 'EFO:0920001' (bead-based spatial transcriptomics)"
         ]
 
     @pytest.mark.parametrize(
@@ -706,7 +707,8 @@ class TestCheckSpatial:
             validator._check_spatial_uns()
             assert validator.errors == [
                 "A dict in uns['spatial'] is required when obs['assay_ontology_term_id'] is "
-                "either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or 'EFO:0030062' (Slide-seqV2)."
+                "either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or "
+                "a descendant of 'EFO:0920001' (bead-based spatial transcriptomics)."
             ]
             validator.reset()
         else:
@@ -725,7 +727,7 @@ class TestCheckSpatial:
         # Confirm spatial is required for Slide-seqV2.
         validator._check_spatial_uns()
         assert validator.errors == [
-            "A dict in uns['spatial'] is required when obs['assay_ontology_term_id'] is either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or 'EFO:0030062' (Slide-seqV2)."
+            "A dict in uns['spatial'] is required when obs['assay_ontology_term_id'] is either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or a descendant of 'EFO:0920001' (bead-based spatial transcriptomics)."
         ]
 
     def test__validate_spatial_allowed_keys_error(self):
@@ -760,7 +762,7 @@ class TestCheckSpatial:
         else:
             # if not spatial, MUST NOT speciffy `is_single`
             assert validator.errors == [
-                "uns['spatial'] is only allowed when obs['assay_ontology_term_id'] is either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or 'EFO:0030062' (Slide-seqV2)"
+                "uns['spatial'] is only allowed when obs['assay_ontology_term_id'] is either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or a descendant of 'EFO:0920001' (bead-based spatial transcriptomics)"
             ]
 
     def test__validate_is_single_required_slide_seqV2_error(self):
@@ -844,7 +846,7 @@ class TestCheckSpatial:
             validator._check_spatial_uns()
             # Report the most general top level error
             assert validator.errors == [
-                "uns['spatial'] is only allowed when obs['assay_ontology_term_id'] is either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or 'EFO:0030062' (Slide-seqV2)"
+                "uns['spatial'] is only allowed when obs['assay_ontology_term_id'] is either a descendant of 'EFO:0010961' (Visium Spatial Gene Expression) or a descendant of 'EFO:0920001' (bead-based spatial transcriptomics)"
             ]
 
     @pytest.mark.parametrize("library_id", [None, "invalid", 1, 1.0, True])
@@ -1189,7 +1191,7 @@ class TestCheckSpatial:
         assert validator.errors
         assert (
             "When obs['assay_ontology_term_id'] is either a descendant"
-            " of 'EFO:0010961' (Visium Spatial Gene Expression) or 'EFO:0030062' (Slide-seqV2), all observations must contain the same value."
+            " of 'EFO:0010961' (Visium Spatial Gene Expression) or a descendant of 'EFO:0920001' (bead-based spatial transcriptomics), all observations must contain the same value."
         ) in validator.errors[0]
 
     def test__validate_assay_type_ontology_term_id_not_unique_ok(self, valid_adata):
@@ -1259,7 +1261,16 @@ class TestCheckSpatial:
         )
         validator.reset()
 
-    @pytest.mark.parametrize("assay_ontology_term_id", ["EFO:0022858", "EFO:0030062", "EFO:0022860"])
+    @pytest.mark.parametrize(
+        "assay_ontology_term_id",
+        [
+            "EFO:0022858",
+            "EFO:0030062",
+            "EFO:0022860",
+            "EFO:0920002",  # Curio Seeker, 3mm
+            "EFO:0920003",  # Curio Seeker, 10mm
+        ],
+    )
     def test__validate_tissue_position_not_required(self, assay_ontology_term_id):
         validator: Validator = Validator()
         validator._set_schema_def()

--- a/schema/7.1.0/schema.md
+++ b/schema/7.1.0/schema.md
@@ -436,7 +436,7 @@ Curators MUST annotate the following columns in the `obs` dataframe:
           <li>
             the most accurate descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010183"><code>"EFO:0010183"</code></a>  for <i>single cell library construction</i> excluding <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> while allowing its descendants
           </li></ul>
-        If <code>assay_ontology_term_id</code> is either a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> or <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0030062"><code>"EFO:0030062"</code></a> for <i>Slide-seqV2</i> then all observations MUST contain the same value.<br><br>
+        If <code>assay_ontology_term_id</code> is either a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> or a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0920001"><code>"EFO:0920001"</code></a> for <i>bead-based spatial transcriptomics</i> then all observations MUST contain the same value.<br><br>
         If <code>assay_ontology_term_id</code> is either <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010891"><code>"EFO:0010891"</code></a> for <i>scATAC-seq</i> or its descendants, there are additional requirements for separate fragments file assets documented in <a href="#scatac-seq-assets">scATAC-seq assets</a>.<br><br>
         An assay based on 10X Genomics products SHOULD be the most accurate descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0008995"><code>"EFO:0008995"</code></a> for <i>10x technology</i>. An assay based on <i>SMART (Switching Mechanism at the 5' end of the RNA Template) or SMARTer technology</i> SHOULD either be <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010184"><code>"EFO:0010184"</code></a> for <i>Smart-like</i> or preferably its most accurate descendant.<br><br>
        <br>Recommended values for specific assays:
@@ -1503,7 +1503,7 @@ Otherwise, to display a dataset in CELLxGENE Explorer, Curators MUST annotate **
     </tr>
     <tr>
       <th>Annotator</th>
-         <td>Curator MUST annotate if <code>assay_ontology_term_id</code> is neither a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> nor <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0030062"><code>"EFO:0030062"</code></a> for <i>Slide-seqV2</i>.<br><br>Curator MAY annotate if <code>assay_ontology_term_id</code> is either a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> or <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0030062"><code>"EFO:0030062"</code></a> for <i>Slide-seqV2</i>.</td>
+         <td>Curator MUST annotate if <code>assay_ontology_term_id</code> is neither a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> nor a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0920001"><code>"EFO:0920001"</code></a> for <i>bead-based spatial transcriptomics</i>.<br><br>Curator MAY annotate if <code>assay_ontology_term_id</code> is either a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> or a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0920001"><code>"EFO:0920001"</code></a> for <i>bead-based spatial transcriptomics</i>.</td>
     </tr>
     <tr>
       <th>Value</th>
@@ -1854,7 +1854,7 @@ Curators MUST annotate the following keys and values in `uns`:
     </tr>
     <tr>
       <th>Annotator</th>
-      <td>Curator MUST annotate if <code>assay_ontology_term_id</code> is descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> or <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0030062"><code>"EFO:0030062"</code></a> for <i>Slide-seqV2</i>; otherwise, this key MUST NOT be present.</td>
+      <td>Curator MUST annotate if <code>assay_ontology_term_id</code> is descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> or a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0920001"><code>"EFO:0920001"</code></a> for <i>bead-based spatial transcriptomics</i>; otherwise, this key MUST NOT be present.</td>
     </tr>
     <tr>
       <th>Value</th>
@@ -1883,7 +1883,7 @@ Curators MUST annotate the following keys and values in `uns`:
     </tr>
     <tr>
       <th>Annotator</th>
-      <td>Curator MUST annotate if <code>assay_ontology_term_id</code> is a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> or <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0030062"><code>"EFO:0030062"</code></a> for <i>Slide-seqV2</i>; otherwise, this key MUST NOT be present.</td>
+      <td>Curator MUST annotate if <code>assay_ontology_term_id</code> is a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> or a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0920001"><code>"EFO:0920001"</code></a> for <i>bead-based spatial transcriptomics</i>; otherwise, this key MUST NOT be present.</td>
     </tr>
     <tr>
       <th>Value</th>
@@ -1891,7 +1891,7 @@ Curators MUST annotate the following keys and values in `uns`:
         <ul>
         <li>if <code>assay_ontology_term_id</code> is a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0010961"><code>"EFO:0010961"</code></a> for <i>Visium Spatial Gene Expression</i> and the dataset represents one Space Ranger output for a single tissue section
       </li>
-      <li> if <code>assay_ontology_term_id</code> is <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0030062"><code>"EFO:0030062"</code></a> for <i>Slide-seqV2</i> and the dataset represents the output for a single array on a puck </li>
+      <li> if <code>assay_ontology_term_id</code> is a descendant of <a href="https://www.ebi.ac.uk/ols4/ontologies/efo/classes?obo_id=EFO%3A0920001"><code>"EFO:0920001"</code></a> for <i>bead-based spatial transcriptomics</i> and the dataset represents the output for a single array on a puck </li>
         </ul>
         Otherwise, this MUST be <code>False</code>.
         </td>
@@ -3067,6 +3067,7 @@ Chromosome Tables are determined by the reference assembly for the gene annotati
   * Added `perturbation_types`
   * Updated the requirements for `cell_type_ontology_term_id` to depend on `[uns]['is_pre_analysis']`
   * Updated the requirements for `cell_type` to depend on `[uns]['is_pre_analysis']`
+  * Updated the spatial requirements for `assay_ontology_term_id` to accept descendants of `"EFO:0920001"` for _bead-based spatial transcriptomics_ (e.g. _Slide-seqV2_, _Curio Seeker_) in place of the prior exact-match on `"EFO:0030062"` for _Slide-seqV2_
 * obsm (Embeddings)
   * Updated the general requirements to depend on `[uns]['is_pre_analysis']`
 * uns (Dataset Metadata)


### PR DESCRIPTION
## Summary

- Replaces the exact-match check on `EFO:0030062` (Slide-seqV2) with a descendant check on `EFO:0920001` (bead-based spatial transcriptomics) wherever spatial validation gates on Slide-seqV2. This extends the same spatial requirements to Curio Seeker assays (`EFO:0920002`, `EFO:0920003`) and any other future bead-based descendant.
- Updates `validate.py` (constants + `_is_supported_spatial_assay`), the corresponding error messages, the `schema/7.1.0/schema.md` annotator/value text in five spots, and the v7.1.0 changelog.
- Updates affected unit tests and adds Curio Seeker term IDs to the relevant parametrized tests in `test_validate.py` and `test_schema_compliance.py`.

## Test plan

- [x] `pytest cellxgene_schema_cli/tests/test_validate.py -k "spatial or tissue_position or assay_type"` — 127 passed
- [x] `pytest cellxgene_schema_cli/tests/test_schema_compliance.py -k "spatial or assay_ontology or visium or slide_seq or obsm"` — 54 passed
- [ ] Manual: validate a fixture with `assay_ontology_term_id = "EFO:0920002"` (Curio Seeker 3mm) and bead-based spatial requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)