### PR TITLE
fix: unblock PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,21 +24,36 @@ jobs:
           cd cellxgene_schema_cli
           echo "version=`python setup.py --version`" >> $GITHUB_OUTPUT
           cd ..
+      - name: Test built distribution locally
+        run: |
+          pip install -r cellxgene_schema_cli/requirements.txt
+          pip install cellxgene_schema_cli/dist/*.whl
+          cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad
+      - name: Check if version already on Test PyPI
+        id: testpypi_check
+        run: |
+          if pip index versions --index-url https://test.pypi.org/simple/ cellxgene-schema 2>/dev/null \
+             | grep -q "Available.*${{ steps.build.outputs.version }}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: cellxgene_schema_cli/dist/
-      - name: Confirm publish to Test PyPI
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 15
-          timeout_seconds: 30
-          polling_interval_seconds: 5
-          command: pip index versions --index-url https://test.pypi.org/simple/ cellxgene-schema | grep Available.*${{ steps.build.outputs.version }}
-      - name: Install and Test Package from Test PyPI
+          skip-existing: true
+      - name: Confirm and test from Test PyPI
+        if: steps.testpypi_check.outputs.exists != 'true'
         run: |
+          for i in $(seq 1 15); do
+            pip index versions --index-url https://test.pypi.org/simple/ cellxgene-schema 2>/dev/null \
+              | grep -q "Available.*${{ steps.build.outputs.version }}" && break
+            echo "Waiting for ${{ steps.build.outputs.version }} to appear on Test PyPI ($i/15)..."
+            sleep 5
+          done
           pip install -r cellxgene_schema_cli/requirements.txt
           pip install --index-url https://test.pypi.org/simple/ cellxgene-schema
           cellxgene-schema validate cellxgene_schema_cli/tests/fixtures/h5ads/example_valid.h5ad

--- a/cellxgene_schema_cli/requirements.txt
+++ b/cellxgene_schema_cli/requirements.txt
@@ -17,4 +17,4 @@ xxhash<4
 matplotlib<4
 pysam>=0.13.0 # for atac-seq fragment files
 pooch>=1.8.0  # for managing downloaded reference files
-bioframe==0.4.0
+bioframe==0.8.0


### PR DESCRIPTION
## Problem

The **Publish to PyPI** workflow fails at the install/test step on `main`:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

`bioframe==0.4.0` imports the deprecated `pkg_resources` at import time, which the current `setuptools` (installed via `pip install -U setuptools` in the build step) no longer ships, breaking `import cellxgene_schema`.

Separately, because PyPI/Test PyPI are immutable, a re-run also fails: the prior run already published the (broken) version to Test PyPI, so the "Publish to Test PyPI" step 400s on the duplicate, and the "Install and Test from Test PyPI" step would only ever re-test the frozen broken artifact.

## Changes

- **Bump `bioframe` `0.4.0 → 0.8.0`** — newer bioframe drops the `pkg_resources` import entirely. Our only usage (`bf.overlap(..., how, cols1, cols2)`) is unchanged across these versions, and 0.8.0 fits all existing pins (python ≥3.10, numpy<3, pandas>2,<3).
- **Add a local install/validate gate** on the freshly built wheel *before* any publish — this is the real gate that blocks a bad build from reaching prod PyPI.
- **`skip-existing: true`** on the Test PyPI publish + a pre-check that skips the Test PyPI round-trip test when the version is already published, so re-runs of an already-published version proceed to prod instead of failing on the immutable duplicate.

## Notes

- This branch does **not** include the `7.1.0` version bump (that lives on `feat-schema7.1.0`); it only fixes the publish pipeline.
- The workflow runs off `main`, so the fix only takes effect once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)